### PR TITLE
feat(#59): signup, login api docs

### DIFF
--- a/apps/backend/core/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/core/src/docs/asciidoc/api-guide.adoc
@@ -93,6 +93,75 @@ include::{snippets}/ulid-generate/response-fields.adoc[]
 |===
 
 
+=== 회원가입
+
+사용자 계정을 생성하고 JWT 토큰을 발급합니다.
+
+[discrete]
+==== 요청
+
+include::{snippets}/user-signup/http-request.adoc[]
+include::{snippets}/user-signup/request-fields.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/user-signup/http-response.adoc[]
+include::{snippets}/user-signup/response-headers.adoc[]
+include::{snippets}/user-signup/response-fields.adoc[]
+
+=== 로그인
+
+이메일과 비밀번호로 로그인하고 JWT 토큰을 발급합니다.
+
+[discrete]
+==== 요청
+
+include::{snippets}/user-login/http-request.adoc[]
+include::{snippets}/user-login/request-fields.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/user-login/http-response.adoc[]
+include::{snippets}/user-login/response-headers.adoc[]
+include::{snippets}/user-login/response-fields.adoc[]
+
+=== 사용자 조회
+
+사용자 ID로 사용자 정보를 조회합니다. (인증 필요)
+
+[discrete]
+==== 요청
+
+include::{snippets}/user-get/http-request.adoc[]
+include::{snippets}/user-get/path-parameters.adoc[]
+include::{snippets}/user-get/request-headers.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/user-get/http-response.adoc[]
+include::{snippets}/user-get/response-headers.adoc[]
+include::{snippets}/user-get/response-fields.adoc[]
+
+=== 토큰 갱신
+
+리프레시 토큰으로 새로운 액세스 토큰을 발급받습니다.
+
+[discrete]
+==== 요청
+
+include::{snippets}/user-refresh/http-request.adoc[]
+include::{snippets}/user-refresh/request-cookies.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/user-refresh/http-response.adoc[]
+include::{snippets}/user-refresh/response-headers.adoc[]
+include::{snippets}/user-refresh/response-fields.adoc[]
+
 == 에러 응답
 
 API 호출이 실패한 경우 다음과 같은 형식으로 에러 응답을 반환합니다.

--- a/apps/backend/core/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/core/src/docs/asciidoc/api-guide.adoc
@@ -127,9 +127,9 @@ include::{snippets}/user-login/http-response.adoc[]
 include::{snippets}/user-login/response-headers.adoc[]
 include::{snippets}/user-login/response-fields.adoc[]
 
-=== 사용자 조회
+=== * 사용자 조회 (스펙 변경 예정)
 
-사용자 ID로 사용자 정보를 조회합니다. (인증 필요)
+사용자 ID로 사용자 정보를 조회합니다. (인증 필요). 요구 사항에 따른 변경 예정
 
 [discrete]
 ==== 요청

--- a/apps/backend/core/src/test/java/com/schemafy/core/common/docs/RestDocsSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/common/docs/RestDocsSnippets.java
@@ -12,8 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 /**
- * REST Docs 문서화를 위한 공통 스니펫 제공 추상 클래스
- * - 도메인별 ApiSnippets 클래스는 이 클래스를 상속받아 구현
+ * REST Docs 문서화를 위한 공통 스니펫 제공 추상 클래스 - 도메인별 ApiSnippets 클래스는 이 클래스를 상속받아 구현
  */
 public abstract class RestDocsSnippets {
 
@@ -24,8 +23,8 @@ public abstract class RestDocsSnippets {
      */
     protected static HeaderDescriptor[] commonRequestHeaders() {
         return new HeaderDescriptor[] {
-                headerWithName("Content-Type").description("요청 컨텐츠 타입").optional(),
-                headerWithName("Accept").description("응답 포맷").optional()
+            headerWithName("Content-Type").description("요청 컨텐츠 타입").optional(),
+            headerWithName("Accept").description("응답 포맷").optional()
         };
     }
 
@@ -33,7 +32,8 @@ public abstract class RestDocsSnippets {
      * Authorization 헤더 생성 (JWT 인증용)
      */
     protected static HeaderDescriptor authorizationHeader() {
-        return headerWithName("Authorization").description("JWT 액세스 토큰 (Bearer {token})");
+        return headerWithName("Authorization")
+                .description("JWT 액세스 토큰 (Bearer {token})");
     }
 
     /**
@@ -41,7 +41,7 @@ public abstract class RestDocsSnippets {
      */
     protected static HeaderDescriptor[] commonResponseHeaders() {
         return new HeaderDescriptor[] {
-                headerWithName("Content-Type").description("응답 컨텐츠 타입")
+            headerWithName("Content-Type").description("응답 컨텐츠 타입")
         };
     }
 
@@ -50,9 +50,10 @@ public abstract class RestDocsSnippets {
      */
     protected static HeaderDescriptor[] authResponseHeaders() {
         return new HeaderDescriptor[] {
-                headerWithName("Content-Type").description("응답 컨텐츠 타입"),
-                headerWithName("Authorization").description("발급된 JWT 액세스 토큰"),
-                headerWithName("Set-Cookie").description("발급된 리프레시 토큰 (HttpOnly 쿠키)")
+            headerWithName("Content-Type").description("응답 컨텐츠 타입"),
+            headerWithName("Authorization").description("발급된 JWT 액세스 토큰"),
+            headerWithName("Set-Cookie")
+                    .description("발급된 리프레시 토큰 (HttpOnly 쿠키)")
         };
     }
 
@@ -60,16 +61,18 @@ public abstract class RestDocsSnippets {
 
     /**
      * 성공 응답 필드 생성 (result 필드 포함)
+     *
      * @param resultFields result 객체 내부 필드들
      */
-    protected static FieldDescriptor[] successResponseFields(FieldDescriptor... resultFields) {
+    protected static FieldDescriptor[] successResponseFields(
+            FieldDescriptor... resultFields) {
         FieldDescriptor[] baseFields = new FieldDescriptor[] {
-                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-                        .description("요청 성공 여부"),
-                fieldWithPath("result").type(JsonFieldType.OBJECT)
-                        .description("응답 데이터").optional(),
-                fieldWithPath("error").type(JsonFieldType.NULL)
-                        .description("에러 정보 (성공 시 null)").optional()
+            fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                    .description("요청 성공 여부"),
+            fieldWithPath("result").type(JsonFieldType.OBJECT)
+                    .description("응답 데이터").optional(),
+            fieldWithPath("error").type(JsonFieldType.NULL)
+                    .description("에러 정보 (성공 시 null)").optional()
         };
 
         return concat(baseFields, resultFields);
@@ -80,12 +83,12 @@ public abstract class RestDocsSnippets {
      */
     protected static FieldDescriptor[] successResponseFieldsWithNullResult() {
         return new FieldDescriptor[] {
-                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-                        .description("요청 성공 여부"),
-                fieldWithPath("result").type(JsonFieldType.NULL)
-                        .description("응답 데이터 (없음)").optional(),
-                fieldWithPath("error").type(JsonFieldType.NULL)
-                        .description("에러 정보 (성공 시 null)").optional()
+            fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                    .description("요청 성공 여부"),
+            fieldWithPath("result").type(JsonFieldType.NULL)
+                    .description("응답 데이터 (없음)").optional(),
+            fieldWithPath("error").type(JsonFieldType.NULL)
+                    .description("에러 정보 (성공 시 null)").optional()
         };
     }
 
@@ -94,16 +97,16 @@ public abstract class RestDocsSnippets {
      */
     protected static FieldDescriptor[] errorResponseFields() {
         return new FieldDescriptor[] {
-                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-                        .description("요청 성공 여부 (항상 false)"),
-                fieldWithPath("result").type(JsonFieldType.NULL)
-                        .description("응답 데이터 (에러 시 null)").optional(),
-                fieldWithPath("error").type(JsonFieldType.OBJECT)
-                        .description("에러 정보"),
-                fieldWithPath("error.code").type(JsonFieldType.STRING)
-                        .description("에러 코드"),
-                fieldWithPath("error.message").type(JsonFieldType.STRING)
-                        .description("에러 메시지")
+            fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                    .description("요청 성공 여부 (항상 false)"),
+            fieldWithPath("result").type(JsonFieldType.NULL)
+                    .description("응답 데이터 (에러 시 null)").optional(),
+            fieldWithPath("error").type(JsonFieldType.OBJECT)
+                    .description("에러 정보"),
+            fieldWithPath("error.code").type(JsonFieldType.STRING)
+                    .description("에러 코드"),
+            fieldWithPath("error.message").type(JsonFieldType.STRING)
+                    .description("에러 메시지")
         };
     }
 
@@ -112,21 +115,24 @@ public abstract class RestDocsSnippets {
     /**
      * 요청 헤더 Snippet 생성
      */
-    protected static Snippet createRequestHeadersSnippet(HeaderDescriptor... headers) {
+    protected static Snippet createRequestHeadersSnippet(
+            HeaderDescriptor... headers) {
         return requestHeaders(headers);
     }
 
     /**
      * 응답 헤더 Snippet 생성
      */
-    protected static Snippet createResponseHeadersSnippet(HeaderDescriptor... headers) {
+    protected static Snippet createResponseHeadersSnippet(
+            HeaderDescriptor... headers) {
         return responseHeaders(headers);
     }
 
     /**
      * 응답 필드 Snippet 생성
      */
-    protected static Snippet createResponseFieldsSnippet(FieldDescriptor... fields) {
+    protected static Snippet createResponseFieldsSnippet(
+            FieldDescriptor... fields) {
         return responseFields(fields);
     }
 
@@ -135,8 +141,10 @@ public abstract class RestDocsSnippets {
     /**
      * 배열 병합 유틸리티
      */
-    protected static FieldDescriptor[] concat(FieldDescriptor[] first, FieldDescriptor[] second) {
-        FieldDescriptor[] result = new FieldDescriptor[first.length + second.length];
+    protected static FieldDescriptor[] concat(FieldDescriptor[] first,
+            FieldDescriptor[] second) {
+        FieldDescriptor[] result = new FieldDescriptor[first.length
+                + second.length];
         System.arraycopy(first, 0, result, 0, first.length);
         System.arraycopy(second, 0, result, first.length, second.length);
         return result;

--- a/apps/backend/core/src/test/java/com/schemafy/core/common/docs/RestDocsSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/common/docs/RestDocsSnippets.java
@@ -1,0 +1,144 @@
+package com.schemafy.core.common.docs;
+
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+/**
+ * REST Docs 문서화를 위한 공통 스니펫 제공 추상 클래스
+ * - 도메인별 ApiSnippets 클래스는 이 클래스를 상속받아 구현
+ */
+public abstract class RestDocsSnippets {
+
+    // ========== 헤더 메서드 (하위 클래스에서 사용) ==========
+
+    /**
+     * 공통 요청 헤더 생성
+     */
+    protected static HeaderDescriptor[] commonRequestHeaders() {
+        return new HeaderDescriptor[] {
+                headerWithName("Content-Type").description("요청 컨텐츠 타입").optional(),
+                headerWithName("Accept").description("응답 포맷").optional()
+        };
+    }
+
+    /**
+     * Authorization 헤더 생성 (JWT 인증용)
+     */
+    protected static HeaderDescriptor authorizationHeader() {
+        return headerWithName("Authorization").description("JWT 액세스 토큰 (Bearer {token})");
+    }
+
+    /**
+     * 공통 응답 헤더 생성
+     */
+    protected static HeaderDescriptor[] commonResponseHeaders() {
+        return new HeaderDescriptor[] {
+                headerWithName("Content-Type").description("응답 컨텐츠 타입")
+        };
+    }
+
+    /**
+     * 인증 응답 헤더 생성 (JWT 토큰 발급 시)
+     */
+    protected static HeaderDescriptor[] authResponseHeaders() {
+        return new HeaderDescriptor[] {
+                headerWithName("Content-Type").description("응답 컨텐츠 타입"),
+                headerWithName("Authorization").description("발급된 JWT 액세스 토큰"),
+                headerWithName("Set-Cookie").description("발급된 리프레시 토큰 (HttpOnly 쿠키)")
+        };
+    }
+
+    // ========== 응답 필드 메서드 (하위 클래스에서 사용) ==========
+
+    /**
+     * 성공 응답 필드 생성 (result 필드 포함)
+     * @param resultFields result 객체 내부 필드들
+     */
+    protected static FieldDescriptor[] successResponseFields(FieldDescriptor... resultFields) {
+        FieldDescriptor[] baseFields = new FieldDescriptor[] {
+                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                        .description("요청 성공 여부"),
+                fieldWithPath("result").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터").optional(),
+                fieldWithPath("error").type(JsonFieldType.NULL)
+                        .description("에러 정보 (성공 시 null)").optional()
+        };
+
+        return concat(baseFields, resultFields);
+    }
+
+    /**
+     * 성공 응답 필드 생성 (result가 null인 경우)
+     */
+    protected static FieldDescriptor[] successResponseFieldsWithNullResult() {
+        return new FieldDescriptor[] {
+                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                        .description("요청 성공 여부"),
+                fieldWithPath("result").type(JsonFieldType.NULL)
+                        .description("응답 데이터 (없음)").optional(),
+                fieldWithPath("error").type(JsonFieldType.NULL)
+                        .description("에러 정보 (성공 시 null)").optional()
+        };
+    }
+
+    /**
+     * 에러 응답 필드 생성
+     */
+    protected static FieldDescriptor[] errorResponseFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                        .description("요청 성공 여부 (항상 false)"),
+                fieldWithPath("result").type(JsonFieldType.NULL)
+                        .description("응답 데이터 (에러 시 null)").optional(),
+                fieldWithPath("error").type(JsonFieldType.OBJECT)
+                        .description("에러 정보"),
+                fieldWithPath("error.code").type(JsonFieldType.STRING)
+                        .description("에러 코드"),
+                fieldWithPath("error.message").type(JsonFieldType.STRING)
+                        .description("에러 메시지")
+        };
+    }
+
+    // ========== Snippet 생성 헬퍼 메서드 ==========
+
+    /**
+     * 요청 헤더 Snippet 생성
+     */
+    protected static Snippet createRequestHeadersSnippet(HeaderDescriptor... headers) {
+        return requestHeaders(headers);
+    }
+
+    /**
+     * 응답 헤더 Snippet 생성
+     */
+    protected static Snippet createResponseHeadersSnippet(HeaderDescriptor... headers) {
+        return responseHeaders(headers);
+    }
+
+    /**
+     * 응답 필드 Snippet 생성
+     */
+    protected static Snippet createResponseFieldsSnippet(FieldDescriptor... fields) {
+        return responseFields(fields);
+    }
+
+    // ========== 유틸리티 메서드 ==========
+
+    /**
+     * 배열 병합 유틸리티
+     */
+    protected static FieldDescriptor[] concat(FieldDescriptor[] first, FieldDescriptor[] second) {
+        FieldDescriptor[] result = new FieldDescriptor[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
@@ -19,12 +19,8 @@ import com.schemafy.core.ulid.service.UlidService;
 import reactor.core.publisher.Mono;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.core.ulid.docs.UlidApiSnippets.*;
 
 @WebFluxTest(controllers = UlidController.class)
 @AutoConfigureRestDocs
@@ -65,19 +61,8 @@ class UlidControllerTest {
                 .jsonPath("$.success").isEqualTo(true)
                 .jsonPath("$.result.ulid").isEqualTo(mockUlid)
                 .consumeWith(document("ulid-generate",
-                        requestHeaders(
-                                headerWithName("Accept")
-                                        .description("요청 응답 포맷(Accept 헤더)")),
-                        responseHeaders(
-                                headerWithName("Content-Type")
-                                        .description("응답 컨텐츠 타입")),
-                        responseFields(
-                                fieldWithPath("success").description("요청 성공 여부")
-                                        .type("boolean"),
-                                fieldWithPath("result").description("응답 데이터")
-                                        .type("object"),
-                                fieldWithPath("result.ulid")
-                                        .description("생성된 ULID 문자열")
-                                        .type("string"))));
+                        generateUlidRequestHeaders(),
+                        generateUlidResponseHeaders(),
+                        generateUlidResponse()));
     }
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/controller/UlidControllerTest.java
@@ -18,9 +18,9 @@ import com.schemafy.core.ulid.service.UlidService;
 
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.core.ulid.docs.UlidApiSnippets.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.core.ulid.docs.UlidApiSnippets.*;
 
 @WebFluxTest(controllers = UlidController.class)
 @AutoConfigureRestDocs

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/docs/UlidApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/docs/UlidApiSnippets.java
@@ -21,8 +21,8 @@ public class UlidApiSnippets extends RestDocsSnippets {
      */
     private static FieldDescriptor[] ulidResponseFields() {
         return new FieldDescriptor[] {
-                fieldWithPath("result.ulid").type(JsonFieldType.STRING)
-                        .description("생성된 ULID 문자열")
+            fieldWithPath("result.ulid").type(JsonFieldType.STRING)
+                    .description("생성된 ULID 문자열")
         };
     }
 
@@ -33,8 +33,7 @@ public class UlidApiSnippets extends RestDocsSnippets {
      */
     public static Snippet generateUlidRequestHeaders() {
         return createRequestHeadersSnippet(
-                headerWithName("Accept").description("요청 응답 포맷(Accept 헤더)")
-        );
+                headerWithName("Accept").description("요청 응답 포맷(Accept 헤더)"));
     }
 
     /**
@@ -48,6 +47,7 @@ public class UlidApiSnippets extends RestDocsSnippets {
      * ULID 생성 응답 필드
      */
     public static Snippet generateUlidResponse() {
-        return createResponseFieldsSnippet(successResponseFields(ulidResponseFields()));
+        return createResponseFieldsSnippet(
+                successResponseFields(ulidResponseFields()));
     }
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/ulid/docs/UlidApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/ulid/docs/UlidApiSnippets.java
@@ -1,0 +1,53 @@
+package com.schemafy.core.ulid.docs;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import com.schemafy.core.common.docs.RestDocsSnippets;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+/**
+ * ULID API 문서화를 위한 스니펫 제공 클래스
+ */
+public class UlidApiSnippets extends RestDocsSnippets {
+
+    // ========== ULID 도메인 공통 필드 ==========
+
+    /**
+     * ULID 응답 필드 (result.* 형태)
+     */
+    private static FieldDescriptor[] ulidResponseFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("result.ulid").type(JsonFieldType.STRING)
+                        .description("생성된 ULID 문자열")
+        };
+    }
+
+    // ========== ULID 생성 API ==========
+
+    /**
+     * ULID 생성 요청 헤더
+     */
+    public static Snippet generateUlidRequestHeaders() {
+        return createRequestHeadersSnippet(
+                headerWithName("Accept").description("요청 응답 포맷(Accept 헤더)")
+        );
+    }
+
+    /**
+     * ULID 생성 응답 헤더
+     */
+    public static Snippet generateUlidResponseHeaders() {
+        return createResponseHeadersSnippet(commonResponseHeaders());
+    }
+
+    /**
+     * ULID 생성 응답 필드
+     */
+    public static Snippet generateUlidResponse() {
+        return createResponseFieldsSnippet(successResponseFields(ulidResponseFields()));
+    }
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
@@ -30,9 +30,9 @@ import com.schemafy.core.user.repository.UserRepository;
 
 import reactor.test.StepVerifier;
 
+import static com.schemafy.core.user.docs.UserApiSnippets.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.core.user.docs.UserApiSnippets.*;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -30,10 +31,13 @@ import com.schemafy.core.user.repository.UserRepository;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.core.user.docs.UserApiSnippets.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureWebTestClient
+@AutoConfigureRestDocs
 @DisplayName("MemberController 통합 테스트")
 class UserControllerTest {
     private static final String API_BASE_PATH = ApiPath.API.replace("{version}",
@@ -78,7 +82,10 @@ class UserControllerTest {
                 .expectHeader().exists("Authorization")
                 .expectHeader().exists("Set-Cookie")
                 .expectBody()
-                .consumeWith(System.out::println) // Print response
+                .consumeWith(document("user-signup",
+                        signUpRequest(),
+                        signUpResponseHeaders(),
+                        signUpResponse()))
                 .jsonPath("$.success").isEqualTo(true)
                 .jsonPath("$.result.id").isNotEmpty()
                 .jsonPath("$.result.email").isEqualTo("test@example.com");
@@ -154,6 +161,11 @@ class UserControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
+                .consumeWith(document("user-get",
+                        getUserPathParameters(),
+                        getUserRequestHeaders(),
+                        getUserResponseHeaders(),
+                        getUserResponse()))
                 .jsonPath("$.success").isEqualTo(true)
                 .jsonPath("$.result.id").isEqualTo(userId)
                 .jsonPath("$.result.email").isEqualTo(signUpRequest.email());
@@ -202,6 +214,10 @@ class UserControllerTest {
                 .expectHeader().exists("Authorization")
                 .expectHeader().exists("Set-Cookie")
                 .expectBody()
+                .consumeWith(document("user-login",
+                        loginRequest(),
+                        loginResponseHeaders(),
+                        loginResponse()))
                 .jsonPath("$.success").isEqualTo(true)
                 .jsonPath("$.result.email").isEqualTo("test@example.com");
     }
@@ -303,6 +319,10 @@ class UserControllerTest {
                 .expectHeader().exists("Authorization")
                 .expectHeader().exists("Set-Cookie")
                 .expectBody()
+                .consumeWith(document("user-refresh",
+                        refreshTokenRequestCookies(),
+                        refreshTokenResponseHeaders(),
+                        refreshTokenResponse()))
                 .jsonPath("$.success").isEqualTo(true);
     }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
@@ -14,8 +14,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 /**
- * User API 문서화를 위한 스니펫 제공 클래스
- * - User 도메인에 특화된 스니펫 정의
+ * User API 문서화를 위한 스니펫 제공 클래스 - User 도메인에 특화된 스니펫 정의
  */
 public class UserApiSnippets extends RestDocsSnippets {
 
@@ -26,12 +25,12 @@ public class UserApiSnippets extends RestDocsSnippets {
      */
     private static FieldDescriptor[] userInfoFields() {
         return new FieldDescriptor[] {
-                fieldWithPath("result.id").type(JsonFieldType.STRING)
-                        .description("사용자 고유 ID (ULID)"),
-                fieldWithPath("result.email").type(JsonFieldType.STRING)
-                        .description("사용자 이메일"),
-                fieldWithPath("result.name").type(JsonFieldType.STRING)
-                        .description("사용자 이름")
+            fieldWithPath("result.id").type(JsonFieldType.STRING)
+                    .description("사용자 고유 ID (ULID)"),
+            fieldWithPath("result.email").type(JsonFieldType.STRING)
+                    .description("사용자 이메일"),
+            fieldWithPath("result.name").type(JsonFieldType.STRING)
+                    .description("사용자 이름")
         };
     }
 
@@ -44,8 +43,7 @@ public class UserApiSnippets extends RestDocsSnippets {
                 fieldWithPath("name").type(JsonFieldType.STRING)
                         .description("사용자 이름"),
                 fieldWithPath("password").type(JsonFieldType.STRING)
-                        .description("비밀번호")
-        );
+                        .description("비밀번호"));
     }
 
     public static Snippet signUpResponseHeaders() {
@@ -53,7 +51,8 @@ public class UserApiSnippets extends RestDocsSnippets {
     }
 
     public static Snippet signUpResponse() {
-        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+        return createResponseFieldsSnippet(
+                successResponseFields(userInfoFields()));
     }
 
     // ========== 로그인 API ==========
@@ -63,8 +62,7 @@ public class UserApiSnippets extends RestDocsSnippets {
                 fieldWithPath("email").type(JsonFieldType.STRING)
                         .description("사용자 이메일"),
                 fieldWithPath("password").type(JsonFieldType.STRING)
-                        .description("비밀번호")
-        );
+                        .description("비밀번호"));
     }
 
     public static Snippet loginResponseHeaders() {
@@ -72,15 +70,15 @@ public class UserApiSnippets extends RestDocsSnippets {
     }
 
     public static Snippet loginResponse() {
-        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+        return createResponseFieldsSnippet(
+                successResponseFields(userInfoFields()));
     }
 
     // ========== 사용자 조회 API ==========
 
     public static Snippet getUserPathParameters() {
         return pathParameters(
-                parameterWithName("userId").description("조회할 사용자 ID (ULID)")
-        );
+                parameterWithName("userId").description("조회할 사용자 ID (ULID)"));
     }
 
     public static Snippet getUserRequestHeaders() {
@@ -92,15 +90,15 @@ public class UserApiSnippets extends RestDocsSnippets {
     }
 
     public static Snippet getUserResponse() {
-        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+        return createResponseFieldsSnippet(
+                successResponseFields(userInfoFields()));
     }
 
     // ========== 토큰 갱신 API ==========
 
     public static Snippet refreshTokenRequestCookies() {
         return requestCookies(
-                cookieWithName("refreshToken").description("리프레시 토큰 (JWT)")
-        );
+                cookieWithName("refreshToken").description("리프레시 토큰 (JWT)"));
     }
 
     public static Snippet refreshTokenResponseHeaders() {
@@ -108,6 +106,7 @@ public class UserApiSnippets extends RestDocsSnippets {
     }
 
     public static Snippet refreshTokenResponse() {
-        return createResponseFieldsSnippet(successResponseFieldsWithNullResult());
+        return createResponseFieldsSnippet(
+                successResponseFieldsWithNullResult());
     }
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
@@ -1,0 +1,113 @@
+package com.schemafy.core.user.docs;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import com.schemafy.core.common.docs.RestDocsSnippets;
+
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+
+/**
+ * User API 문서화를 위한 스니펫 제공 클래스
+ * - User 도메인에 특화된 스니펫 정의
+ */
+public class UserApiSnippets extends RestDocsSnippets {
+
+    // ========== User 도메인 공통 필드 ==========
+
+    /**
+     * 사용자 정보 응답 필드 (result.* 형태)
+     */
+    private static FieldDescriptor[] userInfoFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("result.id").type(JsonFieldType.STRING)
+                        .description("사용자 고유 ID (ULID)"),
+                fieldWithPath("result.email").type(JsonFieldType.STRING)
+                        .description("사용자 이메일"),
+                fieldWithPath("result.name").type(JsonFieldType.STRING)
+                        .description("사용자 이름")
+        };
+    }
+
+    // ========== 회원가입 API ==========
+
+    public static Snippet signUpRequest() {
+        return requestFields(
+                fieldWithPath("email").type(JsonFieldType.STRING)
+                        .description("사용자 이메일 (형식: example@domain.com)"),
+                fieldWithPath("name").type(JsonFieldType.STRING)
+                        .description("사용자 이름"),
+                fieldWithPath("password").type(JsonFieldType.STRING)
+                        .description("비밀번호")
+        );
+    }
+
+    public static Snippet signUpResponseHeaders() {
+        return createResponseHeadersSnippet(authResponseHeaders());
+    }
+
+    public static Snippet signUpResponse() {
+        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+    }
+
+    // ========== 로그인 API ==========
+
+    public static Snippet loginRequest() {
+        return requestFields(
+                fieldWithPath("email").type(JsonFieldType.STRING)
+                        .description("사용자 이메일"),
+                fieldWithPath("password").type(JsonFieldType.STRING)
+                        .description("비밀번호")
+        );
+    }
+
+    public static Snippet loginResponseHeaders() {
+        return createResponseHeadersSnippet(authResponseHeaders());
+    }
+
+    public static Snippet loginResponse() {
+        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+    }
+
+    // ========== 사용자 조회 API ==========
+
+    public static Snippet getUserPathParameters() {
+        return pathParameters(
+                parameterWithName("userId").description("조회할 사용자 ID (ULID)")
+        );
+    }
+
+    public static Snippet getUserRequestHeaders() {
+        return createRequestHeadersSnippet(authorizationHeader());
+    }
+
+    public static Snippet getUserResponseHeaders() {
+        return createResponseHeadersSnippet(commonResponseHeaders());
+    }
+
+    public static Snippet getUserResponse() {
+        return createResponseFieldsSnippet(successResponseFields(userInfoFields()));
+    }
+
+    // ========== 토큰 갱신 API ==========
+
+    public static Snippet refreshTokenRequestCookies() {
+        return requestCookies(
+                cookieWithName("refreshToken").description("리프레시 토큰 (JWT)")
+        );
+    }
+
+    public static Snippet refreshTokenResponseHeaders() {
+        return createResponseHeadersSnippet(authResponseHeaders());
+    }
+
+    public static Snippet refreshTokenResponse() {
+        return createResponseFieldsSnippet(successResponseFieldsWithNullResult());
+    }
+}


### PR DESCRIPTION
## 개요
- 회원가입, 로그인 api 문서 추가
- api 문서 생성 관련 공통 클래스 구현
- ulid 문서 구현 부분 리팩토링
## 이슈
- 현재 getMember API 형태의 개선 필요성을 느꼈습니다.
지금 구현된 형태는 토큰과 id를 둘다 요구하는 형태인데 둘 중 하나를 선택할 필요가 있어보입니다. 이 부분은 다른 분들의 의견에 따라 수정, 추가 하도록 하겠습니다.

- close #59