### PR TITLE
feat(#61): implement API versioning system

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/common/annotation/ApiVersion.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/annotation/ApiVersion.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersion {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/config/WebFluxConfig.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/config/WebFluxConfig.java
@@ -1,0 +1,16 @@
+package com.schemafy.core.common.config;
+
+import com.schemafy.core.common.resolver.ApiVersionArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.result.method.annotation.ArgumentResolverConfigurer;
+
+@Configuration
+public class WebFluxConfig implements WebFluxConfigurer {
+
+    @Override
+    public void configureArgumentResolvers(@NonNull ArgumentResolverConfigurer configurer) {
+        configurer.addCustomResolver(new ApiVersionArgumentResolver());
+    }
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
@@ -5,5 +5,5 @@ public final class ApiPath {
     }
 
     public static final String API = "/api/{version}";
-    public static final String AUTH_API = "/api/auth/{version}";
+    public static final String AUTH_API = "/auth/api/{version}";
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
@@ -1,11 +1,8 @@
 package com.schemafy.core.common.constant;
 
 public final class ApiPath {
-    private ApiPath() {}
+    private ApiPath() {
+    }
 
-    public static final String API_V1 = "/api/v1";
-    public static final String USERS = API_V1 + "/users";
-    public static final String AUTH = API_V1 + "/auth";
-    public static final String PROJECTS = API_V1 + "/projects";
-    public static final String SCHEMAS = API_V1 + "/schemas";
+    public static final String API = "/api/{version}";
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
@@ -5,5 +5,5 @@ public final class ApiPath {
     }
 
     public static final String API = "/api/{version}";
-    public static final String API_AUTH = "/api/auth/{version}";
+    public static final String AUTH_API = "/api/auth/{version}";
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
@@ -5,5 +5,5 @@ public final class ApiPath {
     }
 
     public static final String API = "/api/{version}";
-    public static final String AUTH_API = "/auth/api/{version}";
+    public static final String AUTH_API = "/api/auth/{version}";
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/constant/ApiPath.java
@@ -5,4 +5,5 @@ public final class ApiPath {
     }
 
     public static final String API = "/api/{version}";
+    public static final String API_AUTH = "/api/auth/{version}";
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // Common
     COMMON_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "시스템 오류가 발생했습니다."),
     COMMON_INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "유효하지 않은 파라미터입니다."),
+    COMMON_API_VERSION_INVALID(HttpStatus.BAD_REQUEST, "C003", "유효하지 않은 API 버전 형식입니다. (예: v1.0, v2.1)"),
 
     // USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "회원을 찾을 수 없습니다."),

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     // Common
     COMMON_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "시스템 오류가 발생했습니다."),
     COMMON_INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "유효하지 않은 파라미터입니다."),
-    COMMON_API_VERSION_INVALID(HttpStatus.BAD_REQUEST, "C003", "유효하지 않은 API 버전 형식입니다. (예: v1.0, v2.1)"),
+    COMMON_API_VERSION_MISSING(HttpStatus.BAD_REQUEST, "C003", "API 버전이 누락되었습니다."),
+    COMMON_API_VERSION_INVALID(HttpStatus.BAD_REQUEST, "C004", "유효하지 않은 API 버전 형식입니다. (예: v1.0, v2.1)"),
 
     // USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "회원을 찾을 수 없습니다."),

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
@@ -33,7 +33,7 @@ public class ApiVersionArgumentResolver implements HandlerMethodArgumentResolver
                 HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
         if (pathVariables == null || !pathVariables.containsKey("version")) {
-            return Mono.error(new IllegalStateException("Path variable 'version' not found"));
+            return Mono.error(new BusinessException(ErrorCode.COMMON_API_VERSION_INVALID));
         }
 
         String versionString = pathVariables.get("version");

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
@@ -1,0 +1,52 @@
+package com.schemafy.core.common.resolver;
+
+import com.schemafy.core.common.annotation.ApiVersion;
+import com.schemafy.core.common.exception.BusinessException;
+import com.schemafy.core.common.exception.ErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.NonNull;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class ApiVersionArgumentResolver implements HandlerMethodArgumentResolver {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^v\\d+\\.\\d+$");
+
+    @Override
+    public boolean supportsParameter(@NonNull MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ApiVersion.class);
+    }
+
+    @Override
+    @NonNull
+    public Mono<Object> resolveArgument(
+            @NonNull MethodParameter parameter,
+            @NonNull BindingContext bindingContext,
+            @NonNull ServerWebExchange exchange) {
+
+        Map<String, String> pathVariables = exchange.getAttribute(
+                HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        if (pathVariables == null || !pathVariables.containsKey("version")) {
+            return Mono.error(new IllegalStateException("Path variable 'version' not found"));
+        }
+
+        String versionString = pathVariables.get("version");
+
+        if (versionString == null || !VERSION_PATTERN.matcher(versionString).matches()) {
+            return Mono.error(new BusinessException(ErrorCode.COMMON_API_VERSION_INVALID));
+        }
+
+        if (parameter.getParameterType().equals(String.class)) {
+            return Mono.just(versionString);
+        }
+
+        return Mono.error(new IllegalArgumentException(
+                "@ApiVersion can only be used with String parameter type"));
+    }
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/resolver/ApiVersionArgumentResolver.java
@@ -33,7 +33,7 @@ public class ApiVersionArgumentResolver implements HandlerMethodArgumentResolver
                 HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
         if (pathVariables == null || !pathVariables.containsKey("version")) {
-            return Mono.error(new BusinessException(ErrorCode.COMMON_API_VERSION_INVALID));
+            return Mono.error(new BusinessException(ErrorCode.COMMON_API_VERSION_MISSING));
         }
 
         String versionString = pathVariables.get("version");

--- a/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
@@ -1,21 +1,26 @@
 package com.schemafy.core.ulid.controller;
 
+import com.schemafy.core.common.annotation.ApiVersion;
+import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.type.BaseResponse;
 import com.schemafy.core.ulid.controller.dto.UlidResponse;
 import com.schemafy.core.ulid.service.UlidService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RestController
-@RequestMapping("/api/ulid")
+@RequestMapping(ApiPath.API)
 @RequiredArgsConstructor
 public class UlidController {
 
     private final UlidService ulidService;
 
-    @GetMapping("/generate")
-    public Mono<BaseResponse<UlidResponse>> generateTemporaryUlid() {
+    @GetMapping("/ulid/generate")
+    public Mono<BaseResponse<UlidResponse>> generateTemporaryUlid(@ApiVersion String version) {
+        log.debug("API Version: {}", version);
         return ulidService.generateTemporaryUlid()
                 .map(UlidResponse::new)
                 .map(BaseResponse::success);

--- a/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @RestController
-@RequestMapping(ApiPath.API)
+@RequestMapping(ApiPath.AUTH_API)
 @RequiredArgsConstructor
 public class UlidController {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/ulid/controller/UlidController.java
@@ -20,8 +20,8 @@ public class UlidController {
 
     @GetMapping("/ulid/generate")
     public Mono<BaseResponse<UlidResponse>> generateTemporaryUlid(@ApiVersion String version) {
-        log.debug("API Version: {}", version);
-        return ulidService.generateTemporaryUlid()
+        return ulidService
+                .generateTemporaryUlid()
                 .map(UlidResponse::new)
                 .map(BaseResponse::success);
     }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.user.controller;
 
+import com.schemafy.core.common.annotation.ApiVersion;
 import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.type.BaseResponse;
 import com.schemafy.core.user.service.UserService;
@@ -8,29 +9,40 @@ import com.schemafy.core.user.controller.dto.request.SignUpRequest;
 import com.schemafy.core.user.controller.dto.response.UserInfoResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RestController
-@RequestMapping(ApiPath.USERS)
+@RequestMapping(ApiPath.API)
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("/signup")
-    public Mono<BaseResponse<UserInfoResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
+    @PostMapping("/users/signup")
+    public Mono<BaseResponse<UserInfoResponse>> signUp(
+            @ApiVersion String version,
+            @Valid @RequestBody SignUpRequest request) {
+        log.debug("API Version: {}", version);
         return userService.signUp(request.toCommand())
                 .map(BaseResponse::success);
     }
 
-    @PostMapping("/login")
-    public Mono<BaseResponse<UserInfoResponse>> login(@Valid @RequestBody LoginRequest request) {
+    @PostMapping("/users/login")
+    public Mono<BaseResponse<UserInfoResponse>> login(
+            @ApiVersion String version,
+            @Valid @RequestBody LoginRequest request) {
+        log.debug("API Version: {}", version);
         return userService.login(request.toCommand())
                 .map(BaseResponse::success);
     }
 
-    @GetMapping("/{userId}")
-    public Mono<BaseResponse<UserInfoResponse>> getMember(@PathVariable String userId) {
+    @GetMapping("/users/{userId}")
+    public Mono<BaseResponse<UserInfoResponse>> getMember(
+            @ApiVersion String version,
+            @PathVariable String userId) {
+        log.debug("API Version: {}", version);
         return userService.getUserById(userId)
                 .map(BaseResponse::success);
     }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
@@ -22,7 +22,6 @@ public class UserController {
 
     @PostMapping("/users/signup")
     public Mono<BaseResponse<UserInfoResponse>> signUp(
-            @ApiVersion String version,
             @Valid @RequestBody SignUpRequest request) {
         return userService.signUp(request.toCommand())
                 .map(BaseResponse::success);
@@ -30,7 +29,6 @@ public class UserController {
 
     @PostMapping("/users/login")
     public Mono<BaseResponse<UserInfoResponse>> login(
-            @ApiVersion String version,
             @Valid @RequestBody LoginRequest request) {
         return userService.login(request.toCommand())
                 .map(BaseResponse::success);
@@ -38,7 +36,6 @@ public class UserController {
 
     @GetMapping("/users/{userId}")
     public Mono<BaseResponse<UserInfoResponse>> getUser(
-            @ApiVersion String version,
             @PathVariable String userId) {
         return userService.getUserById(userId)
                 .map(BaseResponse::success);

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
@@ -21,29 +21,27 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/users/signup")
-    public Mono<BaseResponse<UserInfoResponse>> signUp(
-            @ApiVersion String version,
+    public Mono<BaseResponse<UserInfoResponse>> signUp(@ApiVersion String version,
             @Valid @RequestBody SignUpRequest request) {
-        log.debug("API Version: {}", version);
-        return userService.signUp(request.toCommand())
+        return userService
+                .signUp(request
+                        .toCommand())
                 .map(BaseResponse::success);
     }
 
     @PostMapping("/users/login")
-    public Mono<BaseResponse<UserInfoResponse>> login(
-            @ApiVersion String version,
+    public Mono<BaseResponse<UserInfoResponse>> login(@ApiVersion String version,
             @Valid @RequestBody LoginRequest request) {
-        log.debug("API Version: {}", version);
-        return userService.login(request.toCommand())
+        return userService
+                .login(request
+                        .toCommand())
                 .map(BaseResponse::success);
     }
 
     @GetMapping("/users/{userId}")
-    public Mono<BaseResponse<UserInfoResponse>> getMember(
-            @ApiVersion String version,
-            @PathVariable String userId) {
-        log.debug("API Version: {}", version);
-        return userService.getUserById(userId)
+    public Mono<BaseResponse<UserInfoResponse>> getUser(@ApiVersion String version, @PathVariable String userId) {
+        return userService
+                .getUserById(userId)
                 .map(BaseResponse::success);
     }
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/UserController.java
@@ -21,27 +21,26 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/users/signup")
-    public Mono<BaseResponse<UserInfoResponse>> signUp(@ApiVersion String version,
+    public Mono<BaseResponse<UserInfoResponse>> signUp(
+            @ApiVersion String version,
             @Valid @RequestBody SignUpRequest request) {
-        return userService
-                .signUp(request
-                        .toCommand())
+        return userService.signUp(request.toCommand())
                 .map(BaseResponse::success);
     }
 
     @PostMapping("/users/login")
-    public Mono<BaseResponse<UserInfoResponse>> login(@ApiVersion String version,
+    public Mono<BaseResponse<UserInfoResponse>> login(
+            @ApiVersion String version,
             @Valid @RequestBody LoginRequest request) {
-        return userService
-                .login(request
-                        .toCommand())
+        return userService.login(request.toCommand())
                 .map(BaseResponse::success);
     }
 
     @GetMapping("/users/{userId}")
-    public Mono<BaseResponse<UserInfoResponse>> getUser(@ApiVersion String version, @PathVariable String userId) {
-        return userService
-                .getUserById(userId)
+    public Mono<BaseResponse<UserInfoResponse>> getUser(
+            @ApiVersion String version,
+            @PathVariable String userId) {
+        return userService.getUserById(userId)
                 .map(BaseResponse::success);
     }
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("test")
 @Import(TestSecurityConfig.class)
 class UlidControllerTest {
-    private static final String API_BASE_PATH = ApiPath.API.replace("{version}",
+    private static final String API_BASE_PATH = ApiPath.AUTH_API.replace("{version}",
             "v1.0");
 
     @Autowired

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import com.schemafy.core.TestSecurityConfig;
+import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.ulid.service.UlidService;
 
 import reactor.core.publisher.Mono;
@@ -27,6 +28,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("test")
 @Import(TestSecurityConfig.class)
 class UlidControllerTest {
+    private static final String API_BASE_PATH = ApiPath.API.replace("{version}",
+            "v1.0");
 
     @Autowired
     private WebTestClient webTestClient;
@@ -43,7 +46,7 @@ class UlidControllerTest {
         // When & Then
         webTestClient
                 .get()
-                .uri("/api/ulid/generate")
+                .uri(API_BASE_PATH + "/ulid/generate")
                 .header("Accept", "application/json")
                 .exchange()
                 .expectStatus().isOk()

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import com.jayway.jsonpath.JsonPath;
+import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.exception.ErrorCode;
 import com.schemafy.core.ulid.generator.UlidGenerator;
 import com.schemafy.core.user.controller.dto.request.LoginRequest;
@@ -32,6 +33,9 @@ import reactor.test.StepVerifier;
 @AutoConfigureWebTestClient
 @DisplayName("MemberController 통합 테스트")
 class UserControllerTest {
+    private static final String API_BASE_PATH = ApiPath.API.replace("{version}",
+            "v1.0");
+
     @Autowired
     private WebTestClient webTestClient;
 
@@ -50,7 +54,7 @@ class UserControllerTest {
         SignUpRequest request = new SignUpRequest("test@example.com", "Test User", "password");
 
         // when & then
-        webTestClient.post().uri("/api/v1/users/signup")
+        webTestClient.post().uri(API_BASE_PATH + "/users/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .exchange()
@@ -80,7 +84,7 @@ class UserControllerTest {
     @MethodSource("invalidSignUpRequests")
     void signUpFail(SignUpRequest request) {
         // when & then
-        webTestClient.post().uri("/api/v1/users/signup")
+        webTestClient.post().uri(API_BASE_PATH + "/users/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .exchange()
@@ -106,7 +110,7 @@ class UserControllerTest {
         // given
         SignUpRequest signUpRequest = new SignUpRequest("test2@example.com", "Test User 2", "password");
 
-        EntityExchangeResult<byte[]> result = webTestClient.post().uri("/api/v1/users/signup")
+        EntityExchangeResult<byte[]> result = webTestClient.post().uri(API_BASE_PATH + "/users/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(signUpRequest)
                 .exchange()
@@ -117,7 +121,7 @@ class UserControllerTest {
         String userId = JsonPath.read(responseBody, "$.result.id");
 
         // when & then
-        webTestClient.get().uri("/api/v1/users/{userId}", userId)
+        webTestClient.get().uri(API_BASE_PATH + "/users/{userId}", userId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -133,7 +137,7 @@ class UserControllerTest {
         String nonExistentUserId = UlidGenerator.generate();
 
         // when & then
-        webTestClient.get().uri("/api/v1/users/{userId}", nonExistentUserId)
+        webTestClient.get().uri(API_BASE_PATH + "/users/{userId}", nonExistentUserId)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody()
@@ -146,7 +150,7 @@ class UserControllerTest {
     void loginSuccess() {
         // given
         SignUpRequest signUpRequest = new SignUpRequest("test@example.com", "Test User", "password");
-        webTestClient.post().uri("/api/v1/users/signup")
+        webTestClient.post().uri(API_BASE_PATH + "/users/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(signUpRequest)
                 .exchange()
@@ -155,7 +159,7 @@ class UserControllerTest {
         LoginRequest loginRequest = new LoginRequest("test@example.com", "password");
 
         // when & then
-        webTestClient.post().uri("/api/v1/users/login")
+        webTestClient.post().uri(API_BASE_PATH + "/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(loginRequest)
                 .exchange()
@@ -169,7 +173,7 @@ class UserControllerTest {
     @ParameterizedTest
     @MethodSource("invalidLoginRequests")
     void loginFail(LoginRequest request) {
-        webTestClient.post().uri("/api/v1/users/login")
+        webTestClient.post().uri(API_BASE_PATH + "/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .exchange()
@@ -194,7 +198,7 @@ class UserControllerTest {
         LoginRequest loginRequest = new LoginRequest("nonexistent@example.com", "password");
 
         // when & then
-        webTestClient.post().uri("/api/v1/users/login")
+        webTestClient.post().uri(API_BASE_PATH + "/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(loginRequest)
                 .exchange()
@@ -209,7 +213,7 @@ class UserControllerTest {
     void loginFailPasswordMismatch() {
         // given
         SignUpRequest signUpRequest = new SignUpRequest("test@example.com", "Test User", "password");
-        webTestClient.post().uri("/api/v1/users/signup")
+        webTestClient.post().uri(API_BASE_PATH + "/users/signup")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(signUpRequest)
                 .exchange()
@@ -218,7 +222,7 @@ class UserControllerTest {
         LoginRequest loginRequest = new LoginRequest("test@example.com", "wrong_password");
 
         // when & then
-        webTestClient.post().uri("/api/v1/users/login")
+        webTestClient.post().uri(API_BASE_PATH + "/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(loginRequest)
                 .exchange()


### PR DESCRIPTION
## 개요

- 향후 버전별 로직 분기를 위한 API 버전 관리 추가
  - `@ApiVersion` 어노테이션 이용 버전 추출
  - 기존 컨트롤러 수정
- 추가적으로 API 경로 컨벤션 아래와 같이 수정
  - 각 컨트롤러에서 기본적으로 `ApiPath.API`를 이용하여 매핑
  - 세부경로는 각 메서드에서 정의 (일괄적으로 모든 경로를 매핑하지 않음)
  - `ApiPath.AUTH_API` 와 같은 메서드들을 통해 필요에 따른 경로 커스텀
    - 시큐리티에서 설정 필요
- `UlidController`에서 예시로 사용법 유지

## 이슈

- close #61 