### PR TITLE
feat(#79): add isAffected for change detection

### DIFF
--- a/packages/validator/src/lib/builder.ts
+++ b/packages/validator/src/lib/builder.ts
@@ -37,6 +37,7 @@ class DatabaseBuilder {
     return {
       id: this.id,
       schemas: this.schemas.map((builder) => builder.build()),
+      isAffected: false,
     };
   }
 }
@@ -86,6 +87,7 @@ class SchemaBuilder {
       updatedAt: new Date(),
       deletedAt: null,
       tables: this.tables.map((builder) => builder.build()),
+      isAffected: false,
     };
   }
 }
@@ -186,6 +188,7 @@ class TableBuilder {
       indexes,
       constraints,
       relationships,
+      isAffected: false,
     };
   }
 }
@@ -257,6 +260,7 @@ class ColumnBuilder {
       createdAt: new Date(),
       updatedAt: new Date(),
       deletedAt: null,
+      isAffected: false,
     };
   }
 }
@@ -283,6 +287,7 @@ class ConstraintColumnBuilder {
       constraintId: this.constraintId,
       columnId: this.columnId,
       seqNo: this.seqNo,
+      isAffected: false,
     };
   }
 
@@ -371,6 +376,7 @@ class ConstraintBuilder {
       columns: this.columns.map((c) => c.build()),
       defaultExpr: this.defaultExpr,
       checkExpr: this.checkExpr,
+      isAffected: false,
     };
   }
 
@@ -414,6 +420,7 @@ class IndexColumnBuilder {
       columnId: this.columnId,
       seqNo: this.seqNo,
       sortDir: this.sortDir,
+      isAffected: false,
     };
   }
 
@@ -487,6 +494,7 @@ class IndexBuilder {
       type: this.type,
       columns: this.columns.map((c) => c.build()),
       comment: null,
+      isAffected: false,
     };
   }
 
@@ -539,6 +547,7 @@ class RelationshipColumnBuilder {
       fkColumnId: this.fkColumnId,
       refColumnId: this.refColumnId,
       seqNo: this.seqNo,
+      isAffected: false,
     };
   }
 }
@@ -625,6 +634,7 @@ class RelationshipBuilder {
       onUpdate: this.onUpdate,
       fkEnforced: this.fkEnforced,
       columns: this.columns.map((c) => c.build()),
+      isAffected: false,
     };
   }
 }

--- a/packages/validator/src/lib/handlers/columns.ts
+++ b/packages/validator/src/lib/handlers/columns.ts
@@ -28,20 +28,20 @@ export interface ColumnHandlers {
     database: Database,
     schemaId: Schema["id"],
     tableId: Table["id"],
-    column: Omit<Column, "tableId" | "createdAt" | "updatedAt">
+    column: Omit<Column, "tableId" | "createdAt" | "updatedAt">,
   ) => Database;
   deleteColumn: (
     database: Database,
     schemaId: Schema["id"],
     tableId: Table["id"],
-    columnId: Column["id"]
+    columnId: Column["id"],
   ) => Database;
   changeColumnName: (
     database: Database,
     schemaId: Schema["id"],
     tableId: Table["id"],
     columnId: Column["id"],
-    newName: Column["name"]
+    newName: Column["name"],
   ) => Database;
   changeColumnType: (
     database: Database,
@@ -49,21 +49,21 @@ export interface ColumnHandlers {
     tableId: Table["id"],
     columnId: Column["id"],
     dataType: Column["dataType"],
-    lengthScale?: Column["lengthScale"]
+    lengthScale?: Column["lengthScale"],
   ) => Database;
   changeColumnPosition: (
     database: Database,
     schemaId: Schema["id"],
     tableId: Table["id"],
     columnId: Column["id"],
-    newPosition: Column["ordinalPosition"]
+    newPosition: Column["ordinalPosition"],
   ) => Database;
   changeColumnNullable: (
     database: Database,
     schemaId: Schema["id"],
     tableId: Table["id"],
     columnId: Column["id"],
-    nullable: boolean
+    nullable: boolean,
   ) => Database;
 }
 
@@ -98,7 +98,7 @@ export const columnHandlers: ColumnHandlers = {
         throw new ColumnLengthRequiredError(column.dataType);
 
       const vendorValid = helper.categorizedMysqlDataTypes.includes(
-        column.dataType
+        column.dataType,
       );
       if (!vendorValid) throw new ColumnDataTypeInvalidError(column.dataType);
     }
@@ -132,17 +132,17 @@ export const columnHandlers: ColumnHandlers = {
                       isAffected: true,
                       columns: [...t.columns, newColumn],
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
 
     const isPrimaryKey = table.constraints.some(
       (constraint) =>
         constraint.kind === "PRIMARY_KEY" &&
-        constraint.columns.some((cc) => cc.columnId === column.id)
+        constraint.columns.some((cc) => cc.columnId === column.id),
     );
 
     if (isPrimaryKey) {
@@ -150,7 +150,7 @@ export const columnHandlers: ColumnHandlers = {
         currentSchema: Schema,
         parentTableId: string,
         newPkColumn: typeof newColumn,
-        visited: Set<string> = new Set()
+        visited: Set<string> = new Set(),
       ): Schema => {
         if (visited.has(parentTableId)) return currentSchema;
         visited.add(parentTableId);
@@ -161,15 +161,15 @@ export const columnHandlers: ColumnHandlers = {
           for (const rel of table.relationships) {
             if (rel.tgtTableId === parentTableId) {
               const childTable = updatedSchema.tables.find(
-                (t) => t.id === rel.srcTableId
+                (t) => t.id === rel.srcTableId,
               );
               if (!childTable) continue;
 
               const parentTable = updatedSchema.tables.find(
-                (t) => t.id === parentTableId
+                (t) => t.id === parentTableId,
               )!;
               const existingColumn = childTable.columns.find((c) =>
-                c.name.startsWith(`${parentTable.name}_${newPkColumn.name}`)
+                c.name.startsWith(`${parentTable.name}_${newPkColumn.name}`),
               );
 
               if (!existingColumn) {
@@ -197,7 +197,7 @@ export const columnHandlers: ColumnHandlers = {
                           isAffected: true,
                           columns: [...t.columns, newFkColumn],
                         }
-                      : t
+                      : t,
                   ),
                 };
 
@@ -225,10 +225,10 @@ export const columnHandlers: ColumnHandlers = {
                                   isAffected: true,
                                   columns: [...r.columns, newRelColumn],
                                 }
-                              : r
+                              : r,
                           ),
                         }
-                      : t
+                      : t,
                   ),
                 };
 
@@ -237,7 +237,7 @@ export const columnHandlers: ColumnHandlers = {
                     structuredClone(updatedSchema),
                     rel.tgtTableId,
                     newFkColumn,
-                    new Set(visited)
+                    new Set(visited),
                   );
                 }
               }
@@ -249,19 +249,19 @@ export const columnHandlers: ColumnHandlers = {
       };
 
       const updatedSchema = updatedDatabase.schemas.find(
-        (s) => s.id === schemaId
+        (s) => s.id === schemaId,
       )!;
       const propagatedSchema = propagateNewPrimaryKey(
         structuredClone(updatedSchema),
         tableId,
-        newColumn
+        newColumn,
       );
 
       updatedDatabase = {
         ...updatedDatabase,
         isAffected: true,
         schemas: updatedDatabase.schemas.map((s) =>
-          s.id === schemaId ? { ...propagatedSchema, isAffected: true } : s
+          s.id === schemaId ? { ...propagatedSchema, isAffected: true } : s,
         ),
       };
     }
@@ -286,7 +286,7 @@ export const columnHandlers: ColumnHandlers = {
     const isPrimaryKey = table.constraints.some(
       (constraint) =>
         constraint.kind === "PRIMARY_KEY" &&
-        constraint.columns.some((cc) => cc.columnId === columnId)
+        constraint.columns.some((cc) => cc.columnId === columnId),
     );
 
     let updatedDatabase: Database = {
@@ -307,10 +307,10 @@ export const columnHandlers: ColumnHandlers = {
                       .map((idx) => ({
                         ...idx,
                         isAffected: idx.columns.some(
-                          (ic) => ic.columnId === columnId
+                          (ic) => ic.columnId === columnId,
                         ),
                         columns: idx.columns.filter(
-                          (ic) => ic.columnId !== columnId
+                          (ic) => ic.columnId !== columnId,
                         ),
                       }))
                       .filter((idx) => idx.columns.length > 0),
@@ -318,10 +318,10 @@ export const columnHandlers: ColumnHandlers = {
                       .map((constraint) => ({
                         ...constraint,
                         isAffected: constraint.columns.some(
-                          (cc) => cc.columnId === columnId
+                          (cc) => cc.columnId === columnId,
                         ),
                         columns: constraint.columns.filter(
-                          (cc) => cc.columnId !== columnId
+                          (cc) => cc.columnId !== columnId,
                         ),
                       }))
                       .filter((constraint) => constraint.columns.length > 0),
@@ -331,12 +331,12 @@ export const columnHandlers: ColumnHandlers = {
                         isAffected: rel.columns.some(
                           (rc) =>
                             rc.fkColumnId === columnId ||
-                            rc.refColumnId === columnId
+                            rc.refColumnId === columnId,
                         ),
                         columns: rel.columns.filter(
                           (rc) =>
                             rc.fkColumnId !== columnId &&
-                            rc.refColumnId !== columnId
+                            rc.refColumnId !== columnId,
                         ),
                       }))
                       .filter((rel) => rel.columns.length > 0),
@@ -345,7 +345,7 @@ export const columnHandlers: ColumnHandlers = {
                 return t;
               }),
             }
-          : s
+          : s,
       ),
     };
 
@@ -354,7 +354,7 @@ export const columnHandlers: ColumnHandlers = {
         currentSchema: Schema,
         parentTableId: string,
         deletedPkColumnId: string,
-        visited: Set<string> = new Set()
+        visited: Set<string> = new Set(),
       ): Schema => {
         if (visited.has(parentTableId)) return currentSchema;
         visited.add(parentTableId);
@@ -365,7 +365,7 @@ export const columnHandlers: ColumnHandlers = {
           for (const rel of table.relationships) {
             if (rel.tgtTableId === parentTableId) {
               const childTable = updatedSchema.tables.find(
-                (t) => t.id === rel.srcTableId
+                (t) => t.id === rel.srcTableId,
               );
               if (!childTable) continue;
 
@@ -382,19 +382,20 @@ export const columnHandlers: ColumnHandlers = {
                       ? {
                           ...t,
                           isAffected: t.columns.some((c) =>
-                            fkColumnsToDelete.includes(c.id)
+                            fkColumnsToDelete.includes(c.id),
                           ),
                           columns: t.columns.filter(
-                            (col) => !fkColumnsToDelete.includes(col.id)
+                            (col) => !fkColumnsToDelete.includes(col.id),
                           ),
                           indexes: t.indexes
                             .map((idx) => ({
                               ...idx,
                               isAffected: idx.columns.some((ic) =>
-                                fkColumnsToDelete.includes(ic.columnId)
+                                fkColumnsToDelete.includes(ic.columnId),
                               ),
                               columns: idx.columns.filter(
-                                (ic) => !fkColumnsToDelete.includes(ic.columnId)
+                                (ic) =>
+                                  !fkColumnsToDelete.includes(ic.columnId),
                               ),
                             }))
                             .filter((idx) => idx.columns.length > 0),
@@ -402,14 +403,15 @@ export const columnHandlers: ColumnHandlers = {
                             .map((constraint) => ({
                               ...constraint,
                               isAffected: constraint.columns.some((cc) =>
-                                fkColumnsToDelete.includes(cc.columnId)
+                                fkColumnsToDelete.includes(cc.columnId),
                               ),
                               columns: constraint.columns.filter(
-                                (cc) => !fkColumnsToDelete.includes(cc.columnId)
+                                (cc) =>
+                                  !fkColumnsToDelete.includes(cc.columnId),
                               ),
                             }))
                             .filter(
-                              (constraint) => constraint.columns.length > 0
+                              (constraint) => constraint.columns.length > 0,
                             ),
                           relationships: t.relationships
                             .map((relationship) => ({
@@ -417,19 +419,19 @@ export const columnHandlers: ColumnHandlers = {
                               isAffected: relationship.columns.some(
                                 (rc) =>
                                   fkColumnsToDelete.includes(rc.fkColumnId) ||
-                                  fkColumnsToDelete.includes(rc.refColumnId)
+                                  fkColumnsToDelete.includes(rc.refColumnId),
                               ),
                               columns: relationship.columns.filter(
                                 (rc) =>
                                   !fkColumnsToDelete.includes(rc.fkColumnId) &&
-                                  !fkColumnsToDelete.includes(rc.refColumnId)
+                                  !fkColumnsToDelete.includes(rc.refColumnId),
                               ),
                             }))
                             .filter(
-                              (relationship) => relationship.columns.length > 0
+                              (relationship) => relationship.columns.length > 0,
                             ),
                         }
-                      : t
+                      : t,
                   ),
                 };
 
@@ -439,7 +441,7 @@ export const columnHandlers: ColumnHandlers = {
                       structuredClone(updatedSchema),
                       rel.tgtTableId,
                       fkColumnId,
-                      new Set(visited)
+                      new Set(visited),
                     );
                   }
                 }
@@ -452,19 +454,19 @@ export const columnHandlers: ColumnHandlers = {
       };
 
       const updatedSchema = updatedDatabase.schemas.find(
-        (s) => s.id === schemaId
+        (s) => s.id === schemaId,
       )!;
       const cascadedSchema = deleteCascadingForeignKeys(
         structuredClone(updatedSchema),
         tableId,
-        columnId
+        columnId,
       );
 
       updatedDatabase = {
         ...updatedDatabase,
         isAffected: true,
         schemas: updatedDatabase.schemas.map((s) =>
-          s.id === schemaId ? { ...cascadedSchema, isAffected: true } : s
+          s.id === schemaId ? { ...cascadedSchema, isAffected: true } : s,
         ),
       };
     }
@@ -505,13 +507,13 @@ export const columnHandlers: ColumnHandlers = {
                       columns: t.columns.map((c) =>
                         c.id === columnId
                           ? { ...c, name: newName, isAffected: true }
-                          : c
+                          : c,
                       ),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },
@@ -521,7 +523,7 @@ export const columnHandlers: ColumnHandlers = {
     tableId,
     columnId,
     dataType,
-    lengthScale
+    lengthScale,
   ) => {
     // NOTE: 변경에 의해서도 이전과 이후가 같은 상황에 대해선 고려가 필요없는지?
 
@@ -555,13 +557,13 @@ export const columnHandlers: ColumnHandlers = {
                               dataType,
                               lengthScale: lengthScale || c.lengthScale,
                             }
-                          : c
+                          : c,
                       ),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },
@@ -570,7 +572,7 @@ export const columnHandlers: ColumnHandlers = {
     schemaId,
     tableId,
     columnId,
-    newPosition
+    newPosition,
   ) => {
     // NOTE: 변경에 의해서도 이전과 이후가 같은 상황에 대해선 고려가 필요없는지?
 
@@ -604,13 +606,13 @@ export const columnHandlers: ColumnHandlers = {
                               updatedAt: new Date(),
                               ordinalPosition: newPosition,
                             }
-                          : c
+                          : c,
                       ),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },
@@ -639,26 +641,26 @@ export const columnHandlers: ColumnHandlers = {
       structuredClone(database),
       schemaId,
       tableId,
-      columnId
+      columnId,
     );
 
     currentDatabase = columnHandlers.createColumn(
       structuredClone(currentDatabase),
       schemaId,
       tableId,
-      updatedColumn
+      updatedColumn,
     );
 
     if (!nullable) {
       const updatedSchema = currentDatabase.schemas.find(
-        (s) => s.id === schemaId
+        (s) => s.id === schemaId,
       )!;
       const updatedTable = updatedSchema.tables.find((t) => t.id === tableId)!;
 
       const hasNotNull = updatedTable.constraints.some(
         (constraint) =>
           constraint.kind === "NOT_NULL" &&
-          constraint.columns.some((cc) => cc.columnId === columnId)
+          constraint.columns.some((cc) => cc.columnId === columnId),
       );
 
       if (!hasNotNull) {
@@ -697,10 +699,10 @@ export const columnHandlers: ColumnHandlers = {
                           isAffected: true,
                           constraints: [...t.constraints, newConstraint],
                         }
-                      : t
+                      : t,
                   ),
                 }
-              : s
+              : s,
           ),
         };
       }

--- a/packages/validator/src/lib/handlers/constraints.ts
+++ b/packages/validator/src/lib/handlers/constraints.ts
@@ -237,7 +237,9 @@ export const constraintHandlers: ConstraintHandlers = {
                 t.id === tableId
                   ? {
                       ...t,
-                      isAffected: t.constraints.some((c) => c.id === constraintId),
+                      isAffected: t.constraints.some(
+                        (c) => c.id === constraintId,
+                      ),
                       constraints: t.constraints.filter(
                         (c) => c.id !== constraintId,
                       ),
@@ -279,7 +281,9 @@ export const constraintHandlers: ConstraintHandlers = {
                       ...t,
                       isAffected: true,
                       constraints: t.constraints.map((c) =>
-                        c.id === constraintId ? { ...c, name: newName, isAffected: true } : c,
+                        c.id === constraintId
+                          ? { ...c, name: newName, isAffected: true }
+                          : c,
                       ),
                     }
                   : t,
@@ -325,7 +329,11 @@ export const constraintHandlers: ConstraintHandlers = {
                               isAffected: true,
                               columns: [
                                 ...c.columns,
-                                { ...constraintColumn, constraintId, isAffected: true },
+                                {
+                                  ...constraintColumn,
+                                  constraintId,
+                                  isAffected: true,
+                                },
                               ],
                             }
                           : c,
@@ -371,14 +379,16 @@ export const constraintHandlers: ConstraintHandlers = {
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
-                      ...t, 
+                      ...t,
                       isAffected: true,
                       constraints: t.constraints
                         .map((c) =>
                           c.id === constraintId
                             ? {
                                 ...c,
-                                isAffected: c.columns.some((cc) => cc.id === constraintColumnId),
+                                isAffected: c.columns.some(
+                                  (cc) => cc.id === constraintColumnId,
+                                ),
                                 columns: c.columns.filter(
                                   (cc) => cc.id !== constraintColumnId,
                                 ),

--- a/packages/validator/src/lib/handlers/indexes.ts
+++ b/packages/validator/src/lib/handlers/indexes.ts
@@ -1,15 +1,15 @@
 import {
+  DuplicateIndexDefinitionError,
+  IndexColumnNotExistError,
+  IndexColumnNotUniqueError,
+  IndexColumnSortDirInvalidError,
+  IndexNameNotUniqueError,
+  IndexNotExistError,
+  IndexTypeInvalidError,
   SchemaNotExistError,
   TableNotExistError,
-  IndexNotExistError,
-  IndexColumnNotExistError,
-  IndexNameNotUniqueError,
-  IndexColumnNotUniqueError,
-  IndexTypeInvalidError,
-  DuplicateIndexDefinitionError,
-  IndexColumnSortDirInvalidError,
 } from "../errors";
-import { Database, Schema, Table, Index, IndexColumn } from "../types";
+import { Database, Index, IndexColumn, Schema, Table } from "../types";
 
 export interface IndexHandlers {
   createIndex: (
@@ -90,15 +90,18 @@ export const indexHandlers: IndexHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((s) =>
         s.id === schemaId
           ? {
               ...s,
+              isAffected: true,
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
                       ...t,
-                      indexes: [...t.indexes, { ...index, tableId }],
+                      isAffected: true,
+                      indexes: [...t.indexes, { ...index, isAffected: true, tableId }],
                     }
                   : t,
               ),
@@ -119,14 +122,17 @@ export const indexHandlers: IndexHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((s) =>
         s.id === schemaId
           ? {
               ...s,
+              isAffected: true,
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
                       ...t,
+                      isAffected: t.indexes.some((i) => i.id === indexId),
                       indexes: t.indexes.filter((i) => i.id !== indexId),
                     }
                   : t,
@@ -151,16 +157,19 @@ export const indexHandlers: IndexHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((s) =>
         s.id === schemaId
           ? {
               ...s,
+              isAffected: true,
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
                       ...t,
+                      isAffected: true,
                       indexes: t.indexes.map((i) =>
-                        i.id === indexId ? { ...i, name: newName } : i,
+                        i.id === indexId ? { ...i, name: newName, isAffected: true } : i,
                       ),
                     }
                   : t,
@@ -188,21 +197,25 @@ export const indexHandlers: IndexHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((s) =>
         s.id === schemaId
           ? {
               ...s,
+              isAffected: true,
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
                       ...t,
+                      isAffected: true,
                       indexes: t.indexes.map((i) =>
                         i.id === indexId
                           ? {
                               ...i,
+                              isAffected: true,
                               columns: [
                                 ...i.columns,
-                                { ...indexColumn, indexId },
+                                { ...indexColumn, indexId, isAffected: true },
                               ],
                             }
                           : i,
@@ -236,19 +249,23 @@ export const indexHandlers: IndexHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((s) =>
         s.id === schemaId
           ? {
               ...s,
+              isAffected: true,
               tables: s.tables.map((t) =>
                 t.id === tableId
                   ? {
                       ...t,
+                      isAffected: true,
                       indexes: t.indexes
                         .map((i) =>
                           i.id === indexId
                             ? {
                                 ...i,
+                                isAffected: i.columns.some((ic) => ic.id === indexColumnId),
                                 columns: i.columns.filter(
                                   (ic) => ic.id !== indexColumnId,
                                 ),

--- a/packages/validator/src/lib/handlers/indexes.ts
+++ b/packages/validator/src/lib/handlers/indexes.ts
@@ -101,7 +101,10 @@ export const indexHandlers: IndexHandlers = {
                   ? {
                       ...t,
                       isAffected: true,
-                      indexes: [...t.indexes, { ...index, isAffected: true, tableId }],
+                      indexes: [
+                        ...t.indexes,
+                        { ...index, isAffected: true, tableId },
+                      ],
                     }
                   : t,
               ),
@@ -169,7 +172,9 @@ export const indexHandlers: IndexHandlers = {
                       ...t,
                       isAffected: true,
                       indexes: t.indexes.map((i) =>
-                        i.id === indexId ? { ...i, name: newName, isAffected: true } : i,
+                        i.id === indexId
+                          ? { ...i, name: newName, isAffected: true }
+                          : i,
                       ),
                     }
                   : t,
@@ -265,7 +270,9 @@ export const indexHandlers: IndexHandlers = {
                           i.id === indexId
                             ? {
                                 ...i,
-                                isAffected: i.columns.some((ic) => ic.id === indexColumnId),
+                                isAffected: i.columns.some(
+                                  (ic) => ic.id === indexColumnId,
+                                ),
                                 columns: i.columns.filter(
                                   (ic) => ic.id !== indexColumnId,
                                 ),

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -21,36 +21,36 @@ export interface RelationshipHandlers {
   createRelationship: (
     database: Database,
     schemaId: Schema["id"],
-    relationship: Relationship
+    relationship: Relationship,
   ) => Database;
   deleteRelationship: (
     database: Database,
     schemaId: Schema["id"],
-    relationshipId: Relationship["id"]
+    relationshipId: Relationship["id"],
   ) => Database;
   changeRelationshipName: (
     database: Database,
     schemaId: Schema["id"],
     relationshipId: Relationship["id"],
-    newName: Relationship["name"]
+    newName: Relationship["name"],
   ) => Database;
   changeRelationshipCardinality: (
     database: Database,
     schemaId: Schema["id"],
     relationshipId: Relationship["id"],
-    cardinality: Relationship["cardinality"]
+    cardinality: Relationship["cardinality"],
   ) => Database;
   addColumnToRelationship: (
     database: Database,
     schemaId: Schema["id"],
     relationshipId: Relationship["id"],
-    relationshipColumn: Omit<RelationshipColumn, "relationshipId">
+    relationshipColumn: Omit<RelationshipColumn, "relationshipId">,
   ) => Database;
   removeColumnFromRelationship: (
     database: Database,
     schemaId: Schema["id"],
     relationshipId: Relationship["id"],
-    relationshipColumnId: RelationshipColumn["id"]
+    relationshipColumnId: RelationshipColumn["id"],
   ) => Database;
 }
 
@@ -64,21 +64,21 @@ export const relationshipHandlers: RelationshipHandlers = {
     }
 
     const sourceTable = schema.tables.find(
-      (t) => t.id === relationship.srcTableId
+      (t) => t.id === relationship.srcTableId,
     );
     if (!sourceTable)
       throw new RelationshipTargetTableNotExistError(
         relationship.srcTableId,
-        schemaId
+        schemaId,
       );
 
     const targetTable = schema.tables.find(
-      (t) => t.id === relationship.tgtTableId
+      (t) => t.id === relationship.tgtTableId,
     );
     if (!targetTable)
       throw new RelationshipTargetTableNotExistError(
         relationship.tgtTableId,
-        schemaId
+        schemaId,
       );
 
     if (
@@ -86,16 +86,16 @@ export const relationshipHandlers: RelationshipHandlers = {
       helper.detectCircularReference(
         schema,
         relationship.tgtTableId,
-        relationship.srcTableId
+        relationship.srcTableId,
       )
     )
       throw new RelationshipCyclicReferenceError(
         relationship.tgtTableId,
-        relationship.srcTableId
+        relationship.srcTableId,
       );
 
     const duplicateRelationship = targetTable.relationships.find(
-      (r) => r.name === relationship.name
+      (r) => r.name === relationship.name,
     );
     if (duplicateRelationship)
       throw new RelationshipNameNotUniqueError(relationship.name);
@@ -103,24 +103,24 @@ export const relationshipHandlers: RelationshipHandlers = {
     const propagateKeysToChildren = (
       currentSchema: Schema,
       parentTableId: Table["id"],
-      visited: Set<Table["id"]> = new Set()
+      visited: Set<Table["id"]> = new Set(),
     ): Schema => {
       if (visited.has(parentTableId)) return currentSchema;
       visited.add(parentTableId);
 
       const parentTable = currentSchema.tables.find(
-        (t) => t.id === parentTableId
+        (t) => t.id === parentTableId,
       );
       if (!parentTable) return currentSchema;
 
       const pkConstraint = parentTable.constraints.find(
-        (c) => c.kind === "PRIMARY_KEY"
+        (c) => c.kind === "PRIMARY_KEY",
       );
       if (!pkConstraint) return currentSchema;
 
       const pkColumnIds = pkConstraint.columns.map((cc) => cc.columnId);
       const pkColumns = parentTable.columns.filter((col) =>
-        pkColumnIds.includes(col.id)
+        pkColumnIds.includes(col.id),
       );
 
       let updatedSchema = currentSchema;
@@ -129,7 +129,7 @@ export const relationshipHandlers: RelationshipHandlers = {
         for (const rel of table.relationships) {
           if (rel.tgtTableId === parentTableId) {
             const childTable = updatedSchema.tables.find(
-              (t) => t.id === rel.srcTableId
+              (t) => t.id === rel.srcTableId,
             );
             if (!childTable) continue;
 
@@ -138,12 +138,12 @@ export const relationshipHandlers: RelationshipHandlers = {
 
             for (const pkColumn of pkColumns) {
               const relColumn = rel.columns.find(
-                (rc) => rc.refColumnId === pkColumn.id
+                (rc) => rc.refColumnId === pkColumn.id,
               );
 
               if (relColumn && relColumn.fkColumnId) {
                 const existingColumn = childTable.columns.find(
-                  (c) => c.id === relColumn.fkColumnId
+                  (c) => c.id === relColumn.fkColumnId,
                 );
                 if (existingColumn) continue;
               }
@@ -189,7 +189,7 @@ export const relationshipHandlers: RelationshipHandlers = {
                 ...updatedChildTable,
                 isAffected: true,
                 relationships: updatedChildTable.relationships.map((r) =>
-                  r.id === rel.id ? updatedRel : r
+                  r.id === rel.id ? updatedRel : r,
                 ),
               };
             }
@@ -198,13 +198,13 @@ export const relationshipHandlers: RelationshipHandlers = {
               ...updatedSchema,
               isAffected: true,
               tables: updatedSchema.tables.map((t) =>
-                t.id === childTable.id ? updatedChildTable : t
+                t.id === childTable.id ? updatedChildTable : t,
               ),
             };
 
             if (rel.kind === "IDENTIFYING") {
               const childPkConstraint = updatedChildTable.constraints.find(
-                (c) => c.kind === "PRIMARY_KEY"
+                (c) => c.kind === "PRIMARY_KEY",
               );
               if (childPkConstraint && newlyCreatedFkColumns.length > 0) {
                 const newPkColumns = [];
@@ -233,7 +233,7 @@ export const relationshipHandlers: RelationshipHandlers = {
                     ...updatedChildTable,
                     isAffected: true,
                     constraints: updatedChildTable.constraints.map((c) =>
-                      c.id === childPkConstraint.id ? updatedPkConstraint : c
+                      c.id === childPkConstraint.id ? updatedPkConstraint : c,
                     ),
                   };
 
@@ -241,7 +241,7 @@ export const relationshipHandlers: RelationshipHandlers = {
                     ...updatedSchema,
                     isAffected: true,
                     tables: updatedSchema.tables.map((t) =>
-                      t.id === childTable.id ? updatedChildTable : t
+                      t.id === childTable.id ? updatedChildTable : t,
                     ),
                   };
                 }
@@ -250,7 +250,7 @@ export const relationshipHandlers: RelationshipHandlers = {
               updatedSchema = propagateKeysToChildren(
                 structuredClone(updatedSchema),
                 rel.tgtTableId,
-                new Set(visited)
+                new Set(visited),
               );
             }
           }
@@ -278,26 +278,26 @@ export const relationshipHandlers: RelationshipHandlers = {
                         { ...relationship, isAffected: true },
                       ],
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
 
     const updatedSchema = updatedDatabase.schemas.find(
-      (s) => s.id === schemaId
+      (s) => s.id === schemaId,
     )!;
     const propagatedSchema = propagateKeysToChildren(
       structuredClone(updatedSchema),
-      relationship.tgtTableId
+      relationship.tgtTableId,
     );
 
     updatedDatabase = {
       ...updatedDatabase,
       isAffected: true,
       schemas: updatedDatabase.schemas.map((s) =>
-        s.id === schemaId ? { ...propagatedSchema, isAffected: true } : s
+        s.id === schemaId ? { ...propagatedSchema, isAffected: true } : s,
       ),
     };
 
@@ -310,7 +310,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     let foundRelationship = null;
     for (const table of schema.tables) {
       const relationship = table.relationships.find(
-        (r) => r.id === relationshipId
+        (r) => r.id === relationshipId,
       );
       if (relationship) {
         foundRelationship = relationship;
@@ -323,7 +323,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     const deleteRelatedColumns = (
       currentSchema: Schema,
       relationshipToDelete: Relationship,
-      visited: Set<string> = new Set()
+      visited: Set<string> = new Set(),
     ): Schema => {
       const relationshipKey = relationshipToDelete.id;
       if (visited.has(relationshipKey)) return currentSchema;
@@ -343,31 +343,31 @@ export const relationshipHandlers: RelationshipHandlers = {
           if (table.id === relationshipToDelete.srcTableId) {
             const isAffected =
               table.relationships.some(
-                (r) => r.id === relationshipToDelete.id
+                (r) => r.id === relationshipToDelete.id,
               ) ||
               table.columns.some((col) => fkColumnsToDelete.has(col.id)) ||
               table.indexes.some((idx) =>
-                idx.columns.some((ic) => fkColumnsToDelete.has(ic.columnId))
+                idx.columns.some((ic) => fkColumnsToDelete.has(ic.columnId)),
               ) ||
               table.constraints.some((constraint) =>
                 constraint.columns.some((cc) =>
-                  fkColumnsToDelete.has(cc.columnId)
-                )
+                  fkColumnsToDelete.has(cc.columnId),
+                ),
               );
             return {
               ...table,
               isAffected,
               relationships: table.relationships.filter(
-                (r) => r.id !== relationshipToDelete.id
+                (r) => r.id !== relationshipToDelete.id,
               ),
               columns: table.columns.filter(
-                (col) => !fkColumnsToDelete.has(col.id)
+                (col) => !fkColumnsToDelete.has(col.id),
               ),
               indexes: table.indexes
                 .map((idx) => ({
                   ...idx,
                   columns: idx.columns.filter(
-                    (ic) => !fkColumnsToDelete.has(ic.columnId)
+                    (ic) => !fkColumnsToDelete.has(ic.columnId),
                   ),
                 }))
                 .filter((idx) => idx.columns.length > 0),
@@ -375,7 +375,7 @@ export const relationshipHandlers: RelationshipHandlers = {
                 .map((constraint) => ({
                   ...constraint,
                   columns: constraint.columns.filter(
-                    (cc) => !fkColumnsToDelete.has(cc.columnId)
+                    (cc) => !fkColumnsToDelete.has(cc.columnId),
                   ),
                 }))
                 .filter((constraint) => constraint.columns.length > 0),
@@ -389,7 +389,7 @@ export const relationshipHandlers: RelationshipHandlers = {
         for (const table of updatedSchema.tables) {
           const relationshipsToDelete = table.relationships.filter((rel) => {
             return rel.columns.some((relCol) =>
-              fkColumnsToDelete.has(relCol.refColumnId)
+              fkColumnsToDelete.has(relCol.refColumnId),
             );
           });
 
@@ -398,7 +398,7 @@ export const relationshipHandlers: RelationshipHandlers = {
               updatedSchema = deleteRelatedColumns(
                 structuredClone(updatedSchema),
                 relToDelete,
-                new Set(visited)
+                new Set(visited),
               );
             }
           }
@@ -410,14 +410,14 @@ export const relationshipHandlers: RelationshipHandlers = {
 
     const updatedSchema = deleteRelatedColumns(
       structuredClone(schema),
-      foundRelationship
+      foundRelationship,
     );
 
     return {
       ...database,
       isAffected: true,
       schemas: database.schemas.map((s) =>
-        s.id === schemaId ? { ...updatedSchema, isAffected: true } : s
+        s.id === schemaId ? { ...updatedSchema, isAffected: true } : s,
       ),
     };
   },
@@ -429,13 +429,13 @@ export const relationshipHandlers: RelationshipHandlers = {
     let sourceTableId = null;
     for (const table of schema.tables) {
       const relationshipNotUnique = table.relationships.find(
-        (r) => r.name === newName
+        (r) => r.name === newName,
       );
       if (relationshipNotUnique)
         throw new RelationshipNameNotUniqueError(newName);
 
       const relationship = table.relationships.find(
-        (r) => r.id === relationshipId
+        (r) => r.id === relationshipId,
       );
       if (relationship) {
         foundRelationship = relationship;
@@ -463,13 +463,13 @@ export const relationshipHandlers: RelationshipHandlers = {
                       relationships: t.relationships.map((r) =>
                         r.id === relationshipId
                           ? { ...r, name: newName, isAffected: true }
-                          : r
+                          : r,
                       ),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },
@@ -477,7 +477,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     database,
     schemaId,
     relationshipId,
-    cardinality
+    cardinality,
   ) => {
     const schema = database.schemas.find((s) => s.id === schemaId);
     if (!schema) throw new SchemaNotExistError(schemaId);
@@ -485,7 +485,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     let foundRelationship = null;
     for (const table of schema.tables) {
       const relationship = table.relationships.find(
-        (r) => r.id === relationshipId
+        (r) => r.id === relationshipId,
       );
       if (relationship) {
         foundRelationship = relationship;
@@ -504,13 +504,13 @@ export const relationshipHandlers: RelationshipHandlers = {
     let currentDatabase = relationshipHandlers.deleteRelationship(
       structuredClone(database),
       schemaId,
-      relationshipId
+      relationshipId,
     );
 
     currentDatabase = relationshipHandlers.createRelationship(
       structuredClone(currentDatabase),
       schemaId,
-      updatedRelationship
+      updatedRelationship,
     );
 
     return currentDatabase;
@@ -519,7 +519,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     database,
     schemaId,
     relationshipId,
-    relationshipColumn
+    relationshipColumn,
   ) => {
     const schema = database.schemas.find((s) => s.id === schemaId);
     if (!schema) throw new SchemaNotExistError(schemaId);
@@ -528,7 +528,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     let sourceTableId = null;
     for (const table of schema.tables) {
       const relationship = table.relationships.find(
-        (r) => r.id === relationshipId
+        (r) => r.id === relationshipId,
       );
       if (relationship) {
         foundRelationship = relationship;
@@ -559,16 +559,20 @@ export const relationshipHandlers: RelationshipHandlers = {
                               isAffected: true,
                               columns: [
                                 ...r.columns,
-                                { ...relationshipColumn, relationshipId, isAffected: true },
+                                {
+                                  ...relationshipColumn,
+                                  relationshipId,
+                                  isAffected: true,
+                                },
                               ],
                             }
-                          : r
+                          : r,
                       ),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },
@@ -576,7 +580,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     database,
     schemaId,
     relationshipId,
-    relationshipColumnId
+    relationshipColumnId,
   ) => {
     const schema = database.schemas.find((s) => s.id === schemaId);
     if (!schema) throw new SchemaNotExistError(schemaId);
@@ -585,7 +589,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     let sourceTableId = null;
     for (const table of schema.tables) {
       const relationship = table.relationships.find(
-        (r) => r.id === relationshipId
+        (r) => r.id === relationshipId,
       );
       if (relationship) {
         foundRelationship = relationship;
@@ -597,7 +601,7 @@ export const relationshipHandlers: RelationshipHandlers = {
     if (!foundRelationship) throw new RelationshipNotExistError(relationshipId);
 
     const relationshipColumn = foundRelationship.columns.find(
-      (rc) => rc.id === relationshipColumnId
+      (rc) => rc.id === relationshipColumnId,
     );
     if (!relationshipColumn)
       throw new RelationshipColumnNotExistError(relationshipColumnId);
@@ -622,17 +626,17 @@ export const relationshipHandlers: RelationshipHandlers = {
                                 ...r,
                                 isAffected: true,
                                 columns: r.columns.filter(
-                                  (rc) => rc.id !== relationshipColumnId
+                                  (rc) => rc.id !== relationshipColumnId,
                                 ),
                               }
-                            : r
+                            : r,
                         )
                         .filter((r) => r.columns.length > 0),
                     }
-                  : t
+                  : t,
               ),
             }
-          : s
+          : s,
       ),
     };
   },

--- a/packages/validator/src/lib/handlers/schemas.ts
+++ b/packages/validator/src/lib/handlers/schemas.ts
@@ -37,7 +37,9 @@ export const schemaHandlers: SchemaHandlers = {
       ...database,
       isAffected: true,
       schemas: database.schemas.map((schema) =>
-        schema.id === schemaId ? { ...schema, name: newName, isAffected: true } : schema,
+        schema.id === schemaId
+          ? { ...schema, name: newName, isAffected: true }
+          : schema,
       ),
     };
   },
@@ -54,7 +56,12 @@ export const schemaHandlers: SchemaHandlers = {
       isAffected: true,
       schemas: [
         ...database.schemas,
-        { ...schema, isAffected: true, createdAt: new Date(), updatedAt: new Date() },
+        {
+          ...schema,
+          isAffected: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
       ],
     };
   },

--- a/packages/validator/src/lib/handlers/schemas.ts
+++ b/packages/validator/src/lib/handlers/schemas.ts
@@ -35,8 +35,9 @@ export const schemaHandlers: SchemaHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.map((schema) =>
-        schema.id === schemaId ? { ...schema, name: newName } : schema,
+        schema.id === schemaId ? { ...schema, name: newName, isAffected: true } : schema,
       ),
     };
   },
@@ -50,9 +51,10 @@ export const schemaHandlers: SchemaHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: [
         ...database.schemas,
-        { ...schema, createdAt: new Date(), updatedAt: new Date() },
+        { ...schema, isAffected: true, createdAt: new Date(), updatedAt: new Date() },
       ],
     };
   },
@@ -65,6 +67,7 @@ export const schemaHandlers: SchemaHandlers = {
 
     return {
       ...database,
+      isAffected: true,
       schemas: database.schemas.filter((s) => s.id !== schemaId),
     };
   },

--- a/packages/validator/src/lib/types.ts
+++ b/packages/validator/src/lib/types.ts
@@ -42,6 +42,7 @@ export const COLUMN = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   deletedAt: z.date().nullable().optional(),
+  isAffected: z.boolean().default(false),
 });
 
 export const INDEX_COLUMN = z.object({
@@ -50,6 +51,7 @@ export const INDEX_COLUMN = z.object({
   columnId: ULID,
   seqNo: z.number().positive(),
   sortDir: INDEX_SORT_DIR,
+  isAffected: z.boolean().default(false),
 });
 
 export const INDEX = z.object({
@@ -59,6 +61,7 @@ export const INDEX = z.object({
   type: INDEX_TYPE,
   comment: z.string().nullable().optional(),
   columns: z.array(INDEX_COLUMN),
+  isAffected: z.boolean().default(false),
 });
 
 export const CONSTRAINT_COLUMN = z.object({
@@ -66,6 +69,7 @@ export const CONSTRAINT_COLUMN = z.object({
   constraintId: ULID,
   columnId: ULID,
   seqNo: z.number().positive(),
+  isAffected: z.boolean().default(false),
 });
 
 export const CONSTRAINT = z
@@ -77,6 +81,7 @@ export const CONSTRAINT = z
     checkExpr: z.string().nullable().optional(),
     defaultExpr: z.string().nullable().optional(),
     columns: z.array(CONSTRAINT_COLUMN),
+    isAffected: z.boolean().default(false),
   })
   .refine((data) => {
     if (data.kind == "CHECK") {
@@ -94,6 +99,7 @@ export const RELATIONSHIP_COLUMN = z.object({
   fkColumnId: ULID,
   refColumnId: ULID,
   seqNo: z.number().positive(),
+  isAffected: z.boolean().default(false),
 });
 
 export const RELATIONSHIP = z.object({
@@ -107,6 +113,7 @@ export const RELATIONSHIP = z.object({
   onUpdate: RELATIONSHIP_ON_UPDATE,
   fkEnforced: z.literal(false),
   columns: z.array(RELATIONSHIP_COLUMN),
+  isAffected: z.boolean().default(false),
 });
 
 export const TABLE = z.object({
@@ -122,6 +129,7 @@ export const TABLE = z.object({
   indexes: z.array(INDEX),
   constraints: z.array(CONSTRAINT),
   relationships: z.array(RELATIONSHIP),
+  isAffected: z.boolean().default(false),
 });
 
 export const SCHEMA = z.object({
@@ -136,11 +144,13 @@ export const SCHEMA = z.object({
   updatedAt: z.date(),
   deletedAt: z.date().nullable().optional(),
   tables: z.array(TABLE),
+  isAffected: z.boolean().default(false),
 });
 
 export const DATABASE = z.object({
   id: ULID,
   schemas: z.array(SCHEMA),
+  isAffected: z.boolean().default(false),
 });
 
 export type Schema = z.infer<typeof SCHEMA>;

--- a/packages/validator/tests/index.validation.spec.ts
+++ b/packages/validator/tests/index.validation.spec.ts
@@ -91,6 +91,7 @@ describe('Index validation', () => {
         seqNo: 1,
         sortDir: 'ASC',
         id: 'index-column-1',
+        isAffected: false,
       })
     ).toThrow(IndexColumnNotUniqueError);
   });

--- a/packages/validator/tests/table.validation.spec.ts
+++ b/packages/validator/tests/table.validation.spec.ts
@@ -15,6 +15,7 @@ describe('Table validation', () => {
       relationships: [],
       comment: '',
       tableOptions: '',
+      isAffected: false,
     };
 
     const database = createTestDatabase()
@@ -40,6 +41,7 @@ describe('Table validation', () => {
       relationships: [],
       comment: '',
       tableOptions: '',
+      isAffected: false,
     };
 
     const database = createTestDatabase()
@@ -68,6 +70,7 @@ describe('Table validation', () => {
       relationships: [],
       comment: '',
       tableOptions: '',
+      isAffected: false,
     };
 
     const anotherSchemaId = 'schema-2';


### PR DESCRIPTION
## 개요

변경 감지를 위한 `isAffected` 필드를 추가합니다.

현재 일관성 없이 특정 부분에서는 실제 변경 여부와 상관없이 추가하는 부분도 있고, 실제 변경 여부를 확인해서 추가하는 경우가 있는데요, 해당 부분들에는 일부 논의가 필요한 내용도 존재합니다. (이전과 현재가 같은 요청이 들어왔을 때, 릴레이션에서 컬럼이 제거되었을 때, 해당 릴레이션은 삭제되어야하는지 등...) 이러한 내용에 따라서 실제 매핑 정보들도 달라질 수 있을 것 같습니다.

이 작업 이후 누락된 로직 추가와 로직 리팩토링 작업이 완료되면, 이후 논의된 기준에 따라서 변경 감지 여부를 수정하겠습니다.

## 이슈

- close #79 
