### PR TITLE
chore: add issue automation workflow for branch management

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -1,0 +1,498 @@
+name: Issue automation from branch names
+
+on:
+  create:
+    # 'create' can't filter by branch pattern in YAML; we'll guard in job condition
+  push:
+    branches:
+      - 'feat/*'
+      - 'fix/*'
+      - 'chore/*'
+      - 'docs/*'
+      - 'refactor/*'
+      - 'test/*'
+      - 'style/*'
+  pull_request:
+    types: [opened, reopened, ready_for_review, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  repository-projects: write
+
+env:
+  PROJECT_NUMBER: ${{ secrets.PROJECT_NUMBER }}
+  PROJECT_OWNER: ${{ vars.PROJECT_OWNER || github.repository_owner }}
+  PROJECT_STATUS_FIELD_NAME: ${{ vars.PROJECT_STATUS_FIELD_NAME }}
+  STATUS_OPTION_TODO: ${{ vars.STATUS_OPTION_TODO }}
+  STATUS_OPTION_IN_PROGRESS: ${{ vars.STATUS_OPTION_IN_PROGRESS }}
+  STATUS_OPTION_IN_REVIEW: ${{ vars.STATUS_OPTION_IN_REVIEW }}
+  STATUS_OPTION_DONE: ${{ vars.STATUS_OPTION_DONE }}
+
+jobs:
+  in_progress_from_branch:
+    if: (github.event_name == 'create') || (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/chore/') || startsWith(github.ref, 'refs/heads/refactor/') || startsWith(github.ref, 'refs/heads/test/') || startsWith(github.ref, 'refs/heads/style/')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.PROJECT_OWNER || github.repository_owner }}
+      - name: Move linked issue to In Progress in GitHub Projects
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const isCreate = context.eventName === 'create';
+            const refFromCreate = isCreate && context.payload.ref_type === 'branch' ? `refs/heads/${context.payload.ref}` : '';
+            const ref = refFromCreate || context.ref || '';
+            const branch = ref.replace('refs/heads/', '');
+            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            if (!allowedPrefixes.some(p => branch.startsWith(p))) {
+              core.info(`Branch '${branch}' not in allowed prefixes. Skipping.`);
+              return;
+            }
+            const match = branch.match(/#(\d+)/);
+            if (!match) {
+              core.info(`Branch '${branch}' does not contain issue notation like #123. Skipping.`);
+              return;
+            }
+            const issue_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+
+            const projectNumber = process.env.PROJECT_NUMBER;
+            if (!projectNumber) {
+              core.setFailed('PROJECT_NUMBER secret is not set. Define it in repository secrets.');
+              return;
+            }
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || 'Status';
+            const optionInProgress = process.env.STATUS_OPTION_IN_PROGRESS || 'In Progress';
+
+            const ownerLogin = process.env.PROJECT_OWNER || owner;
+            const graph = github.graphql;
+
+            async function getIssueNodeId() {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id } } }`,
+                { owner: ownerLogin, repo, number: issue_number }
+              );
+              const id = data?.repository?.issue?.id;
+              if (!id) throw new Error('Issue not found');
+              return id;
+            }
+
+            async function getProject() {
+              const number = Number(projectNumber);
+              // Try organization
+              let data = await graph(
+                `query($login:String!, $number:Int!){ organization(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                { login: ownerLogin, number }
+              ).catch(() => null);
+              let project = data?.organization?.projectV2 || null;
+              if (!project) {
+                // Try user-owned project
+                data = await graph(
+                  `query($login:String!, $number:Int!){ user(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                  { login: ownerLogin, number }
+                ).catch(() => null);
+                project = data?.user?.projectV2 || null;
+              }
+              if (!project) throw new Error(`ProjectV2 #${projectNumber} not found under ${ownerLogin}`);
+              return project;
+            }
+
+            async function addToProject(projectId, contentId) {
+              const add = await graph(
+                `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId }
+              );
+              return add?.addProjectV2ItemById?.item?.id;
+            }
+
+            async function updateStatus(project, itemId, statusFieldName, optionName) {
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              if (!statusField) throw new Error(`Status field '${statusFieldName}' not found in Project`);
+              const options = (statusField.options || []);
+              const option = options.find(o => o.name === optionName);
+              if (!option) throw new Error(`Option '${optionName}' not found in field '${statusFieldName}'`);
+              await graph(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId }}) { projectV2Item { id } } }`,
+                { projectId: project.id, itemId, fieldId: statusField.id, optionId: option.id }
+              );
+            }
+
+            async function findExistingItemId(projectId, contentId) {
+              // Scan first 100 items for the contentId
+              const data = await graph(
+                `query($projectId:ID!){ node(id:$projectId){ ... on ProjectV2 { id items(first:100){ nodes { id content { __typename ... on Issue { id } ... on PullRequest { id } } } } } } }`,
+                { projectId }
+              );
+              const items = data?.node?.items?.nodes || [];
+              const found = items.find(n => n?.content?.id === contentId);
+              return found?.id || null;
+            }
+
+            async function findOrCreateItemId(project, contentId) {
+              try {
+                const itemId = await addToProject(project.id, contentId);
+                if (itemId) return itemId;
+              } catch (e) {
+                // Fallback if already exists
+                const existingId = await findExistingItemId(project.id, contentId);
+                if (existingId) return existingId;
+                throw e;
+              }
+              const existingId = await findExistingItemId(project.id, contentId);
+              return existingId;
+            }
+
+            const issueNodeId = await getIssueNodeId();
+            const project = await getProject();
+            const itemId = await findOrCreateItemId(project, issueNodeId);
+            await updateStatus(project, itemId, statusFieldName, optionInProgress);
+
+            try {
+              await github.rest.issues.addAssignees({ owner, repo, issue_number, assignees: [context.actor] });
+            } catch (e) {
+              core.info('Could not assign actor: ' + e.message);
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body: `브랜치 \`${branch}\` 에 따라 GitHub Projects 상태를 '${optionInProgress}'로 변경했습니다.` });
+
+  in_review_on_pr_open:
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.PROJECT_OWNER || github.repository_owner }}
+      - name: Move linked issue to In Review in GitHub Projects and update PR body
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            if (!allowedPrefixes.some(p => branch.startsWith(p))) {
+              core.info('PR branch does not match allowed prefixes. Skipping.');
+              return;
+            }
+            const match = branch.match(/#(\d+)/);
+            if (!match) {
+              core.info('PR branch does not contain #<issue>. Skipping.');
+              return;
+            }
+            const issue_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const projectNumber = process.env.PROJECT_NUMBER;
+            if (!projectNumber) {
+              core.setFailed('PROJECT_NUMBER secret is not set. Define it in repository secrets.');
+              return;
+            }
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || 'Status';
+            const optionInReview = process.env.STATUS_OPTION_IN_REVIEW || 'In Review';
+            const ownerLogin = process.env.PROJECT_OWNER || owner;
+            const graph = github.graphql;
+
+            async function getIssueNodeId() {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id } } }`,
+                { owner: ownerLogin, repo, number: issue_number }
+              );
+              const id = data?.repository?.issue?.id;
+              if (!id) throw new Error('Issue not found');
+              return id;
+            }
+
+            async function getProject() {
+              const number = Number(projectNumber);
+              // Try organization
+              let data = await graph(
+                `query($login:String!, $number:Int!){ organization(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                { login: ownerLogin, number }
+              ).catch(() => null);
+              let project = data?.organization?.projectV2 || null;
+              if (!project) {
+                // Try user-owned project
+                data = await graph(
+                  `query($login:String!, $number:Int!){ user(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                  { login: ownerLogin, number }
+                ).catch(() => null);
+                project = data?.user?.projectV2 || null;
+              }
+              if (!project) throw new Error(`ProjectV2 #${projectNumber} not found under ${ownerLogin}`);
+              return project;
+            }
+
+            async function addToProject(projectId, contentId) {
+              const add = await graph(
+                `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId }
+              );
+              return add?.addProjectV2ItemById?.item?.id;
+            }
+
+            async function updateStatus(project, itemId, statusFieldName, optionName) {
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              if (!statusField) throw new Error(`Status field '${statusFieldName}' not found in Project`);
+              const options = (statusField.options || []);
+              const option = options.find(o => o.name === optionName);
+              if (!option) throw new Error(`Option '${optionName}' not found in field '${statusFieldName}'`);
+              await graph(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId }}) { projectV2Item { id } } }`,
+                { projectId: project.id, itemId, fieldId: statusField.id, optionId: option.id }
+              );
+            }
+
+            const issueNodeId = await getIssueNodeId();
+            const project = await getProject();
+            const itemId = await findOrCreateItemId(project, issueNodeId);
+            await updateStatus(project, itemId, statusFieldName, optionInReview);
+
+            const closesString = `Closes #${issue_number}`;
+            const body = pr.body || '';
+            const hasClosing = /\b(closes|fixes|resolves)\s+#\d+/i.test(body);
+            if (!hasClosing) {
+              const newBody = body.length ? `${body}\n\n${closesString}` : closesString;
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, body: newBody });
+            }
+
+  done_on_pr_merged:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.PROJECT_OWNER || github.repository_owner }}
+      - name: Move linked issue to Done in GitHub Projects and close it
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr.merged) {
+              core.info('PR not merged. Skipping.');
+              return;
+            }
+            const branch = pr.head.ref;
+            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            if (!allowedPrefixes.some(p => branch.startsWith(p))) {
+              core.info('PR branch does not match allowed prefixes. Skipping.');
+              return;
+            }
+            const match = branch.match(/#(\d+)/);
+            if (!match) {
+              core.info('PR branch does not contain #<issue>. Skipping.');
+              return;
+            }
+            const issue_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const projectNumber = process.env.PROJECT_NUMBER;
+            if (!projectNumber) {
+              core.setFailed('PROJECT_NUMBER secret is not set. Define it in repository secrets.');
+              return;
+            }
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || 'Status';
+            const optionDone = process.env.STATUS_OPTION_DONE || 'Done';
+            const ownerLogin = process.env.PROJECT_OWNER || owner;
+            const graph = github.graphql;
+
+            async function getIssueNodeId() {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id } } }`,
+                { owner: ownerLogin, repo, number: issue_number }
+              );
+              const id = data?.repository?.issue?.id;
+              if (!id) throw new Error('Issue not found');
+              return id;
+            }
+
+            async function getProject() {
+              const number = Number(projectNumber);
+              // Try organization
+              let data = await graph(
+                `query($login:String!, $number:Int!){ organization(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                { login: ownerLogin, number }
+              ).catch(() => null);
+              let project = data?.organization?.projectV2 || null;
+              if (!project) {
+                // Try user-owned project
+                data = await graph(
+                  `query($login:String!, $number:Int!){ user(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                  { login: ownerLogin, number }
+                ).catch(() => null);
+                project = data?.user?.projectV2 || null;
+              }
+              if (!project) throw new Error(`ProjectV2 #${projectNumber} not found under ${ownerLogin}`);
+              return project;
+            }
+
+            async function addToProject(projectId, contentId) {
+              const add = await graph(
+                `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId }
+              );
+              return add?.addProjectV2ItemById?.item?.id;
+            }
+
+            async function updateStatus(project, itemId, statusFieldName, optionName) {
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              if (!statusField) throw new Error(`Status field '${statusFieldName}' not found in Project`);
+              const options = (statusField.options || []);
+              const option = options.find(o => o.name === optionName);
+              if (!option) throw new Error(`Option '${optionName}' not found in field '${statusFieldName}'`);
+              await graph(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId }}) { projectV2Item { id } } }`,
+                { projectId: project.id, itemId, fieldId: statusField.id, optionId: option.id }
+              );
+            }
+
+            const issueNodeId = await getIssueNodeId();
+            const project = await getProject();
+            const itemId = await findOrCreateItemId(project, issueNodeId);
+            await updateStatus(project, itemId, statusFieldName, optionDone);
+
+            // Close issue explicitly in case auto-closing didn't happen
+            await github.rest.issues.update({ owner, repo, issue_number, state: 'closed' });
+            await github.rest.issues.createComment({ owner, repo, issue_number, body: `PR #${pr.number}이 머지되어 Projects 상태를 '${optionDone}'로 변경하고 이슈를 닫았습니다.` });
+
+  todo_on_pr_closed_unmerged:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged != true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.PROJECT_OWNER || github.repository_owner }}
+      - name: Move linked issue to Todo in GitHub Projects
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (pr.merged) {
+              core.info('PR merged. Skipping.');
+              return;
+            }
+            const branch = pr.head.ref;
+            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            if (!allowedPrefixes.some(p => branch.startsWith(p))) {
+              core.info('PR branch does not match allowed prefixes. Skipping.');
+              return;
+            }
+            const match = branch.match(/#(\d+)/);
+            if (!match) {
+              core.info('PR branch does not contain #<issue>. Skipping.');
+              return;
+            }
+            const issue_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const projectNumber = process.env.PROJECT_NUMBER;
+            if (!projectNumber) {
+              core.setFailed('PROJECT_NUMBER secret is not set. Define it in repository secrets.');
+              return;
+            }
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || 'Status';
+            const optionTodo = process.env.STATUS_OPTION_TODO || 'Todo';
+            const ownerLogin = process.env.PROJECT_OWNER || owner;
+            const graph = github.graphql;
+
+            async function getIssueNodeId() {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id } } }`,
+                { owner: ownerLogin, repo, number: issue_number }
+              );
+              const id = data?.repository?.issue?.id;
+              if (!id) throw new Error('Issue not found');
+              return id;
+            }
+
+            async function getProject() {
+              const number = Number(projectNumber);
+              // Try organization
+              let data = await graph(
+                `query($login:String!, $number:Int!){ organization(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                { login: ownerLogin, number }
+              ).catch(() => null);
+              let project = data?.organization?.projectV2 || null;
+              if (!project) {
+                // Try user-owned project
+                data = await graph(
+                  `query($login:String!, $number:Int!){ user(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                  { login: ownerLogin, number }
+                ).catch(() => null);
+                project = data?.user?.projectV2 || null;
+              }
+              if (!project) throw new Error(`ProjectV2 #${projectNumber} not found under ${ownerLogin}`);
+              return project;
+            }
+
+            async function addToProject(projectId, contentId) {
+              const add = await graph(
+                `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId }
+              );
+              return add?.addProjectV2ItemById?.item?.id;
+            }
+
+            async function findExistingItemId(projectId, contentId) {
+              const data = await graph(
+                `query($projectId:ID!){ node(id:$projectId){ ... on ProjectV2 { id items(first:100){ nodes { id content { __typename ... on Issue { id } ... on PullRequest { id } } } } } } }`,
+                { projectId }
+              );
+              const items = data?.node?.items?.nodes || [];
+              const found = items.find(n => n?.content?.id === contentId);
+              return found?.id || null;
+            }
+
+            async function findOrCreateItemId(project, contentId) {
+              try {
+                const itemId = await addToProject(project.id, contentId);
+                if (itemId) return itemId;
+              } catch (e) {
+                const existingId = await findExistingItemId(project.id, contentId);
+                if (existingId) return existingId;
+                throw e;
+              }
+              const existingId = await findExistingItemId(project.id, contentId);
+              return existingId;
+            }
+
+            async function updateStatus(project, itemId, statusFieldName, optionName) {
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              if (!statusField) throw new Error(`Status field '${statusFieldName}' not found in Project`);
+              const options = (statusField.options || []);
+              const option = options.find(o => o.name === optionName);
+              if (!option) throw new Error(`Option '${optionName}' not found in field '${statusFieldName}'`);
+              await graph(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId }}) { projectV2Item { id } } }`,
+                { projectId: project.id, itemId, fieldId: statusField.id, optionId: option.id }
+              );
+            }
+
+            const issueNodeId = await getIssueNodeId();
+            const project = await getProject();
+            const itemId = await findOrCreateItemId(project, issueNodeId);
+            await updateStatus(project, itemId, statusFieldName, optionTodo);
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body: `PR #${pr.number}이 머지되지 않고 닫혀 Projects 상태를 '${optionTodo}'로 변경했습니다.` });

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -14,6 +14,10 @@ on:
       - 'style/*'
   pull_request:
     types: [opened, reopened, ready_for_review, closed]
+  issues:
+    types: [opened, edited, reopened, closed]
+  repository_dispatch:
+    types: [sync_parent_from_issue]
 
 permissions:
   issues: write
@@ -51,7 +55,7 @@ jobs:
             const refFromCreate = isCreate && context.payload.ref_type === 'branch' ? `refs/heads/${context.payload.ref}` : '';
             const ref = refFromCreate || context.ref || '';
             const branch = ref.replace('refs/heads/', '');
-            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            const allowedPrefixes = ['feat/', 'docs/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
             if (!allowedPrefixes.some(p => branch.startsWith(p))) {
               core.info(`Branch '${branch}' not in allowed prefixes. Skipping.`);
               return;
@@ -164,6 +168,22 @@ jobs:
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `브랜치 \`${branch}\` 에 따라 GitHub Projects 상태를 '${optionInProgress}'로 변경했습니다.` });
 
+      - name: Dispatch parent sync for linked issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const match = (context.ref || '').replace('refs/heads/','').match(/#(\d+)/);
+            if (!match) { core.info('No linked issue number. Skip dispatch.'); return; }
+            const issue_number = Number(match[1]);
+            await github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'sync_parent_from_issue',
+              client_payload: { issue_number }
+            });
+
   in_review_on_pr_open:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
     runs-on: ubuntu-latest
@@ -182,7 +202,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const branch = pr.head.ref;
-            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            const allowedPrefixes = ['feat/', 'docs/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
             if (!allowedPrefixes.some(p => branch.startsWith(p))) {
               core.info('PR branch does not match allowed prefixes. Skipping.');
               return;
@@ -290,7 +310,7 @@ jobs:
               return;
             }
             const branch = pr.head.ref;
-            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            const allowedPrefixes = ['feat/', 'docs/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
             if (!allowedPrefixes.some(p => branch.startsWith(p))) {
               core.info('PR branch does not match allowed prefixes. Skipping.');
               return;
@@ -372,6 +392,23 @@ jobs:
             await github.rest.issues.update({ owner, repo, issue_number, state: 'closed' });
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `PR #${pr.number}이 머지되어 Projects 상태를 '${optionDone}'로 변경하고 이슈를 닫았습니다.` });
 
+      - name: Dispatch parent sync for linked issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const match = pr.head.ref.match(/#(\d+)/);
+            if (!match) { core.info('No linked issue number. Skip dispatch.'); return; }
+            const issue_number = Number(match[1]);
+            await github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'sync_parent_from_issue',
+              client_payload: { issue_number }
+            });
+
   todo_on_pr_closed_unmerged:
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged != true
     runs-on: ubuntu-latest
@@ -394,7 +431,7 @@ jobs:
               return;
             }
             const branch = pr.head.ref;
-            const allowedPrefixes = ['feat/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
+            const allowedPrefixes = ['feat/', 'docs/', 'fix/', 'chore/', 'refactor/', 'test/', 'style/'];
             if (!allowedPrefixes.some(p => branch.startsWith(p))) {
               core.info('PR branch does not match allowed prefixes. Skipping.');
               return;
@@ -496,3 +533,216 @@ jobs:
             await updateStatus(project, itemId, statusFieldName, optionTodo);
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `PR #${pr.number}이 머지되지 않고 닫혀 Projects 상태를 '${optionTodo}'로 변경했습니다.` });
+
+      - name: Dispatch parent sync for linked issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const match = pr.head.ref.match(/#(\d+)/);
+            if (!match) { core.info('No linked issue number. Skip dispatch.'); return; }
+            const issue_number = Number(match[1]);
+            await github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'sync_parent_from_issue',
+              client_payload: { issue_number }
+            });
+
+  sync_parent_status_from_subissues:
+    if: github.event_name == 'issues' || github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.PROJECT_OWNER || github.repository_owner }}
+      - name: Sync parent issue Project status from sub-issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const projectNumber = process.env.PROJECT_NUMBER;
+            if (!projectNumber) {
+              core.setFailed('PROJECT_NUMBER secret is not set. Define it in repository secrets.');
+              return;
+            }
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || 'Status';
+            const optionTodo = process.env.STATUS_OPTION_TODO || 'Todo';
+            const optionInProgress = process.env.STATUS_OPTION_IN_PROGRESS || 'In Progress';
+            const optionDone = process.env.STATUS_OPTION_DONE || 'Done';
+            const ownerLogin = process.env.PROJECT_OWNER || owner;
+            const graph = github.graphql;
+
+            const eventIssueNumber = context.payload.issue?.number || context.payload.client_payload?.issue_number;
+            if (!eventIssueNumber) {
+              core.info('No issue number in payload. Skipping.');
+              return;
+            }
+
+            async function getProject() {
+              const number = Number(projectNumber);
+              let data = await graph(
+                `query($login:String!, $number:Int!){ organization(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                { login: ownerLogin, number }
+              ).catch(() => null);
+              let project = data?.organization?.projectV2 || null;
+              if (!project) {
+                data = await graph(
+                  `query($login:String!, $number:Int!){ user(login:$login){ projectV2(number:$number){ id title fields(first:100){ nodes { __typename ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }`,
+                  { login: ownerLogin, number }
+                ).catch(() => null);
+                project = data?.user?.projectV2 || null;
+              }
+              if (!project) throw new Error(`ProjectV2 #${projectNumber} not found under ${ownerLogin}`);
+              return project;
+            }
+
+            async function addToProject(projectId, contentId) {
+              const add = await graph(
+                `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId }
+              );
+              return add?.addProjectV2ItemById?.item?.id;
+            }
+
+            async function findExistingItemId(projectId, contentId) {
+              const data = await graph(
+                `query($projectId:ID!){ node(id:$projectId){ ... on ProjectV2 { id items(first:100){ nodes { id content { __typename ... on Issue { id } ... on PullRequest { id } } } } } } }`,
+                { projectId }
+              );
+              const items = data?.node?.items?.nodes || [];
+              const found = items.find(n => n?.content?.id === contentId);
+              return found?.id || null;
+            }
+
+            async function findOrCreateItemId(project, contentId) {
+              try {
+                const itemId = await addToProject(project.id, contentId);
+                if (itemId) return itemId;
+              } catch (e) {
+                const existingId = await findExistingItemId(project.id, contentId);
+                if (existingId) return existingId;
+                throw e;
+              }
+              const existingId = await findExistingItemId(project.id, contentId);
+              return existingId;
+            }
+
+            async function getIssueNode(ownerLogin, repo, number) {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id number state } } }`,
+                { owner: ownerLogin, repo, number }
+              );
+              return data?.repository?.issue || null;
+            }
+
+            async function getParentsOfIssue(ownerLogin, repo, number) {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id number trackedInIssues(first:10){ nodes { id number repository{ name owner{ login } } } } } } }`,
+                { owner: ownerLogin, repo, number }
+              ).catch(() => null);
+              const nodes = data?.repository?.issue?.trackedInIssues?.nodes || [];
+              return nodes.map(n => ({ id: n.id, number: n.number, repo: n.repository.name, owner: n.repository.owner.login }));
+            }
+
+            async function getChildrenOfIssue(ownerLogin, repo, number) {
+              const data = await graph(
+                `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner, name:$repo){ issue(number:$number){ id number trackedIssues(first:100){ nodes { id number state repository{ name owner{ login } } } } } } }`,
+                { owner: ownerLogin, repo, number }
+              ).catch(() => null);
+              const nodes = data?.repository?.issue?.trackedIssues?.nodes || [];
+              return nodes.map(n => ({ id: n.id, number: n.number, state: n.state, repo: n.repository.name, owner: n.repository.owner.login }));
+            }
+
+            async function getItemStatusName(project, itemId, statusFieldName) {
+              const data = await graph(
+                `query($itemId:ID!){ node(id:$itemId){ ... on ProjectV2Item { id fieldValues(first:20){ nodes { __typename ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } optionId } } } } } }`,
+                { itemId }
+              );
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              const values = data?.node?.fieldValues?.nodes || [];
+              const sel = values.find(v => v?.field?.name === statusFieldName);
+              if (!sel) return null;
+              const option = (statusField.options || []).find(o => o.id === sel.optionId);
+              return option?.name || null;
+            }
+
+            async function updateStatus(project, itemId, statusFieldName, optionName) {
+              const fields = project.fields.nodes || [];
+              const statusField = fields.find(f => f.name === statusFieldName);
+              if (!statusField) throw new Error(`Status field '${statusFieldName}' not found in Project`);
+              const option = (statusField.options || []).find(o => o.name === optionName);
+              if (!option) throw new Error(`Option '${optionName}' not found in field '${statusFieldName}'`);
+              await graph(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){ updateProjectV2ItemFieldValue(input:{ projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId }}) { projectV2Item { id } } }`,
+                { projectId: project.id, itemId, fieldId: statusField.id, optionId: option.id }
+              );
+            }
+
+            const project = await getProject();
+
+            // Determine parent candidates: parents of current issue, otherwise the current issue as parent
+            let parents = await getParentsOfIssue(ownerLogin, repo, eventIssueNumber);
+            if (!parents || parents.length === 0) {
+              const self = await getIssueNode(ownerLogin, repo, eventIssueNumber);
+              if (self) parents = [{ id: self.id, number: self.number, repo, owner: ownerLogin }];
+            }
+
+            for (const parent of parents) {
+              const children = await getChildrenOfIssue(parent.owner, parent.repo, parent.number);
+              if (!children || children.length === 0) {
+                core.info(`Parent #${parent.number} has no sub-issues. Skipping changes.`);
+                continue; // no effect when no children
+              }
+
+              let anyInProgress = false;
+              let allClosed = true;
+              let allTodo = true;
+
+              for (const child of children) {
+                if (child.state === 'CLOSED') {
+                  // closed → contributes to allClosed; and cannot be Todo/In Progress
+                  allTodo = false; // 닫힌 이슈가 하나라도 있으면 '모두 Todo'는 성립하지 않음
+                } else {
+                  allClosed = false;
+                  // read Project status
+                  const childItemId = await findExistingItemId(project.id, child.id);
+                  if (!childItemId) {
+                    // If not on project, treat as Todo by default
+                    core.info(`Child #${child.number} not on project; treating as Todo.`);
+                  } else {
+                    const statusName = await getItemStatusName(project, childItemId, statusFieldName);
+                    if (statusName === optionInProgress) anyInProgress = true;
+                    if (statusName !== optionTodo) allTodo = false;
+                  }
+                }
+              }
+
+              // Determine target status
+              let target = null;
+              if (allClosed) target = optionDone;
+              else if (anyInProgress) target = optionInProgress;
+              else if (allTodo) target = optionTodo;
+
+              if (!target) {
+                core.info(`No matching target for parent #${parent.number}. Skipping.`);
+                continue;
+              }
+
+              const parentIssue = await getIssueNode(parent.owner, parent.repo, parent.number);
+              const parentItemId = await findOrCreateItemId(project, parentIssue.id);
+              if (!parentItemId) {
+                core.info(`Could not resolve project item for parent #${parent.number}.`);
+                continue;
+              }
+              await updateStatus(project, parentItemId, statusFieldName, target);
+              core.info(`Updated parent #${parent.number} status → ${target}`);
+            }


### PR DESCRIPTION
- Github Project 워크플로우의 상세한 설정의 어려움으로 이슈 상태 트래킹 자동화 추가
  - `feat/#<issue-number>`, `fix/#<issue-number>` 와 같은 형태의 브랜치에 타겟으로 지원
  - 트래킹 타입
    - CREATE BRANCH/COMMIT → `In Progress`
    - PR OPEND → `In Review`
    - PR MERGED → `Done`
    - PR CLOSED → `TODO`
- 실사용해보면서 수정 필요 예상