### PR TITLE
test(#51): update column validation specs

### DIFF
--- a/packages/validator/src/lib/builder.ts
+++ b/packages/validator/src/lib/builder.ts
@@ -237,7 +237,7 @@ class ColumnBuilder {
 
   build(): Column {
     if (!this.tableId) {
-      throw new Error('tableId must be set on ColumnBuilder before building.');
+      this.tableId = `tbl_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -272,7 +272,7 @@ class ConstraintColumnBuilder {
 
   build(): ConstraintColumn {
     if (!this.columnId) {
-      throw new Error(`Column ID for ${this.columnName ?? 'unknown'} not resolved`);
+      this.columnId = `col_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -290,7 +290,8 @@ class ConstraintColumnBuilder {
     if (!this.columnName) return;
     const columnId = columnMap.get(this.columnName);
     if (!columnId) {
-      throw new Error(`Column ${this.columnName} not found in table`);
+      this.columnId = `col_${idGenerator()}`;
+      return;
     }
     this.columnId = columnId;
   }
@@ -356,7 +357,7 @@ class ConstraintBuilder {
 
   build(): Constraint {
     if (!this.tableId) {
-      throw new Error('tableId must be set on ConstraintBuilder before building.');
+      this.tableId = `tbl_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -401,7 +402,7 @@ class IndexColumnBuilder {
 
   build(): IndexColumn {
     if (!this.columnId) {
-      throw new Error(`Column ID for ${this.columnName ?? 'unknown'} not resolved`);
+      this.columnId = `col_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -418,7 +419,8 @@ class IndexColumnBuilder {
     if (!this.columnName) return;
     const columnId = columnMap.get(this.columnName);
     if (!columnId) {
-      throw new Error(`Column ${this.columnName} not found in table`);
+      this.columnId = `col_${idGenerator()}`;
+      return;
     }
     this.columnId = columnId;
   }
@@ -472,7 +474,7 @@ class IndexBuilder {
 
   build(): Index {
     if (!this.tableId) {
-      throw new Error('tableId must be set on IndexBuilder before building.');
+      this.tableId = `tbl_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -521,8 +523,11 @@ class RelationshipColumnBuilder {
   }
 
   build(): RelationshipColumn {
-    if (!this.fkColumnId || !this.refColumnId) {
-      throw new Error('Both fkColumnId and refColumnId must be set for RelationshipColumn');
+    if (!this.fkColumnId) {
+      this.fkColumnId = `fk_${idGenerator()}`;
+    }
+    if (!this.refColumnId) {
+      this.refColumnId = `ref_${idGenerator()}`;
     }
     return {
       id: this.id,
@@ -599,8 +604,11 @@ class RelationshipBuilder {
   }
 
   build(): Relationship {
-    if (!this.srcTableId || !this.tgtTableId) {
-      throw new Error('Both srcTableId and tgtTableId must be set for Relationship');
+    if (!this.srcTableId) {
+      this.srcTableId = `tbl_${idGenerator()}`;
+    }
+    if (!this.tgtTableId) {
+      this.tgtTableId = `tbl_${idGenerator()}`;
     }
     return {
       id: this.id,

--- a/packages/validator/src/lib/types.ts
+++ b/packages/validator/src/lib/types.ts
@@ -15,7 +15,7 @@ export const COLUMN = z.object({
   tableId: ULID,
   name: z.string().min(3).max(40),
   ordinalPosition: z.number().positive(),
-  dataType: z.string(),
+  dataType: z.string().nullable().optional(),
   lengthScale: z.string(),
   isAutoIncrement: z.boolean(),
   charset: z.string(),

--- a/packages/validator/src/lib/utils.ts
+++ b/packages/validator/src/lib/utils.ts
@@ -150,10 +150,14 @@ interface ERDValidator {
 }
 
 export const ERD_VALIDATOR: ERDValidator = (() => {
+  // FIX: 추후에 삭제 (파라미터 미사용 에러 발생 방지)
+  const _use = (..._args: unknown[]) => {};
+
   // 추가적으로 이걸 백엔드에서 검증하기 위해서, 프론트엔드에서 해당 ERD에 대한 모든 데이터가 필요할 것으로 보이는데, 이를 어떻게 하면 좋을지.
   // 단순히 캐싱으로 처리해야하나?
   return {
     validate: (database) => {
+      _use(database);
       // 해당 데이터베이스를 전체적으로 검증하는 것이 필요.
       throw new Error('validate: Not implemented yet');
     },
@@ -174,86 +178,112 @@ export const ERD_VALIDATOR: ERDValidator = (() => {
       };
     },
     createSchema: (database, schema) => {
+      _use(database, schema);
       throw new Error('createSchema: Not implemented yet');
     },
     deleteSchema: (database, schemaId) => {
+      _use(database, schemaId);
       throw new Error('deleteSchema: Not implemented yet');
     },
 
     createTable: (database, schemaId, table) => {
+      _use(database, schemaId, table);
       throw new Error('createTable: Not implemented yet');
     },
     deleteTable: (database, schemaId, tableId) => {
+      _use(database, schemaId, tableId);
       throw new Error('deleteTable: Not implemented yet');
     },
     changeTableName: (database, tableId, newName) => {
+      _use(database, tableId, newName);
       throw new Error('changeTableName: Not implemented yet');
     },
 
     createColumn: (database, schemaId, tableId, column) => {
+      _use(database, schemaId, tableId, column);
       throw new Error('createColumn: Not implemented yet');
     },
     deleteColumn: (database, schemaId, tableId, columnId) => {
+      _use(database, schemaId, tableId, columnId);
       throw new Error('deleteColumn: Not implemented yet');
     },
     changeColumnName: (database, schemaId, tableId, columnId, newName) => {
+      _use(database, schemaId, tableId, columnId, newName);
       throw new Error('changeColumnName: Not implemented yet');
     },
     changeColumnType: (database, schemaId, tableId, columnId, dataType, lengthScale) => {
+      _use(database, schemaId, tableId, columnId, dataType, lengthScale);
       throw new Error('changeColumnType: Not implemented yet');
     },
     changeColumnPosition: (database, schemaId, tableId, columnId, newPosition) => {
+      _use(database, schemaId, tableId, columnId, newPosition);
       throw new Error('changeColumnPosition: Not implemented yet');
     },
 
     createIndex: (database, schemaId, tableId, index) => {
+      _use(database, schemaId, tableId, index);
       throw new Error('createIndex: Not implemented yet');
     },
     deleteIndex: (database, schemaId, tableId, indexId) => {
+      _use(database, schemaId, tableId, indexId);
       throw new Error('deleteIndex: Not implemented yet');
     },
     changeIndexName: (database, schemaId, tableId, indexId, newName) => {
+      _use(database, schemaId, tableId, indexId, newName);
       throw new Error('changeIndexName: Not implemented yet');
     },
     addColumnToIndex: (database, schemaId, tableId, indexId, indexColumn) => {
+      _use(database, schemaId, tableId, indexId, indexColumn);
       throw new Error('addColumnToIndex: Not implemented yet');
     },
     removeColumnFromIndex: (database, schemaId, tableId, indexId, indexColumnId) => {
+      _use(database, schemaId, tableId, indexId, indexColumnId);
       throw new Error('removeColumnFromIndex: Not implemented yet');
     },
 
     createConstraint: (database, schemaId, tableId, constraint) => {
+      _use(database, schemaId, tableId, constraint);
       throw new Error('createConstraint: Not implemented yet');
     },
     deleteConstraint: (database, schemaId, tableId, constraintId) => {
+      _use(database, schemaId, tableId, constraintId);
       throw new Error('deleteConstraint: Not implemented yet');
     },
     changeConstraintName: (database, schemaId, tableId, constraintId, newName) => {
+      _use(database, schemaId, tableId, constraintId, newName);
       throw new Error('changeConstraintName: Not implemented yet');
     },
     addColumnToConstraint: (database, schemaId, tableId, constraintId, constraintColumn) => {
+      _use(database, schemaId, tableId, constraintId, constraintColumn);
       throw new Error('addColumnToConstraint: Not implemented yet');
     },
     removeColumnFromConstraint: (database, schemaId, tableId, constraintId, constraintColumnId) => {
+      _use(database, schemaId, tableId, constraintId, constraintColumnId);
       throw new Error('removeColumnFromConstraint: Not implemented yet');
     },
 
     createRelationship: (database, schemaId, relationship) => {
+      _use(database, schemaId, relationship);
       throw new Error('createRelationship: Not implemented yet');
     },
     deleteRelationship: (database, schemaId, relationshipId) => {
+      _use(database, schemaId, relationshipId);
       throw new Error('deleteRelationship: Not implemented yet');
     },
     changeRelationshipName: (database, schemaId, relationshipId, newName) => {
+      _use(database, schemaId, relationshipId, newName);
       throw new Error('changeRelationshipName: Not implemented yet');
     },
     changeRelationshipCardinality: (database, schemaId, relationshipId, cardinality) => {
+      _use(database, schemaId, relationshipId, cardinality);
       throw new Error('changeRelationshipCardinality: Not implemented yet');
     },
     addColumnToRelationship: (database, schemaId, relationshipId, relationshipColumn) => {
+      _use(database, schemaId, relationshipId, relationshipColumn);
       throw new Error('addColumnToRelationship: Not implemented yet');
     },
     removeColumnFromRelationship: (database, schemaId, relationshipId, relationshipColumnId) => {
+      _use(database, schemaId, relationshipId, relationshipColumnId);
       throw new Error('removeColumnFromRelationship: Not implemented yet');
     },
   };

--- a/packages/validator/tests/column.validation.spec.ts
+++ b/packages/validator/tests/column.validation.spec.ts
@@ -2,14 +2,12 @@ import { createColumnBuilder, createTestDatabase } from '../src/lib/builder';
 import {
   ColumnDataTypeInvalidError,
   ColumnDataTypeRequiredError,
-  ColumnInPrimaryKeyError,
   ColumnLengthRequiredError,
   ColumnNameInvalidError,
   ColumnNameInvalidFormatError,
   ColumnNameIsReservedKeywordError,
   ColumnNameNotUniqueError,
   ColumnPrecisionRequiredError,
-  DefaultValueIncompatibleError,
   MultipleAutoIncrementColumnsError,
 } from '../src/lib/errors';
 import { ERD_VALIDATOR } from '../src/lib/utils';
@@ -30,7 +28,7 @@ describe('Column validation', () => {
     expect(() => ERD_VALIDATOR.createColumn(baseDatabase, schemaId, tableId, column)).toThrow(ColumnNameNotUniqueError);
   });
 
-  test.skip('컬럼의 데이터 타입은 반드시 존재해야 한다', () => {
+  test.skip('데이터 타입이 비어 있어도 컬럼 생성 단계에서는 허용된다', () => {
     const schemaId = 'schema-1';
     const tableId = 'table-1';
 
@@ -42,9 +40,7 @@ describe('Column validation', () => {
 
     const column = createColumnBuilder().withDataType('').build();
 
-    expect(() => ERD_VALIDATOR.createColumn(baseDatabase, schemaId, tableId, column)).toThrow(
-      ColumnDataTypeRequiredError
-    );
+    expect(() => ERD_VALIDATOR.createColumn(baseDatabase, schemaId, tableId, column)).not.toThrow();
   });
 
   test.skip('컬럼의 데이터 타입은 데이터베이스 벤더에서 유효한 값이어야 한다', () => {
@@ -62,6 +58,31 @@ describe('Column validation', () => {
     expect(() => ERD_VALIDATOR.createColumn(baseDatabase, schemaId, tableId, column)).toThrow(
       ColumnDataTypeInvalidError
     );
+  });
+
+  test.skip('validate 단계에서 데이터 타입이 빈 문자열이면 에러를 발생시킨다', () => {
+    const db = createTestDatabase()
+      .withSchema((s) =>
+        s
+          .withId('schema-1')
+          .withTable((t) => t.withId('table-1').withColumn((c) => c.withId('id-col').withName('id').withDataType('')))
+      )
+      .build();
+
+    expect(() => ERD_VALIDATOR.validate(db)).toThrow(ColumnDataTypeRequiredError);
+  });
+
+  test.skip('validate 단계에서 데이터 타입이 null이면 에러를 발생시킨다', () => {
+    const db = createTestDatabase()
+      .withSchema((s) =>
+        s.withId('schema-1').withTable((t) => t.withId('table-1').withColumn((c) => c.withId('id-col').withName('id')))
+      )
+      .build();
+
+    const table = db.schemas[0].tables[0];
+    table.columns[0].dataType = null;
+
+    expect(() => ERD_VALIDATOR.validate(db)).toThrow(ColumnDataTypeRequiredError);
   });
 
   test.skip.each(['VARCHAR', 'CHAR'])('%s 타입은 반드시 길이를 지정해야 한다', (dataType) => {
@@ -159,110 +180,74 @@ describe('Column validation', () => {
     );
   });
 
-  describe('Auto Increment 컬럼은 테이블 당 하나만 존재할 수 있다', () => {
+  test.skip('Auto Increment 컬럼은 테이블 당 하나만 존재할 수 있다.', () => {
     const schemaId = 'schema-1';
     const tableId = 'table-1';
+    const newColumn = createColumnBuilder().withName('new_ai_column').withAutoIncrement(true).build();
+    const dbWithAutoIncrement = createTestDatabase()
+      .withSchema((s) =>
+        s
+          .withId(schemaId)
+          .withTable((t) =>
+            t.withId(tableId).withColumn((c) => c.withId('id-col').withName('id').withAutoIncrement(true))
+          )
+      )
+      .build();
 
-    test.skip('Auto Increment 컬럼은 테이블 당 하나만 존재할 수 있다.', () => {
-      const newColumn = createColumnBuilder().withName('new_ai_column').withAutoIncrement(true).build();
-      const dbWithAutoIncrement = createTestDatabase()
-        .withSchema((s) =>
-          s
-            .withId(schemaId)
-            .withTable((t) =>
-              t.withId(tableId).withColumn((c) => c.withId('id-col').withName('id').withAutoIncrement(true))
+    expect(() => ERD_VALIDATOR.createColumn(dbWithAutoIncrement, schemaId, tableId, newColumn)).toThrow(
+      MultipleAutoIncrementColumnsError
+    );
+  });
+
+  test.skip('숫자 타입이 아닌 컬럼에 Auto Increment를 설정할 수 없다.', () => {
+    createTestDatabase()
+      .withSchema((s) =>
+        s.withTable((t) =>
+          t
+            .withId('table-1')
+            .withColumn((c) =>
+              c
+                .withId('non-numeric-ai-col')
+                .withName('varchar_ai')
+                .withDataType('VARCHAR')
+                .withLengthScale('50')
+                .withAutoIncrement(true)
+            )
+            .withConstraint((c) =>
+              c
+                .withName('pk_varchar_ai')
+                .withKind('PRIMARY_KEY')
+                .withColumn((cc) => cc.withColumnId('non-numeric-ai-col'))
             )
         )
-        .build();
+      )
+      .build();
 
-      expect(() => ERD_VALIDATOR.createColumn(dbWithAutoIncrement, schemaId, tableId, newColumn)).toThrow(
-        MultipleAutoIncrementColumnsError
-      );
-    });
+    // expect(() => ERD_VALIDATOR.validate(db)).toThrow(AutoIncrementNonNumericError);
   });
 
-  describe('컬럼에 기본값이 설정된 경우 해당 값은 컬럼의 데이터 타입과 호환되어야 한다', () => {
-    const schemaId = 'schema-1';
-    const tableId = 'table-1';
-
-    test.skip('컬럼에 기본값(Default)이 설정된 경우, 해당 값은 컬럼의 데이터 타입과 호환되어야 한다.', () => {
-      const db = createTestDatabase()
-        .withSchema((s) =>
-          s.withId(schemaId).withTable((t) =>
-            t
-              .withId(tableId)
-              .withColumn((c) =>
-                c.withId('incompatible-default-col').withName('incompatible_default').withDataType('INT')
-              )
-              .withConstraint(
-                (c) =>
-                  c
-                    .withName('default_constraint')
-                    .withKind('DEFAULT')
-                    .withColumn((cc) => cc.withColumnId('incompatible-default-col'))
-                    .withDefaultExpr("'not_a_number'") // 숫자가 아닌 문자열을 INT 컬럼에 기본값으로 설정
-              )
-          )
-        )
-        .build();
-
-      expect(() => ERD_VALIDATOR.validate(db)).toThrow(DefaultValueIncompatibleError);
-    });
-  });
-
-  describe('숫자 타입이 아닌 컬럼에 Auto Increment를 설정할 수 없다', () => {
-    test.skip('숫자 타입이 아닌 컬럼에 Auto Increment를 설정할 수 없다.', () => {
-      createTestDatabase()
-        .withSchema((s) =>
-          s.withTable((t) =>
-            t
-              .withId('table-1')
-              .withColumn((c) =>
+  test.skip('Primary Key가 아닌 컬럼에 Auto Increment를 설정할 수 없다.', () => {
+    createTestDatabase()
+      .withSchema((s) =>
+        s.withTable((t) =>
+          t
+            .withId('table-1')
+            .withColumn((c) => c.withId('pk-col').withName('id').withDataType('INT'))
+            .withColumn(
+              (c) => c.withId('non-pk-ai-col').withName('non_pk_ai').withDataType('INT').withAutoIncrement(true) // PK가 아닌 컬럼에 AI 설정
+            )
+            .withConstraint(
+              (c) =>
                 c
-                  .withId('non-numeric-ai-col')
-                  .withName('varchar_ai')
-                  .withDataType('VARCHAR')
-                  .withLengthScale('50')
-                  .withAutoIncrement(true)
-              )
-              .withConstraint((c) =>
-                c
-                  .withName('pk_varchar_ai')
+                  .withName('pk_id')
                   .withKind('PRIMARY_KEY')
-                  .withColumn((cc) => cc.withColumnId('non-numeric-ai-col'))
-              )
-          )
+                  .withColumn((cc) => cc.withColumnId('pk-col')) // 다른 컬럼이 PK
+            )
         )
-        .build();
+      )
+      .build();
 
-      // expect(() => ERD_VALIDATOR.validate(db)).toThrow(AutoIncrementNonNumericError);
-    });
-  });
-
-  describe('Primary Key가 아닌 컬럼에 Auto Increment를 설정할 수 없다', () => {
-    test.skip('Primary Key가 아닌 컬럼에 Auto Increment를 설정할 수 없다.', () => {
-      createTestDatabase()
-        .withSchema((s) =>
-          s.withTable((t) =>
-            t
-              .withId('table-1')
-              .withColumn((c) => c.withId('pk-col').withName('id').withDataType('INT'))
-              .withColumn(
-                (c) => c.withId('non-pk-ai-col').withName('non_pk_ai').withDataType('INT').withAutoIncrement(true) // PK가 아닌 컬럼에 AI 설정
-              )
-              .withConstraint(
-                (c) =>
-                  c
-                    .withName('pk_id')
-                    .withKind('PRIMARY_KEY')
-                    .withColumn((cc) => cc.withColumnId('pk-col')) // 다른 컬럼이 PK
-              )
-          )
-        )
-        .build();
-
-      // expect(() => ERD_VALIDATOR.validate(db)).toThrow(AutoIncrementNonPrimaryKeyError);
-    });
+    // expect(() => ERD_VALIDATOR.validate(db)).toThrow(AutoIncrementNonPrimaryKeyError);
   });
 
   test.skip('일반 컬럼을 삭제할 수 있다', () => {
@@ -281,83 +266,41 @@ describe('Column validation', () => {
     expect(() => ERD_VALIDATOR.deleteColumn(database, 'schema-1', 'table-1', 'name-col')).not.toThrow();
   });
 
-  describe('Primary Key 컬럼 삭제 시 에러 발생', () => {
-    test.skip('Primary Key 컬럼 삭제 시 에러 발생', () => {
-      const dbWithPK = createTestDatabase()
-        .withSchema((s) =>
-          s.withId('schema-1').withTable((t) =>
+  test.skip('Foreign Key로 참조되는 컬럼도 삭제 가능하다', () => {
+    const dbWithFK = createTestDatabase()
+      .withSchema((s) =>
+        s
+          .withTable((t) =>
             t
-              .withId('table-1')
-              .withColumn((c) => c.withId('id-col').withName('id').withDataType('INT'))
+              .withId('parent-table')
+              .withName('parent')
+              .withColumn((c) => c.withId('parent-id').withName('id').withDataType('INT'))
               .withConstraint((c) =>
                 c
-                  .withName('pk_id')
+                  .withName('pk_parent')
                   .withKind('PRIMARY_KEY')
-                  .withColumn((cc) => cc.withColumnId('id-col'))
+                  .withColumn((cc) => cc.withColumnId('parent-id'))
               )
           )
-        )
-        .build();
+          .withTable((t) =>
+            t
+              .withId('child-table')
+              .withName('child')
+              .withColumn((c) => c.withId('child-parent-id').withName('parent_id').withDataType('INT'))
+              .withRelationship((r) =>
+                r
+                  .withName('fk_child_parent')
+                  .withKind('NON_IDENTIFYING')
+                  .withTgtTableId('parent-table')
+                  .withColumn((rc) => rc.withFkColumnId('child-parent-id').withRefColumnId('parent-id'))
+              )
+          )
+      )
+      .build();
 
-      expect(() => ERD_VALIDATOR.deleteColumn(dbWithPK, 'schema-1', 'table-1', 'id-col')).toThrow(
-        ColumnInPrimaryKeyError
-      );
-    });
-  });
-
-  describe('Foreign Key로 참조되는 컬럼도 삭제 가능하다', () => {
-    test.skip('Foreign Key로 참조되는 컬럼도 삭제 가능하다', () => {
-      const dbWithFK = createTestDatabase()
-        .withSchema((s) =>
-          s
-            .withTable((t) =>
-              t
-                .withId('parent-table')
-                .withName('parent')
-                .withColumn((c) => c.withId('parent-id').withName('id').withDataType('INT'))
-                .withConstraint((c) =>
-                  c
-                    .withName('pk_parent')
-                    .withKind('PRIMARY_KEY')
-                    .withColumn((cc) => cc.withColumnId('parent-id'))
-                )
-            )
-            .withTable((t) =>
-              t
-                .withId('child-table')
-                .withName('child')
-                .withColumn((c) => c.withId('child-parent-id').withName('parent_id').withDataType('INT'))
-                .withRelationship((r) =>
-                  r
-                    .withName('fk_child_parent')
-                    .withKind('NON_IDENTIFYING')
-                    .withTgtTableId('parent-table')
-                    .withColumn((rc) => rc.withFkColumnId('child-parent-id').withRefColumnId('parent-id'))
-                )
-            )
-        )
-        .build();
-
-      const result = ERD_VALIDATOR.deleteColumn(dbWithFK, 'schema-1', 'parent-table', 'parent-id');
-      const table = result.schemas[0].tables.find((t) => t.id === 'parent-table');
-      expect(table?.columns.some((c) => c.id === 'parent-id')).toBeFalsy();
-    });
-  });
-
-  describe('마지막 컬럼 삭제 시 에러 발생', () => {
-    test.skip('마지막 컬럼 삭제 시 에러 발생', () => {
-      const singleColumnDb = createTestDatabase()
-        .withSchema((s) =>
-          s
-            .withId('schema-1')
-            .withTable((t) =>
-              t.withId('table-1').withColumn((c) => c.withId('only-col').withName('only').withDataType('INT'))
-            )
-        )
-        .build();
-
-      expect(() => ERD_VALIDATOR.deleteColumn(singleColumnDb, 'schema-1', 'table-1', 'only-col')).toThrow();
-    });
+    const result = ERD_VALIDATOR.deleteColumn(dbWithFK, 'schema-1', 'parent-table', 'parent-id');
+    const table = result.schemas[0].tables.find((t) => t.id === 'parent-table');
+    expect(table?.columns.some((c) => c.id === 'parent-id')).toBeFalsy();
   });
 
   test.skip('컬럼 이름을 변경할 수 있다', () => {


### PR DESCRIPTION
## 개요

- 기존 빌더를 통해 데이터 생성시에, ID 누락으로 인한 에러를 임의의 ID 부여하는 방식으로 수정
- `dataType` `null` 값을 허용하도록 수정
- 컬럼과 관련된 테스트 수정

## 관련 이슈

- close #51 