### PR TITLE
feat(#77): add DB_VENDORS

### DIFF
--- a/apps/backend/core/sql/ddl/h2/db_schemas.sql
+++ b/apps/backend/core/sql/ddl/h2/db_schemas.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS db_schemas (
     id              CHAR(26)     NOT NULL,
     project_id      CHAR(26)     NOT NULL,
-    db_vendor_id    VARCHAR(64)  NOT NULL,
+    db_vendor_id    VARCHAR(255) NOT NULL,
     name            VARCHAR(255) NOT NULL,
     charset         VARCHAR(64)  NULL,
     collation       VARCHAR(64)  NULL,

--- a/apps/backend/core/sql/ddl/h2/db_vendors.sql
+++ b/apps/backend/core/sql/ddl/h2/db_vendors.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS db_vendors (
+    display_name      VARCHAR(255) NOT NULL,
+    name              VARCHAR(64)  NOT NULL,
+    version           VARCHAR(64)  NOT NULL,
+    datatype_mappings JSON         NOT NULL,
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at        TIMESTAMP    NULL,
+    CONSTRAINT pk_db_vendors PRIMARY KEY (display_name)
+);
+

--- a/apps/backend/core/sql/ddl/h2/db_vendors_data.sql
+++ b/apps/backend/core/sql/ddl/h2/db_vendors_data.sql
@@ -1,0 +1,258 @@
+MERGE INTO db_vendors (display_name, name, version, datatype_mappings, created_at, updated_at)
+KEY (display_name)
+VALUES (
+    'MySQL 8.0',
+    'mysql',
+    '8.0',
+    '{
+      "schemaVersion": 1,
+      "vendor": "mysql",
+      "versionRange": ">= 8.0",
+      "types": [
+        {
+          "sqlType": "TINYINT",
+          "displayName": "TINYINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "SMALLINT",
+          "displayName": "SMALLINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMINT",
+          "displayName": "MEDIUMINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "INT",
+          "displayName": "INT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "BIGINT",
+          "displayName": "BIGINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "DECIMAL",
+          "displayName": "DECIMAL",
+          "category": "numeric_decimal",
+          "sqlDeclarationTemplate": "DECIMAL({1}, {2})",
+          "parameters": [
+            {
+              "name": "precision",
+              "label": "Precision (M)",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            },
+            {
+              "name": "scale",
+              "label": "Scale (D)",
+              "valueType": "integer",
+              "required": true,
+              "order": 2
+            }
+          ]
+        },
+        {
+          "sqlType": "FLOAT",
+          "displayName": "FLOAT",
+          "category": "numeric_float",
+          "parameters": []
+        },
+        {
+          "sqlType": "DOUBLE",
+          "displayName": "DOUBLE",
+          "category": "numeric_float",
+          "parameters": []
+        },
+        {
+          "sqlType": "BIT",
+          "displayName": "BIT",
+          "category": "numeric_bit",
+          "sqlDeclarationTemplate": "BIT({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Bits",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "DATE",
+          "displayName": "DATE",
+          "category": "datetime_date",
+          "parameters": []
+        },
+        {
+          "sqlType": "TIME",
+          "displayName": "TIME",
+          "category": "datetime_time",
+          "parameters": []
+        },
+        {
+          "sqlType": "DATETIME",
+          "displayName": "DATETIME",
+          "category": "datetime_timestamp",
+          "parameters": []
+        },
+        {
+          "sqlType": "TIMESTAMP",
+          "displayName": "TIMESTAMP",
+          "category": "datetime_timestamp",
+          "parameters": []
+        },
+        {
+          "sqlType": "YEAR",
+          "displayName": "YEAR",
+          "category": "datetime_year",
+          "parameters": []
+        },
+        {
+          "sqlType": "CHAR",
+          "displayName": "CHAR",
+          "category": "string_fixed",
+          "sqlDeclarationTemplate": "CHAR({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "VARCHAR",
+          "displayName": "VARCHAR",
+          "category": "string_variable",
+          "sqlDeclarationTemplate": "VARCHAR({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "BINARY",
+          "displayName": "BINARY",
+          "category": "binary_fixed",
+          "sqlDeclarationTemplate": "BINARY({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "VARBINARY",
+          "displayName": "VARBINARY",
+          "category": "binary_variable",
+          "sqlDeclarationTemplate": "VARBINARY({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "TEXT",
+          "displayName": "TEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMTEXT",
+          "displayName": "MEDIUMTEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "LONGTEXT",
+          "displayName": "LONGTEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "BLOB",
+          "displayName": "BLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMBLOB",
+          "displayName": "MEDIUMBLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "LONGBLOB",
+          "displayName": "LONGBLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "ENUM",
+          "displayName": "ENUM",
+          "category": "string_enum",
+          "sqlDeclarationTemplate": "ENUM({1})",
+          "parameters": [
+            {
+              "name": "values",
+              "label": "Values",
+              "valueType": "string_array",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "SET",
+          "displayName": "SET",
+          "category": "string_set",
+          "sqlDeclarationTemplate": "SET({1})",
+          "parameters": [
+            {
+              "name": "values",
+              "label": "Values",
+              "valueType": "string_array",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "JSON",
+          "displayName": "JSON",
+          "category": "json",
+          "parameters": []
+        }
+      ]
+    }',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+

--- a/apps/backend/core/sql/ddl/mariadb/db_schemas.sql
+++ b/apps/backend/core/sql/ddl/mariadb/db_schemas.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS db_schemas (
     id              CHAR(26)     NOT NULL,
     project_id      CHAR(26)     NOT NULL,
-    db_vendor_id    VARCHAR(64)  NOT NULL,
+    db_vendor_id    VARCHAR(255) NOT NULL,
     name            VARCHAR(255) NOT NULL,
     charset         VARCHAR(64)  NULL,
     collation       VARCHAR(64)  NULL,

--- a/apps/backend/core/sql/ddl/mariadb/db_vendors.sql
+++ b/apps/backend/core/sql/ddl/mariadb/db_vendors.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS db_vendors (
+    display_name      VARCHAR(255) NOT NULL,
+    name              VARCHAR(64)  NOT NULL,
+    version           VARCHAR(64)  NOT NULL,
+    datatype_mappings JSON         NOT NULL,
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at        TIMESTAMP    NULL,
+    CONSTRAINT pk_db_vendors PRIMARY KEY (display_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+

--- a/apps/backend/core/sql/ddl/mariadb/db_vendors_data.sql
+++ b/apps/backend/core/sql/ddl/mariadb/db_vendors_data.sql
@@ -1,0 +1,257 @@
+INSERT IGNORE INTO db_vendors (display_name, name, version, datatype_mappings, created_at, updated_at)
+VALUES (
+    'MySQL 8.0',
+    'mysql',
+    '8.0',
+    '{
+      "schemaVersion": 1,
+      "vendor": "mysql",
+      "versionRange": ">= 8.0",
+      "types": [
+        {
+          "sqlType": "TINYINT",
+          "displayName": "TINYINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "SMALLINT",
+          "displayName": "SMALLINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMINT",
+          "displayName": "MEDIUMINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "INT",
+          "displayName": "INT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "BIGINT",
+          "displayName": "BIGINT",
+          "category": "numeric_integer",
+          "parameters": []
+        },
+        {
+          "sqlType": "DECIMAL",
+          "displayName": "DECIMAL",
+          "category": "numeric_decimal",
+          "sqlDeclarationTemplate": "DECIMAL({1}, {2})",
+          "parameters": [
+            {
+              "name": "precision",
+              "label": "Precision (M)",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            },
+            {
+              "name": "scale",
+              "label": "Scale (D)",
+              "valueType": "integer",
+              "required": true,
+              "order": 2
+            }
+          ]
+        },
+        {
+          "sqlType": "FLOAT",
+          "displayName": "FLOAT",
+          "category": "numeric_float",
+          "parameters": []
+        },
+        {
+          "sqlType": "DOUBLE",
+          "displayName": "DOUBLE",
+          "category": "numeric_float",
+          "parameters": []
+        },
+        {
+          "sqlType": "BIT",
+          "displayName": "BIT",
+          "category": "numeric_bit",
+          "sqlDeclarationTemplate": "BIT({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Bits",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "DATE",
+          "displayName": "DATE",
+          "category": "datetime_date",
+          "parameters": []
+        },
+        {
+          "sqlType": "TIME",
+          "displayName": "TIME",
+          "category": "datetime_time",
+          "parameters": []
+        },
+        {
+          "sqlType": "DATETIME",
+          "displayName": "DATETIME",
+          "category": "datetime_timestamp",
+          "parameters": []
+        },
+        {
+          "sqlType": "TIMESTAMP",
+          "displayName": "TIMESTAMP",
+          "category": "datetime_timestamp",
+          "parameters": []
+        },
+        {
+          "sqlType": "YEAR",
+          "displayName": "YEAR",
+          "category": "datetime_year",
+          "parameters": []
+        },
+        {
+          "sqlType": "CHAR",
+          "displayName": "CHAR",
+          "category": "string_fixed",
+          "sqlDeclarationTemplate": "CHAR({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "VARCHAR",
+          "displayName": "VARCHAR",
+          "category": "string_variable",
+          "sqlDeclarationTemplate": "VARCHAR({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "BINARY",
+          "displayName": "BINARY",
+          "category": "binary_fixed",
+          "sqlDeclarationTemplate": "BINARY({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "VARBINARY",
+          "displayName": "VARBINARY",
+          "category": "binary_variable",
+          "sqlDeclarationTemplate": "VARBINARY({1})",
+          "parameters": [
+            {
+              "name": "length",
+              "label": "Length",
+              "valueType": "integer",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "TEXT",
+          "displayName": "TEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMTEXT",
+          "displayName": "MEDIUMTEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "LONGTEXT",
+          "displayName": "LONGTEXT",
+          "category": "string_text",
+          "parameters": []
+        },
+        {
+          "sqlType": "BLOB",
+          "displayName": "BLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "MEDIUMBLOB",
+          "displayName": "MEDIUMBLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "LONGBLOB",
+          "displayName": "LONGBLOB",
+          "category": "binary_blob",
+          "parameters": []
+        },
+        {
+          "sqlType": "ENUM",
+          "displayName": "ENUM",
+          "category": "string_enum",
+          "sqlDeclarationTemplate": "ENUM({1})",
+          "parameters": [
+            {
+              "name": "values",
+              "label": "Values",
+              "valueType": "string_array",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "SET",
+          "displayName": "SET",
+          "category": "string_set",
+          "sqlDeclarationTemplate": "SET({1})",
+          "parameters": [
+            {
+              "name": "values",
+              "label": "Values",
+              "valueType": "string_array",
+              "required": true,
+              "order": 1
+            }
+          ]
+        },
+        {
+          "sqlType": "JSON",
+          "displayName": "JSON",
+          "category": "json",
+          "parameters": []
+        }
+      ]
+    }',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/exception/ErrorCode.java
@@ -60,7 +60,8 @@ public enum ErrorCode {
             "인덱스 컬럼을 찾을 수 없습니다."),
     ERD_RELATIONSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "E006", "관계를 찾을 수 없습니다."),
     ERD_RELATIONSHIP_COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "E009",
-            "관계 컬럼을 찾을 수 없습니다.");
+            "관계 컬럼을 찾을 수 없습니다."),
+    ERD_VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "E010", "DB 벤더를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/DbVendorRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/DbVendorRepository.java
@@ -1,0 +1,22 @@
+package com.schemafy.core.erd.repository;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.schemafy.core.erd.repository.entity.DbVendor;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public interface DbVendorRepository
+        extends ReactiveCrudRepository<DbVendor, String> {
+
+    public Mono<DbVendor> findByIdAndDeletedAtIsNull(String id);
+
+    public Flux<DbVendor> findByDeletedAtIsNull();
+
+    public Mono<DbVendor> findByNameAndVersionAndDeletedAtIsNull(String name,
+            String version);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/entity/DbVendor.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/entity/DbVendor.java
@@ -1,0 +1,45 @@
+package com.schemafy.core.erd.repository.entity;
+
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import com.schemafy.core.common.type.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table("db_vendors")
+public class DbVendor extends BaseEntity {
+
+    @Column("display_name")
+    protected String id;
+
+    @Column("name")
+    private String name;
+
+    @Column("version")
+    private String version;
+
+    @Column("datatype_mappings")
+    private String datatypeMappings;
+
+    @Builder(builderMethodName = "builder", buildMethodName = "build")
+    private static DbVendor newDbVendor(String displayName, String name,
+            String version, String datatypeMappings) {
+        DbVendor vendor = new DbVendor();
+        vendor.setId(displayName);
+        vendor.setName(name);
+        vendor.setVersion(version);
+        vendor.setDatatypeMappings(datatypeMappings);
+        return vendor;
+    }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/DbVendorService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/DbVendorService.java
@@ -1,0 +1,39 @@
+package com.schemafy.core.erd.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.exception.BusinessException;
+import com.schemafy.core.common.exception.ErrorCode;
+import com.schemafy.core.erd.repository.DbVendorRepository;
+import com.schemafy.core.erd.repository.entity.DbVendor;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DbVendorService {
+
+    private final DbVendorRepository dbVendorRepository;
+
+    public Mono<DbVendor> getVendorByDisplayName(String displayName) {
+        return dbVendorRepository
+                .findByIdAndDeletedAtIsNull(displayName)
+                .switchIfEmpty(Mono.error(
+                        new BusinessException(ErrorCode.ERD_VENDOR_NOT_FOUND)));
+    }
+
+    public Flux<DbVendor> getAllVendors() {
+        return dbVendorRepository.findByDeletedAtIsNull();
+    }
+
+    public Mono<DbVendor> getVendorByNameAndVersion(String name,
+            String version) {
+        return dbVendorRepository.findByNameAndVersionAndDeletedAtIsNull(name,
+                version)
+                .switchIfEmpty(Mono.error(
+                        new BusinessException(ErrorCode.ERD_VENDOR_NOT_FOUND)));
+    }
+
+}


### PR DESCRIPTION
## 개요

DB 벤더 및 데이터 타입 관리 기능을 추가했습니다. 각 DB 벤더별로 지원하는 데이터 타입 정보를 관리할 수 있는 기반을 마련했습니다.

## 주요 변경사항

### DB 벤더

- DbVendor: DB 벤더 정보를 저장하는 엔티티 추가
  - `display_name`: 벤더 표시명 (예: "H2 2.2", "MySQL 8.0")
  - `name`: 벤더 이름 (예: "h2", "mysql")
  - `version`: 벤더 버전 (예: "2.2", "8.0")
  - `datatype_mappings`: JSON 형식의 데이터 타입 매핑 정보

### 데이터베이스 스키마

- db_vendors: H2와 MariaDB용 테이블 생성 스크립트 추가
  - Primary Key: `display_name`

- 초기화 데이터: 각 DB 벤더별 데이터 타입 매핑 정보 포함
  - MySQL 8.0: MySQL 지원 데이터 타입 정보
  - 각 데이터 타입의 SQL 타입, 표시명, 카테고리, 파라미터 정보 포함

## 이슈

- close #77 
