### PR TITLE
fix(#126): add id remapping and propagation fixes

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
@@ -27,12 +27,13 @@ public record AffectedMappingResponse(
     public record PropagatedEntities(
             List<PropagatedColumn> columns,
             List<PropagatedRelationshipColumn> relationshipColumns,
+            List<PropagatedConstraint> constraints,
             List<PropagatedConstraintColumn> constraintColumns,
             List<PropagatedIndexColumn> indexColumns) {
 
         public static PropagatedEntities empty() {
             return new PropagatedEntities(List.of(), List.of(), List.of(),
-                    List.of());
+                    List.of(), List.of());
         }
 
     }
@@ -51,6 +52,15 @@ public record AffectedMappingResponse(
             String fkColumnId,
             String refColumnId,
             int seqNo,
+            String sourceType,
+            String sourceId) {
+    }
+
+    public record PropagatedConstraint(
+            String constraintId,
+            String tableId,
+            String name,
+            String kind,
             String sourceType,
             String sourceId) {
     }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
@@ -26,11 +26,13 @@ public record AffectedMappingResponse(
 
     public record PropagatedEntities(
             List<PropagatedColumn> columns,
+            List<PropagatedRelationshipColumn> relationshipColumns,
             List<PropagatedConstraintColumn> constraintColumns,
             List<PropagatedIndexColumn> indexColumns) {
 
         public static PropagatedEntities empty() {
-            return new PropagatedEntities(List.of(), List.of(), List.of());
+            return new PropagatedEntities(List.of(), List.of(), List.of(),
+                    List.of());
         }
 
     }
@@ -41,6 +43,16 @@ public record AffectedMappingResponse(
             String sourceType,
             String sourceId,
             String sourceColumnId) {
+    }
+
+    public record PropagatedRelationshipColumn(
+            String relationshipColumnId,
+            String relationshipId,
+            String fkColumnId,
+            String refColumnId,
+            int seqNo,
+            String sourceType,
+            String sourceId) {
     }
 
     public record PropagatedConstraintColumn(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -191,7 +191,8 @@ public class AffectedEntitiesSaver {
                     }
 
                     for (Validation.Index index : table.getIndexesList()) {
-                        if (shouldSaveEntity(index.getId(), index.getIsAffected(),
+                        if (shouldSaveEntity(index.getId(),
+                                index.getIsAffected(),
                                 beforeIds, excludedIds)) {
                             indexesToSave.add(index);
                         }
@@ -238,7 +239,8 @@ public class AffectedEntitiesSaver {
                         for (Validation.RelationshipColumn relationshipColumn : relationship
                                 .getColumnsList()) {
                             if (shouldSaveEntity(relationshipColumn.getId(),
-                                    relationshipColumn.getIsAffected(), beforeIds,
+                                    relationshipColumn.getIsAffected(),
+                                    beforeIds,
                                     excludedIds)) {
                                 relationshipColumnsToSave
                                         .add(new RelationshipColumnWithRelationshipId(
@@ -387,10 +389,12 @@ public class AffectedEntitiesSaver {
                                         relationship.getTgtTableId(),
                                         tableIdMap));
                                 return relationshipRepository.save(entity)
-                                        .doOnNext(savedRelationship -> relationshipIdMap
-                                                .put(relationship.getId(),
-                                                        savedRelationship
-                                                                .getId()))
+                                        .doOnNext(
+                                                savedRelationship -> relationshipIdMap
+                                                        .put(relationship
+                                                                .getId(),
+                                                                savedRelationship
+                                                                        .getId()))
                                         .then();
                             }))
                     .then();
@@ -414,8 +418,9 @@ public class AffectedEntitiesSaver {
                                             if (sourceId != null
                                                     && sourceType != null
                                                     && !excludedPropagatedIds
-                                                            .contains(indexColumn
-                                                                    .getId())) {
+                                                            .contains(
+                                                                    indexColumn
+                                                                            .getId())) {
                                                 propagatedIndexColumns
                                                         .add(new PropagatedIndexColumn(
                                                                 savedIndexColumn
@@ -456,8 +461,9 @@ public class AffectedEntitiesSaver {
                                             if (sourceId != null
                                                     && sourceType != null
                                                     && !excludedPropagatedIds
-                                                            .contains(constraintColumn
-                                                                    .getId())) {
+                                                            .contains(
+                                                                    constraintColumn
+                                                                            .getId())) {
                                                 propagatedConstraintColumns
                                                         .add(new PropagatedConstraintColumn(
                                                                 savedConstraintColumn
@@ -477,7 +483,8 @@ public class AffectedEntitiesSaver {
             Mono<Void> saveRelationshipColumnsTask = saveConstraintColumnsTask
                     .thenMany(Flux.fromIterable(relationshipColumnsToSave)
                             .concatMap(item -> {
-                                Validation.RelationshipColumn relationshipColumn = item.relationshipColumn();
+                                Validation.RelationshipColumn relationshipColumn = item
+                                        .relationshipColumn();
 
                                 String relationshipId = remapId(
                                         item.relationshipId(),
@@ -507,8 +514,9 @@ public class AffectedEntitiesSaver {
                                             if (sourceId != null
                                                     && sourceType != null
                                                     && !excludedPropagatedIds
-                                                            .contains(relationshipColumn
-                                                                    .getId())) {
+                                                            .contains(
+                                                                    relationshipColumn
+                                                                            .getId())) {
                                                 propagatedRelationshipColumns
                                                         .add(new PropagatedRelationshipColumn(
                                                                 savedRelationshipColumn
@@ -557,7 +565,8 @@ public class AffectedEntitiesSaver {
                 && !excludedIds.contains(entityId);
     }
 
-    private static String remapId(String originalId, Map<String, String> idMap) {
+    private static String remapId(String originalId,
+            Map<String, String> idMap) {
         String mappedId = idMap.get(originalId);
         return mappedId != null ? mappedId : originalId;
     }
@@ -636,7 +645,8 @@ public class AffectedEntitiesSaver {
         Map<String, String> fkToRefMap = new HashMap<>();
 
         if (EntityType.RELATIONSHIP.name().equals(sourceType)) {
-            Validation.Relationship relationship = findRelationshipById(database,
+            Validation.Relationship relationship = findRelationshipById(
+                    database,
                     sourceId);
             if (relationship == null) {
                 return fkToRefMap;
@@ -649,7 +659,8 @@ public class AffectedEntitiesSaver {
                 }
 
                 fkToRefMap.put(
-                        remapId(relationshipColumn.getFkColumnId(), columnIdMap),
+                        remapId(relationshipColumn.getFkColumnId(),
+                                columnIdMap),
                         remapId(relationshipColumn.getRefColumnId(),
                                 columnIdMap));
             }
@@ -684,7 +695,8 @@ public class AffectedEntitiesSaver {
 
                             fkToRefMap.put(remapId(
                                     relationshipColumn.getFkColumnId(),
-                                    columnIdMap), remapId(
+                                    columnIdMap),
+                                    remapId(
                                             relationshipColumn.getRefColumnId(),
                                             columnIdMap));
                         }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -17,6 +17,7 @@ import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.Pro
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedIndexColumn;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedRelationshipColumn;
 import com.schemafy.core.erd.mapper.ErdMapper;
+import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintRepository;
@@ -634,7 +635,7 @@ public class AffectedEntitiesSaver {
             Map<String, String> columnIdMap) {
         Map<String, String> fkToRefMap = new HashMap<>();
 
-        if ("RELATIONSHIP".equals(sourceType)) {
+        if (EntityType.RELATIONSHIP.name().equals(sourceType)) {
             Validation.Relationship relationship = findRelationshipById(database,
                     sourceId);
             if (relationship == null) {
@@ -655,7 +656,7 @@ public class AffectedEntitiesSaver {
             return fkToRefMap;
         }
 
-        if ("CONSTRAINT".equals(sourceType)) {
+        if (EntityType.CONSTRAINT.name().equals(sourceType)) {
             Validation.Constraint constraint = findConstraintById(database,
                     sourceId);
             if (constraint == null) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -72,7 +72,22 @@ public class AffectedEntitiesSaver {
             Set<String> excludeEntityIds) {
         return saveAffectedEntitiesResult(before, after, excludeEntityId,
                 sourceId,
-                sourceType, excludeEntityIds).map(SaveResult::propagated);
+                sourceType, excludeEntityIds, Set.of())
+                .map(SaveResult::propagated);
+    }
+
+    public Mono<PropagatedEntities> saveAffectedEntities(
+            Validation.Database before,
+            Validation.Database after,
+            String excludeEntityId,
+            String sourceId,
+            String sourceType,
+            Set<String> excludeEntityIds,
+            Set<String> excludePropagatedEntityIds) {
+        return saveAffectedEntitiesResult(before, after, excludeEntityId,
+                sourceId,
+                sourceType, excludeEntityIds, excludePropagatedEntityIds)
+                .map(SaveResult::propagated);
     }
 
     public Mono<SaveResult> saveAffectedEntitiesResult(
@@ -100,6 +115,19 @@ public class AffectedEntitiesSaver {
             String sourceId,
             String sourceType,
             Set<String> excludeEntityIds) {
+        return saveAffectedEntitiesResult(before, after, excludeEntityId,
+                sourceId,
+                sourceType, excludeEntityIds, Set.of());
+    }
+
+    public Mono<SaveResult> saveAffectedEntitiesResult(
+            Validation.Database before,
+            Validation.Database after,
+            String excludeEntityId,
+            String sourceId,
+            String sourceType,
+            Set<String> excludeEntityIds,
+            Set<String> excludePropagatedEntityIds) {
         return Mono.defer(() -> {
             Set<String> excludedIds = new HashSet<>();
             if (excludeEntityId != null) {
@@ -108,6 +136,9 @@ public class AffectedEntitiesSaver {
             if (excludeEntityIds != null) {
                 excludedIds.addAll(excludeEntityIds);
             }
+            Set<String> excludedPropagatedIds = excludePropagatedEntityIds != null
+                    ? excludePropagatedEntityIds
+                    : Set.of();
 
             List<PropagatedColumn> propagatedColumns = new ArrayList<>();
             List<PropagatedRelationshipColumn> propagatedRelationshipColumns = new ArrayList<>();
@@ -252,7 +283,10 @@ public class AffectedEntitiesSaver {
                                                     savedColumn.getId());
 
                                             if (sourceId != null
-                                                    && sourceType != null) {
+                                                    && sourceType != null
+                                                    && !excludedPropagatedIds
+                                                            .contains(
+                                                                    column.getId())) {
                                                 savedPropagatedColumns.add(
                                                         new SavedPropagatedColumn(
                                                                 savedColumn
@@ -318,7 +352,10 @@ public class AffectedEntitiesSaver {
                                                     savedConstraint.getId());
 
                                             if (sourceId != null
-                                                    && sourceType != null) {
+                                                    && sourceType != null
+                                                    && !excludedPropagatedIds
+                                                            .contains(constraint
+                                                                    .getId())) {
                                                 propagatedConstraints
                                                         .add(new PropagatedConstraint(
                                                                 savedConstraint
@@ -374,7 +411,10 @@ public class AffectedEntitiesSaver {
                                                     indexColumn.getId(),
                                                     savedIndexColumn.getId());
                                             if (sourceId != null
-                                                    && sourceType != null) {
+                                                    && sourceType != null
+                                                    && !excludedPropagatedIds
+                                                            .contains(indexColumn
+                                                                    .getId())) {
                                                 propagatedIndexColumns
                                                         .add(new PropagatedIndexColumn(
                                                                 savedIndexColumn
@@ -413,7 +453,10 @@ public class AffectedEntitiesSaver {
                                                     savedConstraintColumn
                                                             .getId());
                                             if (sourceId != null
-                                                    && sourceType != null) {
+                                                    && sourceType != null
+                                                    && !excludedPropagatedIds
+                                                            .contains(constraintColumn
+                                                                    .getId())) {
                                                 propagatedConstraintColumns
                                                         .add(new PropagatedConstraintColumn(
                                                                 savedConstraintColumn
@@ -461,7 +504,10 @@ public class AffectedEntitiesSaver {
                                                     savedRelationshipColumn
                                                             .getId());
                                             if (sourceId != null
-                                                    && sourceType != null) {
+                                                    && sourceType != null
+                                                    && !excludedPropagatedIds
+                                                            .contains(relationshipColumn
+                                                                    .getId())) {
                                                 propagatedRelationshipColumns
                                                         .add(new PropagatedRelationshipColumn(
                                                                 savedRelationshipColumn

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -11,6 +11,7 @@ import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.Pro
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedConstraintColumn;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedEntities;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedIndexColumn;
+import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse.PropagatedRelationshipColumn;
 import com.schemafy.core.erd.mapper.ErdMapper;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintColumnRepository;
@@ -57,6 +58,7 @@ public class AffectedEntitiesSaver {
             List<Mono<Void>> saveTasks = new ArrayList<>();
 
             List<PropagatedColumn> propagatedColumns = new ArrayList<>();
+            List<PropagatedRelationshipColumn> propagatedRelationshipColumns = new ArrayList<>();
             List<PropagatedConstraintColumn> propagatedConstraintColumns = new ArrayList<>();
             List<PropagatedIndexColumn> propagatedIndexColumns = new ArrayList<>();
 
@@ -211,6 +213,7 @@ public class AffectedEntitiesSaver {
                     .flatMap(task -> task)
                     .then(Mono.just(new PropagatedEntities(
                             propagatedColumns,
+                            propagatedRelationshipColumns,
                             propagatedConstraintColumns,
                             propagatedIndexColumns)));
         });

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSoftDeleter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSoftDeleter.java
@@ -77,7 +77,8 @@ public class AffectedEntitiesSoftDeleter {
                 removedRelationshipColumns));
     }
 
-    public Mono<Void> softDeleteEntities(ValidationDatabaseEntityIds idsToDelete) {
+    public Mono<Void> softDeleteEntities(
+            ValidationDatabaseEntityIds idsToDelete) {
         return softDelete(idsToDelete.relationshipColumns(),
                 relationshipColumnRepository::findByIdAndDeletedAtIsNull,
                 relationshipColumnRepository::save)
@@ -127,4 +128,5 @@ public class AffectedEntitiesSoftDeleter {
                         .flatMap(saver))
                 .then();
     }
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSoftDeleter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSoftDeleter.java
@@ -1,0 +1,130 @@
+package com.schemafy.core.erd.service;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.type.BaseEntity;
+import com.schemafy.core.erd.repository.ColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintRepository;
+import com.schemafy.core.erd.repository.IndexColumnRepository;
+import com.schemafy.core.erd.repository.IndexRepository;
+import com.schemafy.core.erd.repository.RelationshipColumnRepository;
+import com.schemafy.core.erd.repository.RelationshipRepository;
+import com.schemafy.core.erd.repository.SchemaRepository;
+import com.schemafy.core.erd.repository.TableRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import validation.Validation;
+
+@Component
+@RequiredArgsConstructor
+public class AffectedEntitiesSoftDeleter {
+
+    private final SchemaRepository schemaRepository;
+    private final TableRepository tableRepository;
+    private final ColumnRepository columnRepository;
+    private final IndexRepository indexRepository;
+    private final IndexColumnRepository indexColumnRepository;
+    private final ConstraintRepository constraintRepository;
+    private final ConstraintColumnRepository constraintColumnRepository;
+    private final RelationshipRepository relationshipRepository;
+    private final RelationshipColumnRepository relationshipColumnRepository;
+
+    public Mono<Void> softDeleteRemovedEntities(
+            Validation.Database before,
+            Validation.Database after) {
+        ValidationDatabaseEntityIds beforeIds = ValidationDatabaseEntityIds
+                .from(before);
+        ValidationDatabaseEntityIds afterIds = ValidationDatabaseEntityIds
+                .from(after);
+
+        Set<String> removedRelationshipColumns = difference(
+                beforeIds.relationshipColumns(),
+                afterIds.relationshipColumns());
+        Set<String> removedConstraintColumns = difference(
+                beforeIds.constraintColumns(),
+                afterIds.constraintColumns());
+        Set<String> removedIndexColumns = difference(beforeIds.indexColumns(),
+                afterIds.indexColumns());
+        Set<String> removedRelationships = difference(beforeIds.relationships(),
+                afterIds.relationships());
+        Set<String> removedConstraints = difference(beforeIds.constraints(),
+                afterIds.constraints());
+        Set<String> removedIndexes = difference(beforeIds.indexes(),
+                afterIds.indexes());
+        Set<String> removedColumns = difference(beforeIds.columns(),
+                afterIds.columns());
+        Set<String> removedTables = difference(beforeIds.tables(),
+                afterIds.tables());
+        Set<String> removedSchemas = difference(beforeIds.schemas(),
+                afterIds.schemas());
+
+        return softDeleteEntities(new ValidationDatabaseEntityIds(
+                removedSchemas,
+                removedTables,
+                removedColumns,
+                removedIndexes,
+                removedIndexColumns,
+                removedConstraints,
+                removedConstraintColumns,
+                removedRelationships,
+                removedRelationshipColumns));
+    }
+
+    public Mono<Void> softDeleteEntities(ValidationDatabaseEntityIds idsToDelete) {
+        return softDelete(idsToDelete.relationshipColumns(),
+                relationshipColumnRepository::findByIdAndDeletedAtIsNull,
+                relationshipColumnRepository::save)
+                .then(softDelete(idsToDelete.constraintColumns(),
+                        constraintColumnRepository::findByIdAndDeletedAtIsNull,
+                        constraintColumnRepository::save))
+                .then(softDelete(idsToDelete.indexColumns(),
+                        indexColumnRepository::findByIdAndDeletedAtIsNull,
+                        indexColumnRepository::save))
+                .then(softDelete(idsToDelete.relationships(),
+                        relationshipRepository::findByIdAndDeletedAtIsNull,
+                        relationshipRepository::save))
+                .then(softDelete(idsToDelete.constraints(),
+                        constraintRepository::findByIdAndDeletedAtIsNull,
+                        constraintRepository::save))
+                .then(softDelete(idsToDelete.indexes(),
+                        indexRepository::findByIdAndDeletedAtIsNull,
+                        indexRepository::save))
+                .then(softDelete(idsToDelete.columns(),
+                        columnRepository::findByIdAndDeletedAtIsNull,
+                        columnRepository::save))
+                .then(softDelete(idsToDelete.tables(),
+                        tableRepository::findByIdAndDeletedAtIsNull,
+                        tableRepository::save))
+                .then(softDelete(idsToDelete.schemas(),
+                        schemaRepository::findByIdAndDeletedAtIsNull,
+                        schemaRepository::save));
+    }
+
+    private static Set<String> difference(Set<String> left, Set<String> right) {
+        Set<String> result = new HashSet<>(left);
+        result.removeAll(right);
+        return result;
+    }
+
+    private static <T extends BaseEntity> Mono<Void> softDelete(
+            Set<String> ids,
+            Function<String, Mono<T>> finder,
+            Function<T, Mono<T>> saver) {
+        if (ids.isEmpty()) {
+            return Mono.empty();
+        }
+
+        return Flux.fromIterable(ids)
+                .concatMap(id -> finder.apply(id)
+                        .doOnNext(BaseEntity::delete)
+                        .flatMap(saver))
+                .then();
+    }
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ColumnService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ColumnService.java
@@ -1,6 +1,7 @@
 package com.schemafy.core.erd.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.common.exception.ErrorCode;
@@ -9,7 +10,6 @@ import com.schemafy.core.erd.controller.dto.response.ColumnResponse;
 import com.schemafy.core.erd.mapper.ErdMapper;
 import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
-import com.schemafy.core.erd.repository.entity.Column;
 import com.schemafy.core.validation.client.ValidationClient;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +23,8 @@ public class ColumnService {
 
     private final ValidationClient validationClient;
     private final ColumnRepository columnRepository;
+    private final AffectedEntitiesSoftDeleter affectedEntitiesSoftDeleter;
+    private final TransactionalOperator transactionalOperator;
 
     public Mono<AffectedMappingResponse> createColumn(
             Validation.CreateColumnRequest request) {
@@ -94,13 +96,21 @@ public class ColumnService {
     }
 
     public Mono<Void> deleteColumn(Validation.DeleteColumnRequest request) {
+        if (!request.hasDatabase()) {
+            return Mono.error(
+                    new BusinessException(ErrorCode.COMMON_INVALID_PARAMETER));
+        }
+
         return columnRepository
                 .findByIdAndDeletedAtIsNull(request.getColumnId())
                 .switchIfEmpty(Mono.error(
                         new BusinessException(ErrorCode.ERD_COLUMN_NOT_FOUND)))
-                .delayUntil(ignore -> validationClient.deleteColumn(request))
-                .doOnNext(Column::delete)
-                .flatMap(columnRepository::save)
+                .flatMap(ignore -> validationClient.deleteColumn(request))
+                .flatMap(afterDatabase -> transactionalOperator.transactional(
+                        affectedEntitiesSoftDeleter
+                                .softDeleteRemovedEntities(
+                                        request.getDatabase(),
+                                        afterDatabase)))
                 .then();
     }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
@@ -1,6 +1,9 @@
 package com.schemafy.core.erd.service;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -52,13 +55,22 @@ public class ConstraintService {
                                             request.getConstraint().getId(),
                                             savedConstraint.getId());
 
+                            Set<String> excludePropagatedIds = new HashSet<>(
+                                    request.getConstraint().getColumnsList()
+                                            .stream()
+                                            .map(Validation.ConstraintColumn::getId)
+                                            .collect(Collectors.toSet()));
+                            excludePropagatedIds.add(savedConstraint.getId());
+
                             return affectedEntitiesSaver
                                     .saveAffectedEntitiesResult(
                                             request.getDatabase(),
                                             updatedDatabase,
                                             savedConstraint.getId(),
                                             savedConstraint.getId(),
-                                            "CONSTRAINT")
+                                            "CONSTRAINT",
+                                            Set.of(),
+                                            excludePropagatedIds)
                                     .map(saveResult -> {
                                         Validation.Database afterDatabase = applyConstraintColumnMappings(
                                                 updatedDatabase,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
@@ -68,7 +68,7 @@ public class ConstraintService {
                                             updatedDatabase,
                                             savedConstraint.getId(),
                                             savedConstraint.getId(),
-                                            "CONSTRAINT",
+                                            EntityType.CONSTRAINT.name(),
                                             Set.of(),
                                             excludePropagatedIds)
                                     .map(saveResult -> {
@@ -167,7 +167,7 @@ public class ConstraintService {
                                             updatedDatabase,
                                             savedConstraintColumn.getId(),
                                             request.getConstraintId(),
-                                            "CONSTRAINT")
+                                            EntityType.CONSTRAINT.name())
                                     .map(propagated -> AffectedMappingResponse
                                             .of(
                                                     request,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ConstraintService.java
@@ -1,5 +1,8 @@
 package com.schemafy.core.erd.service;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
@@ -77,13 +80,20 @@ public class ConstraintService {
             Validation.CreateConstraintRequest request,
             Validation.Database updatedDatabase,
             String constraintId) {
+        Set<String> excludeEntityIds = request.getConstraint()
+                .getColumnsList()
+                .stream()
+                .map(Validation.ConstraintColumn::getId)
+                .collect(Collectors.toSet());
+
         return affectedEntitiesSaver
                 .saveAffectedEntities(
                         request.getDatabase(),
                         updatedDatabase,
                         constraintId,
                         constraintId,
-                        "CONSTRAINT")
+                        "CONSTRAINT",
+                        excludeEntityIds)
                 .map(propagated -> AffectedMappingResponse.of(
                         request,
                         request.getDatabase(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IdMappings.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IdMappings.java
@@ -1,0 +1,16 @@
+package com.schemafy.core.erd.service;
+
+import java.util.Map;
+
+public record IdMappings(
+        Map<String, String> schemas,
+        Map<String, String> tables,
+        Map<String, String> columns,
+        Map<String, String> indexes,
+        Map<String, String> indexColumns,
+        Map<String, String> constraints,
+        Map<String, String> constraintColumns,
+        Map<String, String> relationships,
+        Map<String, String> relationshipColumns) {
+}
+

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IdMappings.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IdMappings.java
@@ -13,4 +13,3 @@ public record IdMappings(
         Map<String, String> relationships,
         Map<String, String> relationshipColumns) {
 }
-

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IndexService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IndexService.java
@@ -1,5 +1,7 @@
 package com.schemafy.core.erd.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
@@ -61,7 +63,7 @@ public class IndexService {
     }
 
     private Mono<Void> saveIndexColumns(
-            java.util.List<Validation.IndexColumn> columns,
+            List<Validation.IndexColumn> columns,
             String indexId) {
         return Flux.fromIterable(columns)
                 .flatMap(column -> {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IndexService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/IndexService.java
@@ -214,10 +214,11 @@ public class IndexService {
                                         .findByIndexIdAndDeletedAtIsNull(
                                                 request.getIndexId())
                                         .hasElements())
-                                .flatMap(hasRemainingColumns -> hasRemainingColumns
-                                        ? Mono.empty()
-                                        : softDeleteIndexIfExists(
-                                                request.getIndexId()))))
+                                .flatMap(
+                                        hasRemainingColumns -> hasRemainingColumns
+                                                ? Mono.empty()
+                                                : softDeleteIndexIfExists(
+                                                        request.getIndexId()))))
                 .then();
     }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
@@ -1,5 +1,8 @@
 package com.schemafy.core.erd.service;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
@@ -82,13 +85,20 @@ public class RelationshipService {
             CreateRelationshipRequestWithExtra request,
             Validation.Database updatedDatabase,
             String relationshipId) {
+        Set<String> excludeEntityIds = request.request().getRelationship()
+                .getColumnsList()
+                .stream()
+                .map(Validation.RelationshipColumn::getId)
+                .collect(Collectors.toSet());
+
         return affectedEntitiesSaver
                 .saveAffectedEntities(
                         request.request().getDatabase(),
                         updatedDatabase,
                         relationshipId,
                         relationshipId,
-                        "RELATIONSHIP")
+                        "RELATIONSHIP",
+                        excludeEntityIds)
                 .map(propagated -> AffectedMappingResponse.of(
                         request.request(),
                         request.request().getDatabase(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
@@ -1,6 +1,8 @@
 package com.schemafy.core.erd.service;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -56,13 +58,22 @@ public class RelationshipService {
                                                     .getId(),
                                             savedRelationship.getId());
 
+                            Set<String> excludePropagatedIds = request.request()
+                                    .getRelationship()
+                                    .getColumnsList()
+                                    .stream()
+                                    .map(Validation.RelationshipColumn::getId)
+                                    .collect(Collectors.toSet());
+
                             return affectedEntitiesSaver
                                     .saveAffectedEntitiesResult(
                                             request.request().getDatabase(),
                                             updatedDatabase,
                                             savedRelationship.getId(),
                                             savedRelationship.getId(),
-                                            "RELATIONSHIP")
+                                            "RELATIONSHIP",
+                                            Set.of(),
+                                            excludePropagatedIds)
                                     .map(saveResult -> {
                                         Validation.Database afterDatabase = applyRelationshipColumnMappings(
                                                 updatedDatabase,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
@@ -84,7 +84,8 @@ public class RelationshipService {
                                                         request.request()
                                                                 .getDatabase(),
                                                         afterDatabase,
-                                                        saveResult.propagated());
+                                                        saveResult
+                                                                .propagated());
                                     });
                         }));
     }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/RelationshipService.java
@@ -71,7 +71,7 @@ public class RelationshipService {
                                             updatedDatabase,
                                             savedRelationship.getId(),
                                             savedRelationship.getId(),
-                                            "RELATIONSHIP",
+                                            EntityType.RELATIONSHIP.name(),
                                             Set.of(),
                                             excludePropagatedIds)
                                     .map(saveResult -> {
@@ -199,7 +199,7 @@ public class RelationshipService {
                                             updatedDatabase,
                                             savedRelationshipColumn.getId(),
                                             request.getRelationshipId(),
-                                            "RELATIONSHIP")
+                                            EntityType.RELATIONSHIP.name())
                                     .map(propagated -> AffectedMappingResponse
                                             .of(
                                                     request,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/TableService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/TableService.java
@@ -1,8 +1,11 @@
 package com.schemafy.core.erd.service;
 
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.common.exception.ErrorCode;
@@ -17,7 +20,6 @@ import com.schemafy.core.erd.controller.dto.response.TableResponse;
 import com.schemafy.core.erd.mapper.ErdMapper;
 import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.TableRepository;
-import com.schemafy.core.erd.repository.entity.Table;
 import com.schemafy.core.validation.client.ValidationClient;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,8 @@ public class TableService {
     private final ConstraintService constraintService;
     private final IndexService indexService;
     private final RelationshipService relationshipService;
+    private final AffectedEntitiesSoftDeleter affectedEntitiesSoftDeleter;
+    private final TransactionalOperator transactionalOperator;
 
     public Mono<AffectedMappingResponse> createTable(
             CreateTableRequestWithExtra request) {
@@ -106,14 +110,143 @@ public class TableService {
     }
 
     public Mono<Void> deleteTable(Validation.DeleteTableRequest request) {
+        if (!request.hasDatabase()) {
+            return Mono.error(
+                    new BusinessException(ErrorCode.COMMON_INVALID_PARAMETER));
+        }
+
         return tableRepository
                 .findByIdAndDeletedAtIsNull(request.getTableId())
                 .switchIfEmpty(Mono.error(
                         new BusinessException(ErrorCode.ERD_TABLE_NOT_FOUND)))
-                .delayUntil(ignore -> validationClient.deleteTable(request))
-                .doOnNext(Table::delete)
-                .flatMap(tableRepository::save)
+                .flatMap(ignore -> validationClient.deleteTable(request))
+                .flatMap(afterDatabase -> transactionalOperator.transactional(
+                        syncTableDeletion(
+                                request.getDatabase(),
+                                afterDatabase,
+                                request.getTableId())))
                 .then();
+    }
+
+    private Mono<Void> syncTableDeletion(
+            Validation.Database before,
+            Validation.Database after,
+            String deletedTableId) {
+        ValidationDatabaseEntityIds beforeIds = ValidationDatabaseEntityIds
+                .from(before);
+        ValidationDatabaseEntityIds afterIds = ValidationDatabaseEntityIds
+                .from(after);
+
+        Set<String> removedRelationshipColumns = difference(
+                beforeIds.relationshipColumns(),
+                afterIds.relationshipColumns());
+        Set<String> removedConstraintColumns = difference(
+                beforeIds.constraintColumns(),
+                afterIds.constraintColumns());
+        Set<String> removedIndexColumns = difference(
+                beforeIds.indexColumns(),
+                afterIds.indexColumns());
+        Set<String> removedRelationships = difference(beforeIds.relationships(),
+                afterIds.relationships());
+        Set<String> removedConstraints = difference(beforeIds.constraints(),
+                afterIds.constraints());
+        Set<String> removedIndexes = difference(beforeIds.indexes(),
+                afterIds.indexes());
+        Set<String> removedColumns = difference(beforeIds.columns(),
+                afterIds.columns());
+        Set<String> removedTables = difference(beforeIds.tables(),
+                afterIds.tables());
+        Set<String> removedSchemas = difference(beforeIds.schemas(),
+                afterIds.schemas());
+
+        TableOwnedEntityIds tableOwnedEntityIds = collectTableOwnedEntityIds(
+                before,
+                deletedTableId);
+        removedColumns.removeAll(tableOwnedEntityIds.columns());
+        removedIndexes.removeAll(tableOwnedEntityIds.indexes());
+        removedIndexColumns.removeAll(tableOwnedEntityIds.indexColumns());
+        removedConstraints.removeAll(tableOwnedEntityIds.constraints());
+        removedConstraintColumns.removeAll(
+                tableOwnedEntityIds.constraintColumns());
+
+        ValidationDatabaseEntityIds idsToDelete = new ValidationDatabaseEntityIds(
+                removedSchemas,
+                removedTables,
+                removedColumns,
+                removedIndexes,
+                removedIndexColumns,
+                removedConstraints,
+                removedConstraintColumns,
+                removedRelationships,
+                removedRelationshipColumns);
+        return affectedEntitiesSoftDeleter.softDeleteEntities(idsToDelete);
+    }
+
+    private static Set<String> difference(Set<String> left, Set<String> right) {
+        Set<String> result = new HashSet<>(left);
+        result.removeAll(right);
+        return result;
+    }
+
+    private record TableOwnedEntityIds(
+            Set<String> columns,
+            Set<String> indexes,
+            Set<String> indexColumns,
+            Set<String> constraints,
+            Set<String> constraintColumns) {
+    }
+
+    private static TableOwnedEntityIds collectTableOwnedEntityIds(
+            Validation.Database database,
+            String tableId) {
+        Set<String> columnIds = new HashSet<>();
+        Set<String> indexIds = new HashSet<>();
+        Set<String> indexColumnIds = new HashSet<>();
+        Set<String> constraintIds = new HashSet<>();
+        Set<String> constraintColumnIds = new HashSet<>();
+
+        for (Validation.Schema schema : database.getSchemasList()) {
+            for (Validation.Table table : schema.getTablesList()) {
+                if (!table.getId().equals(tableId)) {
+                    continue;
+                }
+
+                for (Validation.Column column : table.getColumnsList()) {
+                    columnIds.add(column.getId());
+                }
+
+                for (Validation.Index index : table.getIndexesList()) {
+                    indexIds.add(index.getId());
+                    for (Validation.IndexColumn indexColumn : index
+                            .getColumnsList()) {
+                        indexColumnIds.add(indexColumn.getId());
+                    }
+                }
+
+                for (Validation.Constraint constraint : table
+                        .getConstraintsList()) {
+                    constraintIds.add(constraint.getId());
+                    for (Validation.ConstraintColumn constraintColumn : constraint
+                            .getColumnsList()) {
+                        constraintColumnIds.add(constraintColumn.getId());
+                    }
+                }
+
+                return new TableOwnedEntityIds(
+                        columnIds,
+                        indexIds,
+                        indexColumnIds,
+                        constraintIds,
+                        constraintColumnIds);
+            }
+        }
+
+        return new TableOwnedEntityIds(
+                columnIds,
+                indexIds,
+                indexColumnIds,
+                constraintIds,
+                constraintColumnIds);
     }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/TableService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/TableService.java
@@ -1,7 +1,7 @@
 package com.schemafy.core.erd.service;
 
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseEntityIds.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseEntityIds.java
@@ -1,0 +1,80 @@
+package com.schemafy.core.erd.service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import validation.Validation;
+
+public record ValidationDatabaseEntityIds(
+        Set<String> schemas,
+        Set<String> tables,
+        Set<String> columns,
+        Set<String> indexes,
+        Set<String> indexColumns,
+        Set<String> constraints,
+        Set<String> constraintColumns,
+        Set<String> relationships,
+        Set<String> relationshipColumns) {
+
+    public static ValidationDatabaseEntityIds from(Validation.Database database) {
+        Set<String> schemas = new HashSet<>();
+        Set<String> tables = new HashSet<>();
+        Set<String> columns = new HashSet<>();
+        Set<String> indexes = new HashSet<>();
+        Set<String> indexColumns = new HashSet<>();
+        Set<String> constraints = new HashSet<>();
+        Set<String> constraintColumns = new HashSet<>();
+        Set<String> relationships = new HashSet<>();
+        Set<String> relationshipColumns = new HashSet<>();
+
+        for (Validation.Schema schema : database.getSchemasList()) {
+            schemas.add(schema.getId());
+
+            for (Validation.Table table : schema.getTablesList()) {
+                tables.add(table.getId());
+
+                for (Validation.Column column : table.getColumnsList()) {
+                    columns.add(column.getId());
+                }
+
+                for (Validation.Index index : table.getIndexesList()) {
+                    indexes.add(index.getId());
+                    for (Validation.IndexColumn indexColumn : index
+                            .getColumnsList()) {
+                        indexColumns.add(indexColumn.getId());
+                    }
+                }
+
+                for (Validation.Constraint constraint : table
+                        .getConstraintsList()) {
+                    constraints.add(constraint.getId());
+                    for (Validation.ConstraintColumn constraintColumn : constraint
+                            .getColumnsList()) {
+                        constraintColumns.add(constraintColumn.getId());
+                    }
+                }
+
+                for (Validation.Relationship relationship : table
+                        .getRelationshipsList()) {
+                    relationships.add(relationship.getId());
+                    for (Validation.RelationshipColumn relationshipColumn : relationship
+                            .getColumnsList()) {
+                        relationshipColumns.add(relationshipColumn.getId());
+                    }
+                }
+            }
+        }
+
+        return new ValidationDatabaseEntityIds(
+                schemas,
+                tables,
+                columns,
+                indexes,
+                indexColumns,
+                constraints,
+                constraintColumns,
+                relationships,
+                relationshipColumns);
+    }
+}
+

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseEntityIds.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseEntityIds.java
@@ -16,7 +16,8 @@ public record ValidationDatabaseEntityIds(
         Set<String> relationships,
         Set<String> relationshipColumns) {
 
-    public static ValidationDatabaseEntityIds from(Validation.Database database) {
+    public static ValidationDatabaseEntityIds from(
+            Validation.Database database) {
         Set<String> schemas = new HashSet<>();
         Set<String> tables = new HashSet<>();
         Set<String> columns = new HashSet<>();
@@ -76,5 +77,5 @@ public record ValidationDatabaseEntityIds(
                 relationships,
                 relationshipColumns);
     }
-}
 
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriter.java
@@ -1,0 +1,172 @@
+package com.schemafy.core.erd.service;
+
+import java.util.Map;
+
+import validation.Validation;
+
+public final class ValidationDatabaseIdRewriter {
+
+    private ValidationDatabaseIdRewriter() {
+    }
+
+    public static Validation.Database rewrite(
+            Validation.Database database,
+            IdMappings idMappings) {
+        Validation.Database.Builder dbBuilder = database.toBuilder();
+        dbBuilder.clearSchemas();
+
+        for (Validation.Schema schema : database.getSchemasList()) {
+            Validation.Schema.Builder schemaBuilder = schema.toBuilder();
+            schemaBuilder.setId(remapId(schema.getId(), idMappings.schemas()));
+            schemaBuilder.clearTables();
+
+            for (Validation.Table table : schema.getTablesList()) {
+                Validation.Table.Builder tableBuilder = table.toBuilder();
+                tableBuilder
+                        .setId(remapId(table.getId(), idMappings.tables()));
+                tableBuilder.setSchemaId(
+                        remapId(table.getSchemaId(), idMappings.schemas()));
+
+                tableBuilder.clearColumns();
+                for (Validation.Column column : table.getColumnsList()) {
+                    tableBuilder.addColumns(rewriteColumn(column, idMappings));
+                }
+
+                tableBuilder.clearIndexes();
+                for (Validation.Index index : table.getIndexesList()) {
+                    tableBuilder.addIndexes(rewriteIndex(index, idMappings));
+                }
+
+                tableBuilder.clearConstraints();
+                for (Validation.Constraint constraint : table
+                        .getConstraintsList()) {
+                    tableBuilder
+                            .addConstraints(rewriteConstraint(constraint,
+                                    idMappings));
+                }
+
+                tableBuilder.clearRelationships();
+                for (Validation.Relationship relationship : table
+                        .getRelationshipsList()) {
+                    tableBuilder.addRelationships(rewriteRelationship(
+                            relationship,
+                            idMappings));
+                }
+
+                schemaBuilder.addTables(tableBuilder.build());
+            }
+
+            dbBuilder.addSchemas(schemaBuilder.build());
+        }
+
+        return dbBuilder.build();
+    }
+
+    private static Validation.Column rewriteColumn(
+            Validation.Column column,
+            IdMappings idMappings) {
+        return column.toBuilder()
+                .setId(remapId(column.getId(), idMappings.columns()))
+                .setTableId(remapId(column.getTableId(), idMappings.tables()))
+                .build();
+    }
+
+    private static Validation.Index rewriteIndex(
+            Validation.Index index,
+            IdMappings idMappings) {
+        Validation.Index.Builder builder = index.toBuilder()
+                .setId(remapId(index.getId(), idMappings.indexes()))
+                .setTableId(remapId(index.getTableId(), idMappings.tables()));
+
+        builder.clearColumns();
+        for (Validation.IndexColumn indexColumn : index.getColumnsList()) {
+            builder.addColumns(rewriteIndexColumn(indexColumn, idMappings));
+        }
+
+        return builder.build();
+    }
+
+    private static Validation.IndexColumn rewriteIndexColumn(
+            Validation.IndexColumn indexColumn,
+            IdMappings idMappings) {
+        return indexColumn.toBuilder()
+                .setId(remapId(indexColumn.getId(), idMappings.indexColumns()))
+                .setIndexId(
+                        remapId(indexColumn.getIndexId(), idMappings.indexes()))
+                .setColumnId(remapId(indexColumn.getColumnId(),
+                        idMappings.columns()))
+                .build();
+    }
+
+    private static Validation.Constraint rewriteConstraint(
+            Validation.Constraint constraint,
+            IdMappings idMappings) {
+        Validation.Constraint.Builder builder = constraint.toBuilder()
+                .setId(remapId(constraint.getId(), idMappings.constraints()))
+                .setTableId(
+                        remapId(constraint.getTableId(), idMappings.tables()));
+
+        builder.clearColumns();
+        for (Validation.ConstraintColumn constraintColumn : constraint
+                .getColumnsList()) {
+            builder.addColumns(
+                    rewriteConstraintColumn(constraintColumn, idMappings));
+        }
+
+        return builder.build();
+    }
+
+    private static Validation.ConstraintColumn rewriteConstraintColumn(
+            Validation.ConstraintColumn constraintColumn,
+            IdMappings idMappings) {
+        return constraintColumn.toBuilder()
+                .setId(remapId(constraintColumn.getId(),
+                        idMappings.constraintColumns()))
+                .setConstraintId(remapId(constraintColumn.getConstraintId(),
+                        idMappings.constraints()))
+                .setColumnId(remapId(constraintColumn.getColumnId(),
+                        idMappings.columns()))
+                .build();
+    }
+
+    private static Validation.Relationship rewriteRelationship(
+            Validation.Relationship relationship,
+            IdMappings idMappings) {
+        Validation.Relationship.Builder builder = relationship.toBuilder()
+                .setId(remapId(relationship.getId(), idMappings.relationships()))
+                .setSrcTableId(remapId(relationship.getSrcTableId(),
+                        idMappings.tables()))
+                .setTgtTableId(remapId(relationship.getTgtTableId(),
+                        idMappings.tables()));
+
+        builder.clearColumns();
+        for (Validation.RelationshipColumn relationshipColumn : relationship
+                .getColumnsList()) {
+            builder.addColumns(rewriteRelationshipColumn(relationshipColumn,
+                    idMappings));
+        }
+
+        return builder.build();
+    }
+
+    private static Validation.RelationshipColumn rewriteRelationshipColumn(
+            Validation.RelationshipColumn relationshipColumn,
+            IdMappings idMappings) {
+        return relationshipColumn.toBuilder()
+                .setId(remapId(relationshipColumn.getId(),
+                        idMappings.relationshipColumns()))
+                .setRelationshipId(remapId(relationshipColumn.getRelationshipId(),
+                        idMappings.relationships()))
+                .setFkColumnId(remapId(relationshipColumn.getFkColumnId(),
+                        idMappings.columns()))
+                .setRefColumnId(remapId(relationshipColumn.getRefColumnId(),
+                        idMappings.columns()))
+                .build();
+    }
+
+    private static String remapId(String originalId, Map<String, String> idMap) {
+        String mappedId = idMap.get(originalId);
+        return mappedId != null ? mappedId : originalId;
+    }
+}
+

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriter.java
@@ -6,8 +6,7 @@ import validation.Validation;
 
 public final class ValidationDatabaseIdRewriter {
 
-    private ValidationDatabaseIdRewriter() {
-    }
+    private ValidationDatabaseIdRewriter() {}
 
     public static Validation.Database rewrite(
             Validation.Database database,
@@ -133,7 +132,8 @@ public final class ValidationDatabaseIdRewriter {
             Validation.Relationship relationship,
             IdMappings idMappings) {
         Validation.Relationship.Builder builder = relationship.toBuilder()
-                .setId(remapId(relationship.getId(), idMappings.relationships()))
+                .setId(remapId(relationship.getId(),
+                        idMappings.relationships()))
                 .setSrcTableId(remapId(relationship.getSrcTableId(),
                         idMappings.tables()))
                 .setTgtTableId(remapId(relationship.getTgtTableId(),
@@ -155,8 +155,9 @@ public final class ValidationDatabaseIdRewriter {
         return relationshipColumn.toBuilder()
                 .setId(remapId(relationshipColumn.getId(),
                         idMappings.relationshipColumns()))
-                .setRelationshipId(remapId(relationshipColumn.getRelationshipId(),
-                        idMappings.relationships()))
+                .setRelationshipId(
+                        remapId(relationshipColumn.getRelationshipId(),
+                                idMappings.relationships()))
                 .setFkColumnId(remapId(relationshipColumn.getFkColumnId(),
                         idMappings.columns()))
                 .setRefColumnId(remapId(relationshipColumn.getRefColumnId(),
@@ -164,9 +165,10 @@ public final class ValidationDatabaseIdRewriter {
                 .build();
     }
 
-    private static String remapId(String originalId, Map<String, String> idMap) {
+    private static String remapId(String originalId,
+            Map<String, String> idMap) {
         String mappedId = idMap.get(originalId);
         return mappedId != null ? mappedId : originalId;
     }
-}
 
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ColumnControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ColumnControllerTest.java
@@ -143,6 +143,7 @@ class ColumnControllerTest {
                                                 "relationshipColumns": {},
                                                 "propagated": {
                                                     "columns": [],
+                                                    "relationshipColumns": [],
                                                     "constraintColumns": [],
                                                     "indexColumns": []
                                                 }
@@ -237,6 +238,9 @@ class ColumnControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ConstraintControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ConstraintControllerTest.java
@@ -253,6 +253,9 @@ class ConstraintControllerTest {
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
                                 fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
+                                fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),
                                 fieldWithPath("result.propagated.indexColumns")
@@ -669,6 +672,9 @@ class ConstraintControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/IndexControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/IndexControllerTest.java
@@ -166,6 +166,7 @@ class IndexControllerTest {
                     "relationshipColumns": {},
                     "propagated": {
                         "columns": [],
+                        "relationshipColumns": [],
                         "constraintColumns": [],
                         "indexColumns": []
                     }
@@ -257,6 +258,9 @@ class IndexControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
@@ -164,6 +164,7 @@ class RelationshipControllerTest {
                     },
                     "propagated": {
                         "columns": [],
+                        "relationshipColumns": [],
                         "constraintColumns": [],
                         "indexColumns": []
                     }
@@ -270,6 +271,9 @@ class RelationshipControllerTest {
                                 fieldWithPath("result.propagated.columns")
                                         .description(
                                                 "전파된 컬럼 목록 (식별 관계 시 자식 테이블로 전파)"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),
@@ -963,6 +967,9 @@ class RelationshipControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/SchemaControllerTest.java
@@ -122,6 +122,7 @@ class SchemaControllerTest {
                                                 "relationshipColumns": {},
                                                 "propagated": {
                                                     "columns": [],
+                                                    "relationshipColumns": [],
                                                     "constraintColumns": [],
                                                     "indexColumns": []
                                                 }
@@ -199,6 +200,9 @@ class SchemaControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/TableControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/TableControllerTest.java
@@ -152,6 +152,7 @@ class TableControllerTest {
                                                 "relationshipColumns": {},
                                                 "propagated": {
                                                     "columns": [],
+                                                    "relationshipColumns": [],
                                                     "constraintColumns": [],
                                                     "indexColumns": []
                                                 }
@@ -229,6 +230,9 @@ class TableControllerTest {
                                         .description("전파된 엔티티 정보"),
                                 fieldWithPath("result.propagated.columns")
                                         .description("전파된 컬럼 목록"),
+                                fieldWithPath(
+                                        "result.propagated.relationshipColumns")
+                                        .description("전파된 관계 컬럼 목록"),
                                 fieldWithPath(
                                         "result.propagated.constraintColumns")
                                         .description("전파된 제약조건 컬럼 목록"),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
@@ -21,6 +21,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.security.WithMockCustomUser;
+import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintRepository;
@@ -128,9 +129,9 @@ class PropagationE2ETest {
         assertThat(propagated.path("indexColumns")).isEmpty();
 
         assertThat(state.propagatedColumnId()).isNotBlank();
-        assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
-        assertThat(state.propagatedSourceId())
-                .isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceType())
+                .isEqualTo(EntityType.RELATIONSHIP.name());
+        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
         assertThat(state.propagatedConstraintId()).isNotBlank();
@@ -158,9 +159,9 @@ class PropagationE2ETest {
 
         assertThat(state.propagatedConstraintId()).isEmpty();
         assertThat(state.propagatedConstraintColumnId()).isEmpty();
-        assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
-        assertThat(state.propagatedSourceId())
-                .isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceType())
+                .isEqualTo(EntityType.RELATIONSHIP.name());
+        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
     }
@@ -608,7 +609,7 @@ class PropagationE2ETest {
         JsonNode propagatedColumn = propagated.path("columns").get(0);
         String propagatedColumnId = propagatedColumn.path("columnId").asText();
         assertThat(propagatedColumn.path("sourceType").asText())
-                .isEqualTo("CONSTRAINT");
+                .isEqualTo(EntityType.CONSTRAINT.name());
         assertThat(propagatedColumn.path("sourceId").asText())
                 .isEqualTo(state.parentPkId());
         assertThat(propagatedColumn.path("sourceColumnId").asText())

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
@@ -131,7 +131,8 @@ class PropagationE2ETest {
         assertThat(state.propagatedColumnId()).isNotBlank();
         assertThat(state.propagatedSourceType())
                 .isEqualTo(EntityType.RELATIONSHIP.name());
-        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceId())
+                .isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
         assertThat(state.propagatedConstraintId()).isNotBlank();
@@ -161,7 +162,8 @@ class PropagationE2ETest {
         assertThat(state.propagatedConstraintColumnId()).isEmpty();
         assertThat(state.propagatedSourceType())
                 .isEqualTo(EntityType.RELATIONSHIP.name());
-        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceId())
+                .isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
@@ -1,0 +1,1233 @@
+package com.schemafy.core.erd.e2e;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Message;
+import com.google.protobuf.util.JsonFormat;
+import com.schemafy.core.common.constant.ApiPath;
+import com.schemafy.core.common.security.WithMockCustomUser;
+import com.schemafy.core.erd.repository.ColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintRepository;
+import com.schemafy.core.erd.repository.IndexColumnRepository;
+import com.schemafy.core.erd.repository.IndexRepository;
+import com.schemafy.core.erd.repository.RelationshipColumnRepository;
+import com.schemafy.core.erd.repository.RelationshipRepository;
+import com.schemafy.core.erd.repository.SchemaRepository;
+import com.schemafy.core.erd.repository.TableRepository;
+
+import validation.Validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+@DisplayName("Relationship propagation e2e")
+@WithMockCustomUser(roles = "EDITOR")
+class PropagationE2ETest {
+
+    private static final String API_BASE_PATH = ApiPath.API
+            .replace("{version}", "v1.0");
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules();
+
+    private static final String DATABASE_ID = "06DM1EE3B0GWCZR6WX47EPMDNW";
+    private static final String SCHEMA_REQUEST_ID = "06DM1EF33VJGYMTJ14CB2KW9E4";
+    private static final String PARENT_TABLE_REQUEST_ID = "06DM1ERGQ1PAJ8XJVVCWANCTWC";
+    private static final String CHILD_TABLE_REQUEST_ID = "06DM1EWQ8NR2TYSR60GY6YC9M0";
+    private static final String PARENT_COLUMN_REQUEST_ID = "06DM1GXTA463ZRJQ9Z49TY5D04";
+    private static final String CHILD_COLUMN_REQUEST_ID = "06DM1HFV32RT0EXAHPNSWZWJ0M";
+    private static final String PK_REQUEST_ID = "06DM1HZK016R3YBN6WBF9TQJ8C";
+    private static final String PK_COLUMN_REQUEST_ID = "06DM1J80MTQ0JDAY9ADJGDXVHR";
+    private static final String RELATIONSHIP_REQUEST_ID = "06DM1ZF4PN20Q564N19VABPGPG";
+    private static final String REL_COLUMN_REQUEST_ID = "06DM1ZWBFSJ98RXF6PPA3XKFPC";
+    private static final String FK_COLUMN_REQUEST_ID = "06DM236JPDCG17FN6TC0ZNMFNC";
+    private static final String EXTRA_PARENT_COLUMN_REQUEST_ID = "06DM1GXTA463ZRJQ9Z49TY5D05";
+    private static final String EXTRA_PARENT_PK_COLUMN_REQUEST_ID = "06DM1J80MTQ0JDAY9ADJGDXVHS";
+    private static final String REL_EXTRA_PARENT_COLUMN_REQUEST_ID = "06DM1GXTA463ZRJQ9Z49TY5D06";
+    private static final String REL_EXTRA_CHILD_COLUMN_REQUEST_ID = "06DM1HFV32RT0EXAHPNSWZWJ0N";
+    private static final String REL_EXTRA_REL_COLUMN_REQUEST_ID = "06DM1ZWBFSJ98RXF6PPA3XKFPE";
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private SchemaRepository schemaRepository;
+
+    @Autowired
+    private TableRepository tableRepository;
+
+    @Autowired
+    private ColumnRepository columnRepository;
+
+    @Autowired
+    private IndexRepository indexRepository;
+
+    @Autowired
+    private IndexColumnRepository indexColumnRepository;
+
+    @Autowired
+    private ConstraintRepository constraintRepository;
+
+    @Autowired
+    private ConstraintColumnRepository constraintColumnRepository;
+
+    @Autowired
+    private RelationshipRepository relationshipRepository;
+
+    @Autowired
+    private RelationshipColumnRepository relationshipColumnRepository;
+
+    @BeforeEach
+    void resetDatabase() {
+        relationshipColumnRepository.deleteAll().block();
+        relationshipRepository.deleteAll().block();
+        constraintColumnRepository.deleteAll().block();
+        constraintRepository.deleteAll().block();
+        indexColumnRepository.deleteAll().block();
+        indexRepository.deleteAll().block();
+        columnRepository.deleteAll().block();
+        tableRepository.deleteAll().block();
+        schemaRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("IDENTIFYING 관계 생성 시 전파/매핑이 정상 반환된다")
+    void identifyingRelationshipMappingFlow() throws Exception {
+        SetupResult setup = setupIdentifyingRelationship();
+        SetupState state = setup.state();
+        JsonNode propagated = setup.relationshipResponse().path("result")
+                .path("propagated");
+
+        assertThat(state.relationshipId()).isNotBlank()
+                .isNotEqualTo(RELATIONSHIP_REQUEST_ID);
+        assertThat(state.relationshipColumnId()).isNotBlank()
+                .isNotEqualTo(REL_COLUMN_REQUEST_ID);
+
+        assertThat(propagated.path("columns")).hasSize(1);
+        assertThat(propagated.path("constraints")).hasSize(1);
+        assertThat(propagated.path("constraintColumns")).hasSize(1);
+        assertThat(propagated.path("relationshipColumns")).isEmpty();
+        assertThat(propagated.path("indexColumns")).isEmpty();
+
+        assertThat(state.propagatedColumnId()).isNotBlank();
+        assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
+        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceColumnId())
+                .isEqualTo(state.parentColumnId());
+        assertThat(state.propagatedConstraintId()).isNotBlank();
+        assertThat(state.propagatedConstraintColumnId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("NON_IDENTIFYING 관계 생성 시 전파가 컬럼만 반환된다")
+    void nonIdentifyingRelationshipMappingFlow() throws Exception {
+        SetupResult setup = setupNonIdentifyingRelationship();
+        SetupState state = setup.state();
+        JsonNode propagated = setup.relationshipResponse().path("result")
+                .path("propagated");
+
+        assertThat(state.relationshipId()).isNotBlank()
+                .isNotEqualTo(RELATIONSHIP_REQUEST_ID);
+        assertThat(state.relationshipColumnId()).isNotBlank()
+                .isNotEqualTo(REL_COLUMN_REQUEST_ID);
+
+        assertThat(propagated.path("columns")).hasSize(1);
+        assertThat(propagated.path("constraints")).isEmpty();
+        assertThat(propagated.path("constraintColumns")).isEmpty();
+        assertThat(propagated.path("relationshipColumns")).isEmpty();
+        assertThat(propagated.path("indexColumns")).isEmpty();
+
+        assertThat(state.propagatedConstraintId()).isEmpty();
+        assertThat(state.propagatedConstraintColumnId()).isEmpty();
+        assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
+        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceColumnId())
+                .isEqualTo(state.parentColumnId());
+    }
+
+    @Test
+    @DisplayName("관계 삭제 시 전파된 컬럼/제약조건이 제거된다")
+    void deleteRelationshipRemovesPropagatedEntities() throws Exception {
+        SetupState state = setupIdentifyingRelationship().state();
+
+        Validation.Database database = buildDatabaseWithRelationship(state);
+        Validation.DeleteRelationshipRequest deleteRequest = Validation.DeleteRelationshipRequest
+                .newBuilder()
+                .setDatabase(database)
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/relationships/" + state.relationshipId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+        JsonNode relationships = childTableResponse.path("result")
+                .path("relationships");
+
+        assertThat(containsId(columns, state.childColumnId())).isTrue();
+        assertThat(containsId(columns, state.propagatedColumnId())).isFalse();
+        assertThat(containsId(constraints, state.propagatedConstraintId()))
+                .isFalse();
+        assertThat(relationships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("NON_IDENTIFYING 관계 컬럼 추가 시 제약은 변경되지 않는다")
+    void addRelationshipColumnDoesNotChangeConstraints() throws Exception {
+        SetupState state = setupNonIdentifyingRelationship().state();
+
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildChildTableWithRelationship(state);
+
+        JsonNode extraParentResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(state.schemaId(),
+                        state.parentTableId(),
+                        REL_EXTRA_PARENT_COLUMN_REQUEST_ID, "code", 2, false,
+                        List.of(parentTable, childTable))));
+        String extraParentColumnId = extractNestedMapping(extraParentResponse,
+                "columns", state.parentTableId(),
+                REL_EXTRA_PARENT_COLUMN_REQUEST_ID);
+
+        Validation.Table parentWithExtra = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true),
+                        buildColumn(extraParentColumnId,
+                                state.parentTableId(), "code", 2, false)));
+
+        JsonNode extraChildResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(state.schemaId(),
+                        state.childTableId(),
+                        REL_EXTRA_CHILD_COLUMN_REQUEST_ID, "parent_code", 3,
+                        false,
+                        List.of(parentWithExtra, childTable))));
+        String extraChildColumnId = extractNestedMapping(extraChildResponse,
+                "columns", state.childTableId(),
+                REL_EXTRA_CHILD_COLUMN_REQUEST_ID);
+
+        Validation.RelationshipColumn extraRelationshipColumn = buildRelationshipColumn(
+                REL_EXTRA_REL_COLUMN_REQUEST_ID, state.relationshipId(),
+                extraChildColumnId, extraParentColumnId, 2);
+        Validation.Relationship existingRelationship = buildRelationship(state,
+                List.of(buildRelationshipColumn(state.relationshipColumnId(),
+                        state.relationshipId(), state.propagatedColumnId(),
+                        state.parentColumnId(), 1)));
+
+        Validation.Table childWithExtra = buildTable(state.childTableId(),
+                state.schemaId(), "child",
+                List.of(buildColumn(state.childColumnId(),
+                        state.childTableId(), "id", 1, true),
+                        buildColumn(state.propagatedColumnId(),
+                                state.childTableId(), "parent_id", 2, false),
+                        buildColumn(extraChildColumnId,
+                                state.childTableId(), "parent_code", 3,
+                                false)),
+                List.of(), List.of(existingRelationship));
+
+        Validation.AddColumnToRelationshipRequest addRequest = Validation.AddColumnToRelationshipRequest
+                .newBuilder()
+                .setDatabase(buildDatabase(state.schemaId(),
+                        List.of(parentWithExtra, childWithExtra)))
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .setRelationshipColumn(extraRelationshipColumn)
+                .build();
+
+        JsonNode addResponse = postJson(
+                "/relationships/" + state.relationshipId() + "/columns",
+                toJson(addRequest));
+
+        String mappedRelationshipColumnId = extractNestedMapping(addResponse,
+                "relationshipColumns", state.relationshipId(),
+                REL_EXTRA_REL_COLUMN_REQUEST_ID);
+        assertThat(mappedRelationshipColumnId).isNotBlank()
+                .isNotEqualTo(REL_EXTRA_REL_COLUMN_REQUEST_ID);
+
+        JsonNode propagated = addResponse.path("result").path("propagated");
+        assertThat(propagated.path("columns")).isEmpty();
+        assertThat(propagated.path("constraints")).isEmpty();
+        assertThat(propagated.path("constraintColumns")).isEmpty();
+        assertThat(propagated.path("relationshipColumns")).isEmpty();
+        assertThat(propagated.path("indexColumns")).isEmpty();
+
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode relationships = childTableResponse.path("result")
+                .path("relationships");
+        assertThat(relationshipColumnCount(relationships)).isEqualTo(2);
+        assertThat(containsRelationshipColumn(relationships, extraChildColumnId,
+                extraParentColumnId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("NON_IDENTIFYING 관계 컬럼 삭제 시 FK 컬럼만 제거된다")
+    void removeRelationshipColumnDoesNotChangeConstraints() throws Exception {
+        SetupState state = setupNonIdentifyingRelationship().state();
+
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildChildTableWithRelationship(state);
+
+        JsonNode extraParentResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(state.schemaId(),
+                        state.parentTableId(),
+                        REL_EXTRA_PARENT_COLUMN_REQUEST_ID, "code", 2, false,
+                        List.of(parentTable, childTable))));
+        String extraParentColumnId = extractNestedMapping(extraParentResponse,
+                "columns", state.parentTableId(),
+                REL_EXTRA_PARENT_COLUMN_REQUEST_ID);
+
+        Validation.Table parentWithExtra = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true),
+                        buildColumn(extraParentColumnId,
+                                state.parentTableId(), "code", 2, false)));
+
+        JsonNode extraChildResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(state.schemaId(),
+                        state.childTableId(),
+                        REL_EXTRA_CHILD_COLUMN_REQUEST_ID, "parent_code", 3,
+                        false,
+                        List.of(parentWithExtra, childTable))));
+        String extraChildColumnId = extractNestedMapping(extraChildResponse,
+                "columns", state.childTableId(),
+                REL_EXTRA_CHILD_COLUMN_REQUEST_ID);
+
+        Validation.RelationshipColumn extraRelationshipColumn = buildRelationshipColumn(
+                REL_EXTRA_REL_COLUMN_REQUEST_ID, state.relationshipId(),
+                extraChildColumnId, extraParentColumnId, 2);
+        Validation.Relationship existingRelationship = buildRelationship(state,
+                List.of(buildRelationshipColumn(state.relationshipColumnId(),
+                        state.relationshipId(), state.propagatedColumnId(),
+                        state.parentColumnId(), 1)));
+
+        Validation.Table childWithExtra = buildTable(state.childTableId(),
+                state.schemaId(), "child",
+                List.of(buildColumn(state.childColumnId(),
+                        state.childTableId(), "id", 1, true),
+                        buildColumn(state.propagatedColumnId(),
+                                state.childTableId(), "parent_id", 2, false),
+                        buildColumn(extraChildColumnId,
+                                state.childTableId(), "parent_code", 3,
+                                false)),
+                List.of(), List.of(existingRelationship));
+
+        Validation.AddColumnToRelationshipRequest addRequest = Validation.AddColumnToRelationshipRequest
+                .newBuilder()
+                .setDatabase(buildDatabase(state.schemaId(),
+                        List.of(parentWithExtra, childWithExtra)))
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .setRelationshipColumn(extraRelationshipColumn)
+                .build();
+
+        JsonNode addResponse = postJson(
+                "/relationships/" + state.relationshipId() + "/columns",
+                toJson(addRequest));
+        String mappedRelationshipColumnId = extractNestedMapping(addResponse,
+                "relationshipColumns", state.relationshipId(),
+                REL_EXTRA_REL_COLUMN_REQUEST_ID);
+
+        Validation.Relationship updatedRelationship = buildRelationship(state,
+                List.of(buildRelationshipColumn(state.relationshipColumnId(),
+                        state.relationshipId(), state.propagatedColumnId(),
+                        state.parentColumnId(), 1),
+                        buildRelationshipColumn(mappedRelationshipColumnId,
+                                state.relationshipId(), extraChildColumnId,
+                                extraParentColumnId, 2)));
+
+        Validation.Table childWithRelationshipColumns = buildTable(
+                state.childTableId(),
+                state.schemaId(),
+                "child",
+                List.of(buildColumn(state.childColumnId(),
+                        state.childTableId(), "id", 1, true),
+                        buildColumn(state.propagatedColumnId(),
+                                state.childTableId(), "parent_id", 2, false),
+                        buildColumn(extraChildColumnId,
+                                state.childTableId(), "parent_code", 3,
+                                false)),
+                List.of(),
+                List.of(updatedRelationship));
+
+        Validation.RemoveColumnFromRelationshipRequest removeRequest = Validation.RemoveColumnFromRelationshipRequest
+                .newBuilder()
+                .setDatabase(buildDatabase(state.schemaId(),
+                        List.of(parentWithExtra,
+                                childWithRelationshipColumns)))
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .setRelationshipColumnId(mappedRelationshipColumnId)
+                .build();
+
+        JsonNode removeResponse = deleteJson(
+                "/relationships/" + state.relationshipId() + "/columns/"
+                        + mappedRelationshipColumnId,
+                toJson(removeRequest));
+        assertThat(removeResponse.path("success").asBoolean()).isTrue();
+
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+        JsonNode relationships = childTableResponse.path("result")
+                .path("relationships");
+
+        assertThat(containsId(columns, extraChildColumnId)).isFalse();
+        assertThat(constraints).isEmpty();
+        assertThat(relationshipColumnCount(relationships)).isEqualTo(1);
+        assertThat(containsRelationshipColumn(relationships,
+                state.propagatedColumnId(), state.parentColumnId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("IDENTIFYING -> NON_IDENTIFYING 전환 시 제약 전파가 제거된다")
+    void changeRelationshipKindToNonIdentifying() throws Exception {
+        SetupState state = setupIdentifyingRelationship().state();
+
+        Validation.DeleteRelationshipRequest deleteRequest = Validation.DeleteRelationshipRequest
+                .newBuilder()
+                .setDatabase(buildDatabaseWithRelationship(state))
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/relationships/" + state.relationshipId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildTable(state.childTableId(),
+                state.schemaId(), "child",
+                List.of(buildColumn(state.childColumnId(),
+                        state.childTableId(), "id", 1, true)),
+                List.of(), List.of());
+
+        JsonNode createResponse = postJson("/relationships",
+                toJson(buildCreateRelationshipRequest(state.schemaId(),
+                        state.parentTableId(), state.childTableId(),
+                        state.parentColumnId(),
+                        Validation.RelationshipKind.NON_IDENTIFYING,
+                        List.of(parentTable, childTable))));
+
+        JsonNode propagated = createResponse.path("result").path("propagated");
+        assertThat(propagated.path("columns")).hasSize(1);
+        assertThat(propagated.path("constraints")).isEmpty();
+        assertThat(propagated.path("constraintColumns")).isEmpty();
+
+        String newFkColumnId = propagated.path("columns").get(0)
+                .path("columnId").asText();
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+
+        assertThat(containsId(columns, state.childColumnId())).isTrue();
+        assertThat(containsId(columns, newFkColumnId)).isTrue();
+        assertThat(constraints).isEmpty();
+    }
+
+    @Test
+    @DisplayName("NON_IDENTIFYING -> IDENTIFYING 전환 시 제약 전파가 생성된다")
+    void changeRelationshipKindToIdentifying() throws Exception {
+        SetupState state = setupNonIdentifyingRelationship().state();
+
+        Validation.DeleteRelationshipRequest deleteRequest = Validation.DeleteRelationshipRequest
+                .newBuilder()
+                .setDatabase(buildDatabaseWithRelationship(state))
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/relationships/" + state.relationshipId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildTable(state.childTableId(),
+                state.schemaId(), "child",
+                List.of(buildColumn(state.childColumnId(),
+                        state.childTableId(), "id", 1, true)),
+                List.of(), List.of());
+
+        JsonNode createResponse = postJson("/relationships",
+                toJson(buildCreateRelationshipRequest(state.schemaId(),
+                        state.parentTableId(), state.childTableId(),
+                        state.parentColumnId(),
+                        Validation.RelationshipKind.IDENTIFYING,
+                        List.of(parentTable, childTable))));
+
+        JsonNode propagated = createResponse.path("result").path("propagated");
+        assertThat(propagated.path("columns")).hasSize(1);
+        assertThat(propagated.path("constraints")).hasSize(1);
+        assertThat(propagated.path("constraintColumns")).hasSize(1);
+
+        String newFkColumnId = propagated.path("columns").get(0)
+                .path("columnId").asText();
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+
+        assertThat(containsId(columns, state.childColumnId())).isTrue();
+        assertThat(containsId(columns, newFkColumnId)).isTrue();
+        assertThat(constraints).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("NON_IDENTIFYING 관계 삭제 시 FK 컬럼만 제거된다")
+    void deleteNonIdentifyingRelationshipRemovesFkColumn() throws Exception {
+        SetupState state = setupNonIdentifyingRelationship().state();
+
+        Validation.Database database = buildDatabaseWithRelationship(state);
+        Validation.DeleteRelationshipRequest deleteRequest = Validation.DeleteRelationshipRequest
+                .newBuilder()
+                .setDatabase(database)
+                .setSchemaId(state.schemaId())
+                .setRelationshipId(state.relationshipId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/relationships/" + state.relationshipId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+        JsonNode relationships = childTableResponse.path("result")
+                .path("relationships");
+
+        assertThat(containsId(columns, state.childColumnId())).isTrue();
+        assertThat(containsId(columns, state.propagatedColumnId())).isFalse();
+        assertThat(constraints).isEmpty();
+        assertThat(relationships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("PK 컬럼 추가 시 FK/제약조건/관계 컬럼이 전파된다")
+    void addPkColumnPropagatesToIdentifyingChild() throws Exception {
+        SetupState state = setupIdentifyingRelationship().state();
+
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildChildTableWithRelationship(state);
+
+        JsonNode extraColumnResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(state.schemaId(),
+                        state.parentTableId(),
+                        EXTRA_PARENT_COLUMN_REQUEST_ID, "code", 2, false,
+                        List.of(parentTable, childTable))));
+        String extraParentColumnId = extractNestedMapping(extraColumnResponse,
+                "columns", state.parentTableId(),
+                EXTRA_PARENT_COLUMN_REQUEST_ID);
+
+        Validation.Table parentWithExtraColumn = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true),
+                        buildColumn(extraParentColumnId,
+                                state.parentTableId(), "code", 2, false)));
+
+        Validation.AddColumnToConstraintRequest addColumnRequest = Validation.AddColumnToConstraintRequest
+                .newBuilder()
+                .setDatabase(buildDatabase(state.schemaId(),
+                        List.of(parentWithExtraColumn, childTable)))
+                .setSchemaId(state.schemaId())
+                .setTableId(state.parentTableId())
+                .setConstraintId(state.parentPkId())
+                .setConstraintColumn(Validation.ConstraintColumn.newBuilder()
+                        .setId(EXTRA_PARENT_PK_COLUMN_REQUEST_ID)
+                        .setColumnId(extraParentColumnId)
+                        .setSeqNo(2)
+                        .build())
+                .build();
+
+        JsonNode addResponse = postJson(
+                "/constraints/" + state.parentPkId() + "/columns",
+                toJson(addColumnRequest));
+
+        String mappedConstraintColumnId = extractNestedMapping(addResponse,
+                "constraintColumns", state.parentPkId(),
+                EXTRA_PARENT_PK_COLUMN_REQUEST_ID);
+        assertThat(mappedConstraintColumnId).isNotBlank()
+                .isNotEqualTo(EXTRA_PARENT_PK_COLUMN_REQUEST_ID);
+
+        JsonNode propagated = addResponse.path("result").path("propagated");
+        assertThat(propagated.path("columns")).hasSize(1);
+        assertThat(propagated.path("constraintColumns")).hasSize(1);
+        assertThat(propagated.path("relationshipColumns")).hasSize(1);
+        assertThat(propagated.path("constraints")).isEmpty();
+        assertThat(propagated.path("indexColumns")).isEmpty();
+
+        JsonNode propagatedColumn = propagated.path("columns").get(0);
+        String propagatedColumnId = propagatedColumn.path("columnId").asText();
+        assertThat(propagatedColumn.path("sourceType").asText())
+                .isEqualTo("CONSTRAINT");
+        assertThat(propagatedColumn.path("sourceId").asText())
+                .isEqualTo(state.parentPkId());
+        assertThat(propagatedColumn.path("sourceColumnId").asText())
+                .isEqualTo(extraParentColumnId);
+
+        JsonNode propagatedConstraintColumn = propagated
+                .path("constraintColumns").get(0);
+        assertThat(propagatedConstraintColumn.path("constraintId").asText())
+                .isEqualTo(state.propagatedConstraintId());
+        assertThat(propagatedConstraintColumn.path("columnId").asText())
+                .isEqualTo(propagatedColumnId);
+
+        JsonNode propagatedRelationshipColumn = propagated
+                .path("relationshipColumns").get(0);
+        assertThat(propagatedRelationshipColumn.path("relationshipId").asText())
+                .isEqualTo(state.relationshipId());
+        assertThat(propagatedRelationshipColumn.path("fkColumnId").asText())
+                .isEqualTo(propagatedColumnId);
+        assertThat(propagatedRelationshipColumn.path("refColumnId").asText())
+                .isEqualTo(extraParentColumnId);
+    }
+
+    @Test
+    @DisplayName("자식 테이블 삭제 시 관계가 정리되고 부모는 유지된다")
+    void deleteChildTableRemovesRelationshipAndColumns() throws Exception {
+        SetupState state = setupIdentifyingRelationship().state();
+        Validation.Database database = buildDatabaseWithRelationship(state);
+
+        Validation.DeleteTableRequest deleteRequest = Validation.DeleteTableRequest
+                .newBuilder()
+                .setDatabase(database)
+                .setSchemaId(state.schemaId())
+                .setTableId(state.childTableId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/tables/" + state.childTableId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        JsonNode childNotFoundResponse = getJsonExpect4xx(
+                "/tables/" + state.childTableId());
+        assertThat(childNotFoundResponse.path("success").asBoolean())
+                .isFalse();
+
+        JsonNode parentResponse = getJson(
+                "/tables/" + state.parentTableId());
+        assertThat(parentResponse.path("success").asBoolean()).isTrue();
+        assertThat(containsId(parentResponse.path("result").path("columns"),
+                state.parentColumnId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("테이블 삭제 시 관계 및 전파된 컬럼이 제거된다")
+    void deleteTableRemovesRelationshipsAndColumns() throws Exception {
+        SetupState state = setupIdentifyingRelationship().state();
+        Validation.Database database = buildDatabaseWithRelationship(state);
+
+        Validation.DeleteTableRequest deleteRequest = Validation.DeleteTableRequest
+                .newBuilder()
+                .setDatabase(database)
+                .setSchemaId(state.schemaId())
+                .setTableId(state.parentTableId())
+                .build();
+
+        JsonNode deleteResponse = deleteJson(
+                "/tables/" + state.parentTableId(),
+                toJson(deleteRequest));
+        assertThat(deleteResponse.path("success").asBoolean()).isTrue();
+
+        JsonNode childTableResponse = getJson(
+                "/tables/" + state.childTableId());
+        JsonNode columns = childTableResponse.path("result")
+                .path("columns");
+        JsonNode constraints = childTableResponse.path("result")
+                .path("constraints");
+        JsonNode relationships = childTableResponse.path("result")
+                .path("relationships");
+
+        assertThat(containsId(columns, state.childColumnId())).isTrue();
+        assertThat(containsId(columns, state.propagatedColumnId())).isFalse();
+        assertThat(containsId(constraints, state.propagatedConstraintId()))
+                .isFalse();
+        assertThat(relationships).isEmpty();
+
+        JsonNode parentNotFoundResponse = getJsonExpect4xx(
+                "/tables/" + state.parentTableId());
+        assertThat(parentNotFoundResponse.path("success").asBoolean())
+                .isFalse();
+    }
+
+    private JsonNode postJson(String path, String body) throws Exception {
+        String responseBody = webTestClient.post()
+                .uri(API_BASE_PATH + path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return objectMapper.readTree(responseBody);
+    }
+
+    private JsonNode deleteJson(String path, String body) throws Exception {
+        String responseBody = webTestClient.method(HttpMethod.DELETE)
+                .uri(API_BASE_PATH + path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return objectMapper.readTree(responseBody);
+    }
+
+    private JsonNode getJson(String path) throws Exception {
+        String responseBody = webTestClient.get()
+                .uri(API_BASE_PATH + path)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return objectMapper.readTree(responseBody);
+    }
+
+    private JsonNode getJsonExpect4xx(String path) throws Exception {
+        String responseBody = webTestClient.get()
+                .uri(API_BASE_PATH + path)
+                .exchange()
+                .expectStatus().is4xxClientError()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return objectMapper.readTree(responseBody);
+    }
+
+    private boolean containsId(JsonNode arrayNode, String id) {
+        if (arrayNode == null || !arrayNode.isArray()) {
+            return false;
+        }
+        for (JsonNode node : arrayNode) {
+            if (id.equals(node.path("id").asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsRelationshipColumn(JsonNode relationships,
+            String fkColumnId, String refColumnId) {
+        if (relationships == null || !relationships.isArray()) {
+            return false;
+        }
+        for (JsonNode relationship : relationships) {
+            JsonNode columns = relationship.path("columns");
+            if (!columns.isArray()) {
+                continue;
+            }
+            for (JsonNode column : columns) {
+                String fk = column.path("srcColumnId").asText();
+                if (fk.isEmpty()) {
+                    fk = column.path("fkColumnId").asText();
+                }
+                String ref = column.path("tgtColumnId").asText();
+                if (ref.isEmpty()) {
+                    ref = column.path("refColumnId").asText();
+                }
+                if (fkColumnId.equals(fk) && refColumnId.equals(ref)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private int relationshipColumnCount(JsonNode relationships) {
+        if (relationships == null || !relationships.isArray()) {
+            return 0;
+        }
+        int count = 0;
+        for (JsonNode relationship : relationships) {
+            JsonNode columns = relationship.path("columns");
+            if (columns.isArray()) {
+                count += columns.size();
+            }
+        }
+        return count;
+    }
+
+    private String extractMapping(JsonNode response, String field,
+            String requestId) {
+        String value = response.path("result").path(field).path(requestId)
+                .asText();
+        assertThat(value).as("mapping for %s", requestId).isNotBlank();
+        return value;
+    }
+
+    private String extractNestedMapping(JsonNode response, String field,
+            String key, String requestId) {
+        String value = response.path("result").path(field).path(key)
+                .path(requestId).asText();
+        assertThat(value).as("mapping for %s/%s", key, requestId).isNotBlank();
+        return value;
+    }
+
+    private String toJson(Message message) throws Exception {
+        return JsonFormat.printer().print(message);
+    }
+
+    private SetupResult setupIdentifyingRelationship() throws Exception {
+        return setupRelationship(Validation.RelationshipKind.IDENTIFYING);
+    }
+
+    private SetupResult setupNonIdentifyingRelationship() throws Exception {
+        return setupRelationship(Validation.RelationshipKind.NON_IDENTIFYING);
+    }
+
+    private SetupResult setupRelationship(Validation.RelationshipKind kind)
+            throws Exception {
+        JsonNode schemaResponse = postJson("/schemas",
+                toJson(buildCreateSchemaRequest()));
+        String schemaId = extractMapping(schemaResponse, "schemas",
+                SCHEMA_REQUEST_ID);
+
+        JsonNode parentTableResponse = postJson("/tables",
+                toJson(buildCreateTableRequest(schemaId,
+                        PARENT_TABLE_REQUEST_ID, "parent", List.of())));
+        String parentTableId = extractMapping(parentTableResponse, "tables",
+                PARENT_TABLE_REQUEST_ID);
+
+        Validation.Table parentTableState = buildTable(parentTableId, schemaId,
+                "parent", List.of(), List.of(), List.of());
+        JsonNode childTableResponse = postJson("/tables",
+                toJson(buildCreateTableRequest(schemaId,
+                        CHILD_TABLE_REQUEST_ID, "child",
+                        List.of(parentTableState))));
+        String childTableId = extractMapping(childTableResponse, "tables",
+                CHILD_TABLE_REQUEST_ID);
+
+        Validation.Table childTableState = buildTable(childTableId, schemaId,
+                "child", List.of(), List.of(), List.of());
+        JsonNode parentColumnResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(schemaId, parentTableId,
+                        PARENT_COLUMN_REQUEST_ID, "id", 1, true,
+                        List.of(parentTableState, childTableState))));
+        String parentColumnId = extractNestedMapping(parentColumnResponse,
+                "columns", parentTableId, PARENT_COLUMN_REQUEST_ID);
+
+        Validation.Table parentWithColumn = buildTable(parentTableId, schemaId,
+                "parent",
+                List.of(buildColumn(parentColumnId, parentTableId, "id", 1,
+                        true)),
+                List.of(), List.of());
+        JsonNode childColumnResponse = postJson("/columns",
+                toJson(buildCreateColumnRequest(schemaId, childTableId,
+                        CHILD_COLUMN_REQUEST_ID, "id", 1, true,
+                        List.of(parentWithColumn, childTableState))));
+        String childColumnId = extractNestedMapping(childColumnResponse,
+                "columns", childTableId, CHILD_COLUMN_REQUEST_ID);
+
+        Validation.Table childWithColumn = buildTable(childTableId, schemaId,
+                "child",
+                List.of(buildColumn(childColumnId, childTableId, "id", 1,
+                        true)),
+                List.of(), List.of());
+        JsonNode constraintResponse = postJson("/constraints",
+                toJson(buildCreatePkRequest(schemaId, parentTableId,
+                        parentColumnId,
+                        List.of(parentWithColumn, childWithColumn))));
+        String parentPkId = extractNestedMapping(constraintResponse,
+                "constraints", parentTableId, PK_REQUEST_ID);
+        String parentPkColumnId = extractNestedMapping(constraintResponse,
+                "constraintColumns", parentPkId, PK_COLUMN_REQUEST_ID);
+
+        Validation.Table parentWithPk = buildTable(parentTableId, schemaId,
+                "parent",
+                List.of(buildColumn(parentColumnId, parentTableId, "id", 1,
+                        true)),
+                List.of(buildPkConstraint(parentPkId, parentTableId,
+                        parentPkColumnId, parentColumnId)),
+                List.of());
+
+        JsonNode relationshipResponse = postJson("/relationships",
+                toJson(buildCreateRelationshipRequest(schemaId, parentTableId,
+                        childTableId, parentColumnId, kind,
+                        List.of(parentWithPk, childWithColumn))));
+
+        String relationshipId = extractNestedMapping(relationshipResponse,
+                "relationships", childTableId, RELATIONSHIP_REQUEST_ID);
+        String relationshipColumnId = extractNestedMapping(relationshipResponse,
+                "relationshipColumns", relationshipId, REL_COLUMN_REQUEST_ID);
+
+        JsonNode propagated = relationshipResponse.path("result")
+                .path("propagated");
+        JsonNode propagatedColumn = propagated.path("columns").get(0);
+        JsonNode constraints = propagated.path("constraints");
+        JsonNode constraintColumns = propagated.path("constraintColumns");
+
+        String propagatedConstraintId = "";
+        if (constraints.isArray() && constraints.size() > 0) {
+            propagatedConstraintId = constraints.get(0).path("constraintId")
+                    .asText();
+        }
+
+        String propagatedConstraintColumnId = "";
+        if (constraintColumns.isArray() && constraintColumns.size() > 0) {
+            propagatedConstraintColumnId = constraintColumns.get(0)
+                    .path("constraintColumnId")
+                    .asText();
+        }
+
+        SetupState state = new SetupState(
+                schemaId,
+                parentTableId,
+                childTableId,
+                parentColumnId,
+                childColumnId,
+                parentPkId,
+                parentPkColumnId,
+                relationshipId,
+                relationshipColumnId,
+                kind,
+                propagatedColumn.path("columnId").asText(),
+                propagatedConstraintId,
+                propagatedConstraintColumnId,
+                propagatedColumn.path("sourceType").asText(),
+                propagatedColumn.path("sourceId").asText(),
+                propagatedColumn.path("sourceColumnId").asText());
+
+        return new SetupResult(state, relationshipResponse);
+    }
+
+    private Validation.CreateSchemaRequest buildCreateSchemaRequest() {
+        Validation.Schema schema = Validation.Schema.newBuilder()
+                .setId(SCHEMA_REQUEST_ID)
+                .setProjectId(DATABASE_ID)
+                .setDbVendorId(Validation.DbVendor.MYSQL)
+                .setName("main")
+                .setCharset("utf8mb4")
+                .setCollation("utf8mb4_general_ci")
+                .setVendorOption("")
+                .build();
+
+        return Validation.CreateSchemaRequest.newBuilder()
+                .setDatabase(Validation.Database.newBuilder().setId(DATABASE_ID))
+                .setSchema(schema)
+                .build();
+    }
+
+    private Validation.CreateTableRequest buildCreateTableRequest(
+            String schemaId,
+            String tableId,
+            String name,
+            List<Validation.Table> existingTables) {
+        Validation.Table table = buildTable(tableId, schemaId, name, List.of(),
+                List.of(), List.of());
+        Validation.Database database = buildDatabase(schemaId, existingTables);
+        return Validation.CreateTableRequest.newBuilder()
+                .setDatabase(database)
+                .setSchemaId(schemaId)
+                .setTable(table)
+                .build();
+    }
+
+    private Validation.CreateColumnRequest buildCreateColumnRequest(
+            String schemaId,
+            String tableId,
+            String columnId,
+            String name,
+            int ordinalPosition,
+            boolean isAutoIncrement,
+            List<Validation.Table> tables) {
+        Validation.Database database = buildDatabase(schemaId, tables);
+        Validation.Column column = buildColumn(columnId, tableId, name,
+                ordinalPosition, isAutoIncrement);
+        return Validation.CreateColumnRequest.newBuilder()
+                .setDatabase(database)
+                .setSchemaId(schemaId)
+                .setTableId(tableId)
+                .setColumn(column)
+                .build();
+    }
+
+    private Validation.CreateConstraintRequest buildCreatePkRequest(
+            String schemaId,
+            String tableId,
+            String columnId,
+            List<Validation.Table> tables) {
+        Validation.ConstraintColumn constraintColumn = Validation.ConstraintColumn
+                .newBuilder()
+                .setId(PK_COLUMN_REQUEST_ID)
+                .setConstraintId(PK_REQUEST_ID)
+                .setColumnId(columnId)
+                .setSeqNo(1)
+                .build();
+
+        Validation.Constraint constraint = Validation.Constraint.newBuilder()
+                .setId(PK_REQUEST_ID)
+                .setTableId(tableId)
+                .setName("PK")
+                .setKind(Validation.ConstraintKind.PRIMARY_KEY)
+                .addColumns(constraintColumn)
+                .build();
+
+        Validation.Database database = buildDatabase(schemaId, tables);
+        return Validation.CreateConstraintRequest.newBuilder()
+                .setDatabase(database)
+                .setSchemaId(schemaId)
+                .setTableId(tableId)
+                .setConstraint(constraint)
+                .build();
+    }
+
+    private Validation.CreateRelationshipRequest buildCreateRelationshipRequest(
+            String schemaId,
+            String parentTableId,
+            String childTableId,
+            String parentColumnId,
+            Validation.RelationshipKind kind,
+            List<Validation.Table> tables) {
+        Validation.RelationshipColumn relationshipColumn = Validation.RelationshipColumn
+                .newBuilder()
+                .setId(REL_COLUMN_REQUEST_ID)
+                .setRelationshipId(RELATIONSHIP_REQUEST_ID)
+                .setFkColumnId(FK_COLUMN_REQUEST_ID)
+                .setRefColumnId(parentColumnId)
+                .setSeqNo(1)
+                .build();
+
+        Validation.Relationship relationship = Validation.Relationship
+                .newBuilder()
+                .setId(RELATIONSHIP_REQUEST_ID)
+                .setSrcTableId(childTableId)
+                .setTgtTableId(parentTableId)
+                .setName("FK_test")
+                .setKind(kind)
+                .setCardinality(
+                        Validation.RelationshipCardinality.ONE_TO_MANY)
+                .setOnDelete(Validation.RelationshipOnDelete.NO_ACTION)
+                .setOnUpdate(Validation.RelationshipOnUpdate.NO_ACTION_UPDATE)
+                .setFkEnforced(false)
+                .addColumns(relationshipColumn)
+                .build();
+
+        Validation.Database database = buildDatabase(schemaId, tables);
+        return Validation.CreateRelationshipRequest.newBuilder()
+                .setDatabase(database)
+                .setSchemaId(schemaId)
+                .setRelationship(relationship)
+                .build();
+    }
+
+    private Validation.Database buildDatabase(String schemaId,
+            List<Validation.Table> tables) {
+        Validation.Schema schema = Validation.Schema.newBuilder()
+                .setId(schemaId)
+                .setProjectId(DATABASE_ID)
+                .setDbVendorId(Validation.DbVendor.MYSQL)
+                .setName("main")
+                .setCharset("utf8mb4")
+                .setCollation("utf8mb4_general_ci")
+                .setVendorOption("")
+                .addAllTables(tables)
+                .build();
+
+        return Validation.Database.newBuilder()
+                .setId(DATABASE_ID)
+                .addSchemas(schema)
+                .build();
+    }
+
+    private Validation.Table buildTable(String tableId, String schemaId,
+            String name, List<Validation.Column> columns,
+            List<Validation.Constraint> constraints,
+            List<Validation.Relationship> relationships) {
+        return Validation.Table.newBuilder()
+                .setId(tableId)
+                .setSchemaId(schemaId)
+                .setName(name)
+                .setComment("")
+                .setTableOptions("")
+                .addAllColumns(columns)
+                .addAllConstraints(constraints)
+                .addAllRelationships(relationships)
+                .build();
+    }
+
+    private Validation.Column buildColumn(String columnId, String tableId,
+            String name, int ordinalPosition, boolean isAutoIncrement) {
+        return Validation.Column.newBuilder()
+                .setId(columnId)
+                .setTableId(tableId)
+                .setName(name)
+                .setOrdinalPosition(ordinalPosition)
+                .setDataType("INT")
+                .setIsAutoIncrement(isAutoIncrement)
+                .build();
+    }
+
+    private Validation.Constraint buildPkConstraint(String constraintId,
+            String tableId, String constraintColumnId, String columnId) {
+        return buildPkConstraint(constraintId, tableId, constraintColumnId,
+                columnId, "PK");
+    }
+
+    private Validation.Constraint buildPkConstraint(String constraintId,
+            String tableId, String constraintColumnId, String columnId,
+            String name) {
+        Validation.ConstraintColumn constraintColumn = Validation.ConstraintColumn
+                .newBuilder()
+                .setId(constraintColumnId)
+                .setConstraintId(constraintId)
+                .setColumnId(columnId)
+                .setSeqNo(1)
+                .build();
+
+        return Validation.Constraint.newBuilder()
+                .setId(constraintId)
+                .setTableId(tableId)
+                .setName(name)
+                .setKind(Validation.ConstraintKind.PRIMARY_KEY)
+                .addColumns(constraintColumn)
+                .build();
+    }
+
+    private Validation.Relationship buildRelationship(SetupState state,
+            String fkColumnId) {
+        return buildRelationship(state, List.of(buildRelationshipColumn(
+                state.relationshipColumnId(), state.relationshipId(), fkColumnId,
+                state.parentColumnId(), 1)));
+    }
+
+    private Validation.Relationship buildRelationship(SetupState state,
+            List<Validation.RelationshipColumn> columns) {
+        return Validation.Relationship.newBuilder()
+                .setId(state.relationshipId())
+                .setSrcTableId(state.childTableId())
+                .setTgtTableId(state.parentTableId())
+                .setName("FK_test")
+                .setKind(state.relationshipKind())
+                .setCardinality(
+                        Validation.RelationshipCardinality.ONE_TO_MANY)
+                .setOnDelete(Validation.RelationshipOnDelete.NO_ACTION)
+                .setOnUpdate(Validation.RelationshipOnUpdate.NO_ACTION_UPDATE)
+                .setFkEnforced(false)
+                .addAllColumns(columns)
+                .build();
+    }
+
+    private Validation.RelationshipColumn buildRelationshipColumn(String id,
+            String relationshipId, String fkColumnId, String refColumnId,
+            int seqNo) {
+        return Validation.RelationshipColumn.newBuilder()
+                .setId(id)
+                .setRelationshipId(relationshipId)
+                .setFkColumnId(fkColumnId)
+                .setRefColumnId(refColumnId)
+                .setSeqNo(seqNo)
+                .build();
+    }
+
+    private Validation.Table buildParentTableWithPk(SetupState state,
+            List<Validation.Column> columns) {
+        Validation.Constraint parentPk = buildPkConstraint(state.parentPkId(),
+                state.parentTableId(), state.parentPkColumnId(),
+                state.parentColumnId());
+        return buildTable(state.parentTableId(), state.schemaId(), "parent",
+                columns, List.of(parentPk), List.of());
+    }
+
+    private Validation.Table buildChildTableWithRelationship(SetupState state) {
+        Validation.Column childIdColumn = buildColumn(state.childColumnId(),
+                state.childTableId(), "id", 1, true);
+        Validation.Column fkColumn = buildColumn(state.propagatedColumnId(),
+                state.childTableId(), "parent_id", 2, false);
+        Validation.Relationship relationship = buildRelationship(state,
+                state.propagatedColumnId());
+        List<Validation.Constraint> constraints = List.of();
+        if (state.relationshipKind() == Validation.RelationshipKind.IDENTIFYING) {
+            Validation.Constraint childPk = buildPkConstraint(
+                    state.propagatedConstraintId(), state.childTableId(),
+                    state.propagatedConstraintColumnId(),
+                    state.propagatedColumnId(), "pk_child");
+            constraints = List.of(childPk);
+        }
+
+        return buildTable(state.childTableId(), state.schemaId(), "child",
+                List.of(childIdColumn, fkColumn),
+                constraints, List.of(relationship));
+    }
+
+    private Validation.Database buildDatabaseWithRelationship(SetupState state) {
+        Validation.Table parentTable = buildParentTableWithPk(state,
+                List.of(buildColumn(state.parentColumnId(),
+                        state.parentTableId(), "id", 1, true)));
+        Validation.Table childTable = buildChildTableWithRelationship(state);
+        return buildDatabase(state.schemaId(), List.of(parentTable, childTable));
+    }
+
+    private record SetupState(
+            String schemaId,
+            String parentTableId,
+            String childTableId,
+            String parentColumnId,
+            String childColumnId,
+            String parentPkId,
+            String parentPkColumnId,
+            String relationshipId,
+            String relationshipColumnId,
+            Validation.RelationshipKind relationshipKind,
+            String propagatedColumnId,
+            String propagatedConstraintId,
+            String propagatedConstraintColumnId,
+            String propagatedSourceType,
+            String propagatedSourceId,
+            String propagatedSourceColumnId) {
+    }
+
+    private record SetupResult(SetupState state,
+            JsonNode relationshipResponse) {
+    }
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/e2e/PropagationE2ETest.java
@@ -2,10 +2,6 @@ package com.schemafy.core.erd.e2e;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +9,11 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -128,7 +129,8 @@ class PropagationE2ETest {
 
         assertThat(state.propagatedColumnId()).isNotBlank();
         assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
-        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceId())
+                .isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
         assertThat(state.propagatedConstraintId()).isNotBlank();
@@ -157,7 +159,8 @@ class PropagationE2ETest {
         assertThat(state.propagatedConstraintId()).isEmpty();
         assertThat(state.propagatedConstraintColumnId()).isEmpty();
         assertThat(state.propagatedSourceType()).isEqualTo("RELATIONSHIP");
-        assertThat(state.propagatedSourceId()).isEqualTo(state.relationshipId());
+        assertThat(state.propagatedSourceId())
+                .isEqualTo(state.relationshipId());
         assertThat(state.propagatedSourceColumnId())
                 .isEqualTo(state.parentColumnId());
     }
@@ -953,7 +956,8 @@ class PropagationE2ETest {
                 .build();
 
         return Validation.CreateSchemaRequest.newBuilder()
-                .setDatabase(Validation.Database.newBuilder().setId(DATABASE_ID))
+                .setDatabase(
+                        Validation.Database.newBuilder().setId(DATABASE_ID))
                 .setSchema(schema)
                 .build();
     }
@@ -1137,7 +1141,8 @@ class PropagationE2ETest {
     private Validation.Relationship buildRelationship(SetupState state,
             String fkColumnId) {
         return buildRelationship(state, List.of(buildRelationshipColumn(
-                state.relationshipColumnId(), state.relationshipId(), fkColumnId,
+                state.relationshipColumnId(), state.relationshipId(),
+                fkColumnId,
                 state.parentColumnId(), 1)));
     }
 
@@ -1187,7 +1192,8 @@ class PropagationE2ETest {
         Validation.Relationship relationship = buildRelationship(state,
                 state.propagatedColumnId());
         List<Validation.Constraint> constraints = List.of();
-        if (state.relationshipKind() == Validation.RelationshipKind.IDENTIFYING) {
+        if (state
+                .relationshipKind() == Validation.RelationshipKind.IDENTIFYING) {
             Validation.Constraint childPk = buildPkConstraint(
                     state.propagatedConstraintId(), state.childTableId(),
                     state.propagatedConstraintColumnId(),
@@ -1200,12 +1206,14 @@ class PropagationE2ETest {
                 constraints, List.of(relationship));
     }
 
-    private Validation.Database buildDatabaseWithRelationship(SetupState state) {
+    private Validation.Database buildDatabaseWithRelationship(
+            SetupState state) {
         Validation.Table parentTable = buildParentTableWithPk(state,
                 List.of(buildColumn(state.parentColumnId(),
                         state.parentTableId(), "id", 1, true)));
         Validation.Table childTable = buildChildTableWithRelationship(state);
-        return buildDatabase(state.schemaId(), List.of(parentTable, childTable));
+        return buildDatabase(state.schemaId(),
+                List.of(parentTable, childTable));
     }
 
     private record SetupState(
@@ -1230,4 +1238,5 @@ class PropagationE2ETest {
     private record SetupResult(SetupState state,
             JsonNode relationshipResponse) {
     }
+
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
+import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintRepository;
@@ -173,7 +174,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         relationshipId,
                         relationshipId,
-                        "RELATIONSHIP",
+                        EntityType.RELATIONSHIP.name(),
                         Set.of());
 
         StepVerifier.create(result)
@@ -185,7 +186,7 @@ class AffectedEntitiesSaverTest {
                     assertThat(propagatedColumn.tableId())
                             .isEqualTo(childTableId);
                     assertThat(propagatedColumn.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedColumn.sourceId())
                             .isEqualTo(relationshipId);
                     assertThat(propagatedColumn.sourceColumnId())
@@ -203,7 +204,7 @@ class AffectedEntitiesSaverTest {
                     assertThat(propagatedRelationshipColumn.seqNo())
                             .isEqualTo(1);
                     assertThat(propagatedRelationshipColumn.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedRelationshipColumn.sourceId())
                             .isEqualTo(relationshipId);
 
@@ -256,7 +257,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         null,
                         sourceId,
-                        "RELATIONSHIP",
+                        EntityType.RELATIONSHIP.name(),
                         Set.of())
                 .flatMap(propagated -> {
                     assertThat(propagated.constraints()).hasSize(1);
@@ -281,7 +282,7 @@ class AffectedEntitiesSaverTest {
                             .constraints().get(0);
 
                     assertThat(propagatedConstraint.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedConstraint.sourceId())
                             .isEqualTo(sourceId);
                     assertThat(propagatedConstraint.tableId())
@@ -397,7 +398,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         relationshipId,
                         relationshipId,
-                        "RELATIONSHIP",
+                        EntityType.RELATIONSHIP.name(),
                         Set.of())
                 .flatMap(propagated -> {
                     assertThat(propagated.relationshipColumns()).hasSize(1);
@@ -550,7 +551,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         constraintId,
                         constraintId,
-                        "CONSTRAINT",
+                        EntityType.CONSTRAINT.name(),
                         Set.of(constraintColumnId));
 
         StepVerifier.create(result)
@@ -562,7 +563,7 @@ class AffectedEntitiesSaverTest {
                     assertThat(propagatedColumn.tableId())
                             .isEqualTo(childTableId);
                     assertThat(propagatedColumn.sourceType())
-                            .isEqualTo("CONSTRAINT");
+                            .isEqualTo(EntityType.CONSTRAINT.name());
                     assertThat(propagatedColumn.sourceId())
                             .isEqualTo(constraintId);
                     assertThat(propagatedColumn.sourceColumnId())
@@ -576,7 +577,7 @@ class AffectedEntitiesSaverTest {
                     assertThat(propagatedRelationshipColumn.refColumnId())
                             .isEqualTo(parentColumnId);
                     assertThat(propagatedRelationshipColumn.sourceType())
-                            .isEqualTo("CONSTRAINT");
+                            .isEqualTo(EntityType.CONSTRAINT.name());
                     assertThat(propagatedRelationshipColumn.sourceId())
                             .isEqualTo(constraintId);
 
@@ -710,7 +711,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         null,
                         relationshipId,
-                        "RELATIONSHIP",
+                        EntityType.RELATIONSHIP.name(),
                         Set.of(),
                         Set.of(requestRelationshipColumnId));
 
@@ -821,7 +822,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         null,
                         constraintId,
-                        "CONSTRAINT",
+                        EntityType.CONSTRAINT.name(),
                         Set.of(),
                         Set.of(constraintId, requestConstraintColumnId));
 
@@ -921,7 +922,7 @@ class AffectedEntitiesSaverTest {
                         after,
                         null,
                         sourceId,
-                        "RELATIONSHIP",
+                        EntityType.RELATIONSHIP.name(),
                         Set.of(),
                         Set.of());
 
@@ -955,7 +956,7 @@ class AffectedEntitiesSaverTest {
                     assertThat(propagatedIndexColumn.columnId())
                             .isEqualTo(savedColumnId);
                     assertThat(propagatedIndexColumn.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedIndexColumn.sourceId())
                             .isEqualTo(sourceId);
                 })

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
@@ -1,0 +1,359 @@
+package com.schemafy.core.erd.service;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
+import com.schemafy.core.erd.repository.ColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintColumnRepository;
+import com.schemafy.core.erd.repository.ConstraintRepository;
+import com.schemafy.core.erd.repository.IndexColumnRepository;
+import com.schemafy.core.erd.repository.IndexRepository;
+import com.schemafy.core.erd.repository.RelationshipColumnRepository;
+import com.schemafy.core.erd.repository.RelationshipRepository;
+import com.schemafy.core.erd.repository.SchemaRepository;
+import com.schemafy.core.erd.repository.TableRepository;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import validation.Validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("AffectedEntitiesSaver 테스트")
+class AffectedEntitiesSaverTest {
+
+    @Autowired
+    AffectedEntitiesSaver affectedEntitiesSaver;
+
+    @Autowired
+    RelationshipColumnRepository relationshipColumnRepository;
+
+    @Autowired
+    RelationshipRepository relationshipRepository;
+
+    @Autowired
+    ConstraintColumnRepository constraintColumnRepository;
+
+    @Autowired
+    ConstraintRepository constraintRepository;
+
+    @Autowired
+    IndexColumnRepository indexColumnRepository;
+
+    @Autowired
+    IndexRepository indexRepository;
+
+    @Autowired
+    ColumnRepository columnRepository;
+
+    @Autowired
+    TableRepository tableRepository;
+
+    @Autowired
+    SchemaRepository schemaRepository;
+
+    @BeforeEach
+    void setUp() {
+        relationshipColumnRepository.deleteAll().block();
+        relationshipRepository.deleteAll().block();
+        constraintColumnRepository.deleteAll().block();
+        constraintRepository.deleteAll().block();
+        indexColumnRepository.deleteAll().block();
+        indexRepository.deleteAll().block();
+        columnRepository.deleteAll().block();
+        tableRepository.deleteAll().block();
+        schemaRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("RELATIONSHIP 전파 컬럼의 sourceColumnId는 relationshipColumn.refColumnId를 따른다")
+    void saveAffectedEntities_relationshipSource_setsSourceColumnId() {
+        String schemaId = "schema-1";
+        String parentTableId = "parent-table";
+        String childTableId = "child-table";
+        String parentColumnId = "parent-id-col";
+        String relationshipId = "be-relationship-id";
+        String fkColumnLogicalId = "fk-col-logical";
+        String relationshipColumnLogicalId = "relcol-logical";
+
+        Validation.Database before = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId(schemaId)
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(parentTableId)
+                                .setName("parent")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(parentColumnId)
+                                        .setTableId(parentTableId)
+                                        .setName("id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .build())
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setName("child")
+                                .build())
+                        .build())
+                .build();
+
+        Validation.Database after = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId(schemaId)
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(parentTableId)
+                                .setName("parent")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(parentColumnId)
+                                        .setTableId(parentTableId)
+                                        .setName("id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .build())
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setName("child")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(fkColumnLogicalId)
+                                        .setTableId(childTableId)
+                                        .setName("parent_id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .setIsAffected(true)
+                                        .build())
+                                .addRelationships(Validation.Relationship
+                                        .newBuilder()
+                                        .setId(relationshipId)
+                                        .setSrcTableId(childTableId)
+                                        .setTgtTableId(parentTableId)
+                                        .setName("fk_child_parent")
+                                        .setKind(
+                                                Validation.RelationshipKind.IDENTIFYING)
+                                        .setCardinality(
+                                                Validation.RelationshipCardinality.ONE_TO_MANY)
+                                        .setIsAffected(true)
+                                        .addColumns(
+                                                Validation.RelationshipColumn
+                                                        .newBuilder()
+                                                        .setId(relationshipColumnLogicalId)
+                                                        .setRelationshipId(
+                                                                relationshipId)
+                                                        .setFkColumnId(
+                                                                fkColumnLogicalId)
+                                                        .setRefColumnId(
+                                                                parentColumnId)
+                                                        .setSeqNo(1)
+                                                        .setIsAffected(true)
+                                                        .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        Mono<AffectedMappingResponse.PropagatedEntities> result = affectedEntitiesSaver
+                .saveAffectedEntities(
+                        before,
+                        after,
+                        relationshipId,
+                        relationshipId,
+                        "RELATIONSHIP",
+                        Set.of());
+
+        StepVerifier.create(result)
+                .assertNext(propagated -> {
+                    assertThat(propagated.columns()).hasSize(1);
+                    AffectedMappingResponse.PropagatedColumn propagatedColumn = propagated
+                            .columns().get(0);
+
+                    assertThat(propagatedColumn.tableId())
+                            .isEqualTo(childTableId);
+                    assertThat(propagatedColumn.sourceType())
+                            .isEqualTo("RELATIONSHIP");
+                    assertThat(propagatedColumn.sourceId())
+                            .isEqualTo(relationshipId);
+                    assertThat(propagatedColumn.sourceColumnId())
+                            .isEqualTo(parentColumnId);
+
+                    assertThat(propagated.relationshipColumns()).hasSize(1);
+                    AffectedMappingResponse.PropagatedRelationshipColumn propagatedRelationshipColumn = propagated
+                            .relationshipColumns().get(0);
+                    assertThat(propagatedRelationshipColumn.relationshipId())
+                            .isEqualTo(relationshipId);
+                    assertThat(propagatedRelationshipColumn.fkColumnId())
+                            .isEqualTo(propagatedColumn.columnId());
+                    assertThat(propagatedRelationshipColumn.refColumnId())
+                            .isEqualTo(parentColumnId);
+                    assertThat(propagatedRelationshipColumn.seqNo())
+                            .isEqualTo(1);
+                    assertThat(propagatedRelationshipColumn.sourceType())
+                            .isEqualTo("RELATIONSHIP");
+                    assertThat(propagatedRelationshipColumn.sourceId())
+                            .isEqualTo(relationshipId);
+
+                    assertThat(propagated.constraintColumns()).isEmpty();
+                    assertThat(propagated.indexColumns()).isEmpty();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("CONSTRAINT 전파 컬럼의 sourceColumnId는 부모 PK 컬럼을 따른다")
+    void saveAffectedEntities_constraintSource_setsSourceColumnId() {
+        String schemaId = "schema-1";
+        String parentTableId = "parent-table";
+        String childTableId = "child-table";
+        String parentColumnId = "parent-id-col";
+        String constraintId = "be-constraint-id";
+        String constraintColumnId = "fe-constraint-col-1";
+        String relationshipId = "relationship-1";
+        String fkColumnLogicalId = "fk-col-logical";
+        String relationshipColumnLogicalId = "relcol-logical";
+
+        Validation.Database before = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId(schemaId)
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(parentTableId)
+                                .setName("parent")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(parentColumnId)
+                                        .setTableId(parentTableId)
+                                        .setName("id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .build())
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setName("child")
+                                .build())
+                        .build())
+                .build();
+
+        Validation.Database after = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId(schemaId)
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(parentTableId)
+                                .setName("parent")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(parentColumnId)
+                                        .setTableId(parentTableId)
+                                        .setName("id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .addConstraints(Validation.Constraint
+                                        .newBuilder()
+                                        .setId(constraintId)
+                                        .setTableId(parentTableId)
+                                        .setName("pk_parent")
+                                        .setKind(
+                                                Validation.ConstraintKind.PRIMARY_KEY)
+                                        .setIsAffected(true)
+                                        .addColumns(
+                                                Validation.ConstraintColumn
+                                                        .newBuilder()
+                                                        .setId(constraintColumnId)
+                                                        .setConstraintId(
+                                                                constraintId)
+                                                        .setColumnId(
+                                                                parentColumnId)
+                                                        .setSeqNo(1)
+                                                        .setIsAffected(true)
+                                                        .build())
+                                        .build())
+                                .build())
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setName("child")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(fkColumnLogicalId)
+                                        .setTableId(childTableId)
+                                        .setName("parent_id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .setIsAffected(true)
+                                        .build())
+                                .addRelationships(Validation.Relationship
+                                        .newBuilder()
+                                        .setId(relationshipId)
+                                        .setSrcTableId(childTableId)
+                                        .setTgtTableId(parentTableId)
+                                        .setName("fk_child_parent")
+                                        .setKind(
+                                                Validation.RelationshipKind.IDENTIFYING)
+                                        .setCardinality(
+                                                Validation.RelationshipCardinality.ONE_TO_MANY)
+                                        .addColumns(
+                                                Validation.RelationshipColumn
+                                                        .newBuilder()
+                                                        .setId(relationshipColumnLogicalId)
+                                                        .setRelationshipId(
+                                                                relationshipId)
+                                                        .setFkColumnId(
+                                                                fkColumnLogicalId)
+                                                        .setRefColumnId(
+                                                                parentColumnId)
+                                                        .setSeqNo(1)
+                                                        .setIsAffected(true)
+                                                        .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        Mono<AffectedMappingResponse.PropagatedEntities> result = affectedEntitiesSaver
+                .saveAffectedEntities(
+                        before,
+                        after,
+                        constraintId,
+                        constraintId,
+                        "CONSTRAINT",
+                        Set.of(constraintColumnId));
+
+        StepVerifier.create(result)
+                .assertNext(propagated -> {
+                    assertThat(propagated.columns()).hasSize(1);
+                    AffectedMappingResponse.PropagatedColumn propagatedColumn = propagated
+                            .columns().get(0);
+
+                    assertThat(propagatedColumn.tableId())
+                            .isEqualTo(childTableId);
+                    assertThat(propagatedColumn.sourceType())
+                            .isEqualTo("CONSTRAINT");
+                    assertThat(propagatedColumn.sourceId())
+                            .isEqualTo(constraintId);
+                    assertThat(propagatedColumn.sourceColumnId())
+                            .isEqualTo(parentColumnId);
+
+                    assertThat(propagated.relationshipColumns()).hasSize(1);
+                    AffectedMappingResponse.PropagatedRelationshipColumn propagatedRelationshipColumn = propagated
+                            .relationshipColumns().get(0);
+                    assertThat(propagatedRelationshipColumn.fkColumnId())
+                            .isEqualTo(propagatedColumn.columnId());
+                    assertThat(propagatedRelationshipColumn.refColumnId())
+                            .isEqualTo(parentColumnId);
+                    assertThat(propagatedRelationshipColumn.sourceType())
+                            .isEqualTo("CONSTRAINT");
+                    assertThat(propagatedRelationshipColumn.sourceId())
+                            .isEqualTo(constraintId);
+
+                    assertThat(propagated.constraintColumns()).isEmpty();
+                    assertThat(propagated.indexColumns()).isEmpty();
+                })
+                .verifyComplete();
+    }
+
+}
+

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
@@ -2,12 +2,13 @@ package com.schemafy.core.erd.service;
 
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.repository.ColumnRepository;
@@ -19,8 +20,8 @@ import com.schemafy.core.erd.repository.RelationshipColumnRepository;
 import com.schemafy.core.erd.repository.RelationshipRepository;
 import com.schemafy.core.erd.repository.SchemaRepository;
 import com.schemafy.core.erd.repository.TableRepository;
-import com.schemafy.core.erd.repository.entity.Constraint;
 import com.schemafy.core.erd.repository.entity.Column;
+import com.schemafy.core.erd.repository.entity.Constraint;
 import com.schemafy.core.erd.repository.entity.RelationshipColumn;
 
 import reactor.core.publisher.Mono;
@@ -430,7 +431,8 @@ class AffectedEntitiesSaverTest {
                     assertThat(savedRelationshipColumn.getSrcColumnId())
                             .isEqualTo(relationshipColumn.fkColumnId());
                     assertThat(savedSrcColumn.getId())
-                            .isEqualTo(savedRelationshipColumn.getSrcColumnId());
+                            .isEqualTo(
+                                    savedRelationshipColumn.getSrcColumnId());
                 })
                 .verifyComplete();
     }
@@ -1063,7 +1065,8 @@ class AffectedEntitiesSaverTest {
                                                         .setRelationshipId(
                                                                 relationshipId)
                                                         .setFkColumnId(columnId)
-                                                        .setRefColumnId(columnId)
+                                                        .setRefColumnId(
+                                                                columnId)
                                                         .setSeqNo(1)
                                                         .setIsAffected(true)
                                                         .build())

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
@@ -699,8 +699,7 @@ class AffectedEntitiesSaverTest {
         Mono<Tuple3<AffectedEntitiesSaver.SaveResult, Column, RelationshipColumn>> result = affectedEntitiesSaver
                 .saveAffectedEntitiesResult(before, after)
                 .flatMap(saveResult -> {
-                    AffectedEntitiesSaver.IdMappings idMappings = saveResult
-                            .idMappings();
+                    IdMappings idMappings = saveResult.idMappings();
                     return Mono.zip(
                             Mono.just(saveResult),
                             columnRepository.findByIdAndDeletedAtIsNull(
@@ -717,8 +716,7 @@ class AffectedEntitiesSaverTest {
                     Column savedColumn = tuple.getT2();
                     RelationshipColumn savedRelationshipColumn = tuple.getT3();
 
-                    AffectedEntitiesSaver.IdMappings idMappings = saveResult
-                            .idMappings();
+                    IdMappings idMappings = saveResult.idMappings();
 
                     assertThat(idMappings.schemas()).isEmpty();
                     assertThat(idMappings.tables()).isEmpty();

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ColumnServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ColumnServiceTest.java
@@ -309,9 +309,45 @@ class ColumnServiceTest {
                         .build())
                 .block();
 
+        Validation.Database beforeDatabase = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-1")
+                        .setName("schema")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId("table-1")
+                                .setSchemaId("schema-1")
+                                .setName("table")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(saved.getId())
+                                        .setTableId("table-1")
+                                        .setName("to_delete")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("VARCHAR(255)")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        Validation.Database afterDatabase = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-1")
+                        .setName("schema")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId("table-1")
+                                .setSchemaId("schema-1")
+                                .setName("table")
+                                .build())
+                        .build())
+                .build();
+
+        given(validationClient
+                .deleteColumn(any(Validation.DeleteColumnRequest.class)))
+                .willReturn(Mono.just(afterDatabase));
+
         StepVerifier.create(columnService.deleteColumn(
                 Validation.DeleteColumnRequest.newBuilder()
                         .setColumnId(saved.getId())
+                        .setDatabase(beforeDatabase)
                         .build()))
                 .verifyComplete();
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import org.mockito.ArgumentCaptor;
 
 import com.schemafy.core.common.exception.BusinessException;
@@ -29,10 +28,9 @@ import com.schemafy.core.validation.client.ValidationClient;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import validation.Validation;
-
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
+import validation.Validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -323,7 +321,8 @@ class ConstraintServiceTest {
 
                     assertThat(response.constraintColumns())
                             .containsKey(savedConstraintId);
-                    assertThat(response.constraintColumns().get(savedConstraintId))
+                    assertThat(
+                            response.constraintColumns().get(savedConstraintId))
                             .containsEntry("fe-constraint-col-1",
                                     persistedConstraintColumnId);
                 })
@@ -341,7 +340,7 @@ class ConstraintServiceTest {
 
         assertThat(containsConstraintColumnId(afterDbCaptor.getValue(),
                 "fe-constraint-col-1"))
-                        .isTrue();
+                .isTrue();
         assertThat(excludePropagatedCaptor.getValue())
                 .contains("fe-constraint-col-1");
     }
@@ -1036,7 +1035,8 @@ class ConstraintServiceTest {
                         .getConstraintsList()) {
                     for (Validation.ConstraintColumn constraintColumn : constraint
                             .getColumnsList()) {
-                        if (constraintColumn.getId().equals(constraintColumnId)) {
+                        if (constraintColumn.getId()
+                                .equals(constraintColumnId)) {
                             return true;
                         }
                     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -18,6 +18,7 @@ import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.common.exception.ErrorCode;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
+import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintColumnRepository;
 import com.schemafy.core.erd.repository.ConstraintRepository;
@@ -298,7 +299,7 @@ class ConstraintServiceTest {
         // then
         String persistedConstraintColumnId = "be-constraint-col-1";
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), eq("CONSTRAINT"), any(), any()))
+                any(), any(), eq(EntityType.CONSTRAINT.name()), any(), any()))
                 .willReturn(Mono.just(
                         new AffectedEntitiesSaver.SaveResult(
                                 AffectedMappingResponse.PropagatedEntities
@@ -336,7 +337,8 @@ class ConstraintServiceTest {
 
         verify(affectedEntitiesSaver).saveAffectedEntitiesResult(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("CONSTRAINT"), any(), excludePropagatedCaptor.capture());
+                eq(EntityType.CONSTRAINT.name()), any(),
+                excludePropagatedCaptor.capture());
 
         assertThat(containsConstraintColumnId(afterDbCaptor.getValue(),
                 "fe-constraint-col-1"))
@@ -534,7 +536,7 @@ class ConstraintServiceTest {
                                     List.of(new AffectedMappingResponse.PropagatedColumn(
                                             "propagated-parent-id-col",
                                             "child-table",
-                                            "CONSTRAINT",
+                                            EntityType.CONSTRAINT.name(),
                                             sourceId,
                                             "parent-id-col")),
                                     List.of(),
@@ -543,7 +545,7 @@ class ConstraintServiceTest {
                                             "propagated-constraint-col",
                                             "child-pk-constraint",
                                             "propagated-parent-id-col",
-                                            "CONSTRAINT",
+                                            EntityType.CONSTRAINT.name(),
                                             sourceId)),
                                     List.of()),
                             new IdMappings(Map.of(), Map.of(), Map.of(),
@@ -580,7 +582,7 @@ class ConstraintServiceTest {
                     assertThat(propagatedColumn.tableId())
                             .isEqualTo("child-table");
                     assertThat(propagatedColumn.sourceType())
-                            .isEqualTo("CONSTRAINT");
+                            .isEqualTo(EntityType.CONSTRAINT.name());
                     assertThat(propagatedColumn.sourceId())
                             .isEqualTo(savedConstraintId);
                     assertThat(propagatedColumn.sourceColumnId())
@@ -597,7 +599,7 @@ class ConstraintServiceTest {
                     assertThat(propagatedConstraintColumn.columnId())
                             .isEqualTo("propagated-parent-id-col");
                     assertThat(propagatedConstraintColumn.sourceType())
-                            .isEqualTo("CONSTRAINT");
+                            .isEqualTo(EntityType.CONSTRAINT.name());
                     assertThat(propagatedConstraintColumn.sourceId())
                             .isEqualTo(savedConstraintId);
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -34,6 +34,7 @@ import reactor.util.function.Tuples;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -324,18 +325,16 @@ class ConstraintServiceTest {
 
         ArgumentCaptor<Validation.Database> afterDbCaptor = ArgumentCaptor
                 .forClass(Validation.Database.class);
-        ArgumentCaptor<Set> excludeIdsCaptor = ArgumentCaptor
-                .forClass(Set.class);
 
         verify(affectedEntitiesSaver).saveAffectedEntities(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("CONSTRAINT"), excludeIdsCaptor.capture());
+                eq("CONSTRAINT"), argThat((Set<String> excludeEntityIds) -> {
+                    return excludeEntityIds.contains("fe-constraint-col-1");
+                }));
 
         assertThat(containsConstraintColumnId(afterDbCaptor.getValue(),
                 "fe-constraint-col-1"))
                         .isTrue();
-        assertThat(excludeIdsCaptor.getValue())
-                .contains("fe-constraint-col-1");
     }
 
     @Test
@@ -529,6 +528,7 @@ class ConstraintServiceTest {
                                     "CONSTRAINT",
                                     sourceId,
                                     "parent-id-col")),
+                            List.of(),
                             List.of(),
                             List.of(new AffectedMappingResponse.PropagatedConstraintColumn(
                                     "propagated-constraint-col",
@@ -747,6 +747,7 @@ class ConstraintServiceTest {
                 .build();
 
         AffectedMappingResponse.PropagatedEntities propagatedEntities = new AffectedMappingResponse.PropagatedEntities(
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of(),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -351,6 +351,7 @@ class ConstraintServiceTest {
                                 "be-constraint-id",
                                 "parent-id-col" // 원본 컬럼 ID
                         )),
+                List.of(),
                 List.of(
                         // 전파된 제약조건 컬럼
                         new AffectedMappingResponse.PropagatedConstraintColumn(
@@ -571,6 +572,7 @@ class ConstraintServiceTest {
                 .build();
 
         AffectedMappingResponse.PropagatedEntities propagatedEntities = new AffectedMappingResponse.PropagatedEntities(
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of());

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -2,6 +2,7 @@ package com.schemafy.core.erd.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -99,6 +100,10 @@ class ConstraintServiceTest {
                 .willReturn(Mono.just(emptySaveResult));
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(),
                 any(Validation.Database.class), any(), any(), any(), any()))
+                .willReturn(Mono.just(emptySaveResult));
+        given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(),
+                any(Validation.Database.class), any(), any(), any(), any(),
+                any()))
                 .willReturn(Mono.just(emptySaveResult));
 
         given(affectedEntitiesSaver.saveAffectedEntities(any(),
@@ -295,7 +300,8 @@ class ConstraintServiceTest {
         // then
         String persistedConstraintColumnId = "be-constraint-col-1";
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), eq("CONSTRAINT"))).willReturn(Mono.just(
+                any(), any(), eq("CONSTRAINT"), any(), any()))
+                .willReturn(Mono.just(
                         new AffectedEntitiesSaver.SaveResult(
                                 AffectedMappingResponse.PropagatedEntities
                                         .empty(),
@@ -326,13 +332,18 @@ class ConstraintServiceTest {
         ArgumentCaptor<Validation.Database> afterDbCaptor = ArgumentCaptor
                 .forClass(Validation.Database.class);
 
+        ArgumentCaptor<Set<String>> excludePropagatedCaptor = ArgumentCaptor
+                .forClass(Set.class);
+
         verify(affectedEntitiesSaver).saveAffectedEntitiesResult(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("CONSTRAINT"));
+                eq("CONSTRAINT"), any(), excludePropagatedCaptor.capture());
 
         assertThat(containsConstraintColumnId(afterDbCaptor.getValue(),
                 "fe-constraint-col-1"))
                         .isTrue();
+        assertThat(excludePropagatedCaptor.getValue())
+                .contains("fe-constraint-col-1");
     }
 
     @Test
@@ -516,7 +527,7 @@ class ConstraintServiceTest {
                 any(Validation.CreateConstraintRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), any()))
+                any(), any(), any(), any(), any()))
                 .willAnswer(invocation -> {
                     String sourceId = invocation.getArgument(3);
                     return Mono.just(new AffectedEntitiesSaver.SaveResult(

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -78,6 +78,10 @@ class ConstraintServiceTest {
                 any(Validation.Database.class), any(), any(), any()))
                 .willReturn(Mono.just(
                         AffectedMappingResponse.PropagatedEntities.empty()));
+        given(affectedEntitiesSaver.saveAffectedEntities(any(),
+                any(Validation.Database.class), any(), any(), any(), any()))
+                .willReturn(Mono.just(
+                        AffectedMappingResponse.PropagatedEntities.empty()));
     }
 
     @Test
@@ -131,7 +135,7 @@ class ConstraintServiceTest {
                 any(Validation.CreateConstraintRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntities(any(), any(), any(),
-                any(), any()))
+                any(), any(), any()))
                 .willReturn(Mono
                         .just(AffectedMappingResponse.PropagatedEntities
                                 .empty()));
@@ -367,7 +371,7 @@ class ConstraintServiceTest {
                 any(Validation.CreateConstraintRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntities(any(), any(), any(),
-                any(), any()))
+                any(), any(), any()))
                 .willReturn(Mono.just(propagatedEntities));
 
         // when

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/IndexServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/IndexServiceTest.java
@@ -409,7 +409,8 @@ class IndexServiceTest {
                 .verifyComplete();
 
         StepVerifier
-                .create(indexColumnRepository.findById(savedIndexColumn.getId()))
+                .create(indexColumnRepository
+                        .findById(savedIndexColumn.getId()))
                 .assertNext(found -> assertThat(found.isDeleted()).isTrue())
                 .verifyComplete();
     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/IndexServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/IndexServiceTest.java
@@ -1,5 +1,7 @@
 package com.schemafy.core.erd.service;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -22,6 +24,8 @@ import com.schemafy.core.validation.client.ValidationClient;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.util.function.Tuple3;
+import reactor.util.function.Tuples;
 import validation.Validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,6 +82,20 @@ class IndexServiceTest {
                         .setTableId("table-1")
                         .setName("idx_test")
                         .setType(Validation.IndexType.BTREE)
+                        .addColumns(Validation.IndexColumn.newBuilder()
+                                .setId("fe-index-column-1")
+                                .setIndexId("fe-index-id")
+                                .setColumnId("column-1")
+                                .setSeqNo(1)
+                                .setSortDir(Validation.IndexSortDir.ASC)
+                                .build())
+                        .addColumns(Validation.IndexColumn.newBuilder()
+                                .setId("fe-index-column-2")
+                                .setIndexId("fe-index-id")
+                                .setColumnId("column-2")
+                                .setSeqNo(2)
+                                .setSortDir(Validation.IndexSortDir.DESC)
+                                .build())
                         .build())
                 .setDatabase(Validation.Database.newBuilder()
                         .setId("proj-1")
@@ -105,12 +123,34 @@ class IndexServiceTest {
                                 .setName("test-table")
                                 .setIsAffected(true)
                                 .addIndexes(Validation.Index.newBuilder()
-                                        .setId("be-index-id")
+                                        .setId("validator-index-id")
                                         .setTableId("table-1")
                                         .setName("idx_test")
                                         .setType(Validation.IndexType.BTREE)
                                         .setComment("")
                                         .setIsAffected(true)
+                                        .addColumns(Validation.IndexColumn
+                                                .newBuilder()
+                                                .setId("validator-index-column-1")
+                                                .setIndexId(
+                                                        "validator-index-id")
+                                                .setColumnId("column-1")
+                                                .setSeqNo(1)
+                                                .setSortDir(
+                                                        Validation.IndexSortDir.ASC)
+                                                .setIsAffected(true)
+                                                .build())
+                                        .addColumns(Validation.IndexColumn
+                                                .newBuilder()
+                                                .setId("validator-index-column-2")
+                                                .setIndexId(
+                                                        "validator-index-id")
+                                                .setColumnId("column-2")
+                                                .setSeqNo(2)
+                                                .setSortDir(
+                                                        Validation.IndexSortDir.DESC)
+                                                .setIsAffected(true)
+                                                .build())
                                         .build())
                                 .build())
                         .build())
@@ -121,23 +161,56 @@ class IndexServiceTest {
                 .willReturn(Mono.just(mockResponse));
 
         // when
-        Mono<AffectedMappingResponse> result = indexService
-                .createIndex(request);
+        Mono<Tuple3<AffectedMappingResponse, Index, List<IndexColumn>>> result = indexService
+                .createIndex(request)
+                .flatMap(response -> indexRepository.findAll().single()
+                        .flatMap(savedIndex -> indexColumnRepository
+                                .findByIndexIdAndDeletedAtIsNull(
+                                        savedIndex.getId())
+                                .collectList()
+                                .map(savedIndexColumns -> Tuples.of(
+                                        response,
+                                        savedIndex,
+                                        savedIndexColumns))));
 
         // then
         StepVerifier.create(result)
-                .assertNext(response -> {
+                .assertNext(tuple -> {
+                    AffectedMappingResponse response = tuple.getT1();
+                    Index savedIndex = tuple.getT2();
+                    var savedIndexColumns = tuple.getT3();
+
+                    String savedIndexId = savedIndex.getId();
+                    assertThat(savedIndexColumns).hasSize(2);
+
+                    String savedIndexColumnId1 = savedIndexColumns.stream()
+                            .filter(c -> c.getColumnId().equals("column-1"))
+                            .findFirst()
+                            .orElseThrow()
+                            .getId();
+                    String savedIndexColumnId2 = savedIndexColumns.stream()
+                            .filter(c -> c.getColumnId().equals("column-2"))
+                            .findFirst()
+                            .orElseThrow()
+                            .getId();
+
                     // 인덱스 매핑 정보 확인 (FE-ID → BE-ID 매핑)
                     // indexes는 tableId로 그룹핑된 nested map
                     assertThat(response.indexes()).hasSize(1);
                     assertThat(response.indexes().get("table-1"))
-                            .containsEntry("fe-index-id", "be-index-id");
+                            .containsEntry("fe-index-id", savedIndexId);
 
                     // 다른 매핑들은 비어있어야 함 (인덱스만 생성했으므로)
                     assertThat(response.schemas()).isEmpty();
                     assertThat(response.tables()).isEmpty();
                     assertThat(response.columns()).isEmpty();
-                    assertThat(response.indexColumns()).isEmpty();
+                    assertThat(response.indexColumns())
+                            .containsKey(savedIndexId);
+                    assertThat(response.indexColumns().get(savedIndexId))
+                            .containsEntry("fe-index-column-1",
+                                    savedIndexColumnId1)
+                            .containsEntry("fe-index-column-2",
+                                    savedIndexColumnId2);
                     assertThat(response.constraints()).isEmpty();
                     assertThat(response.constraintColumns()).isEmpty();
                     assertThat(response.relationships()).isEmpty();
@@ -292,12 +365,51 @@ class IndexServiceTest {
 
         StepVerifier.create(indexService.removeColumnFromIndex(
                 Validation.RemoveColumnFromIndexRequest.newBuilder()
+                        .setIndexId("index-1")
                         .setIndexColumnId(saved.getId())
                         .build()))
                 .verifyComplete();
 
         // 삭제 플래그 확인 (deletedAt not null)
         StepVerifier.create(indexColumnRepository.findById(saved.getId()))
+                .assertNext(found -> assertThat(found.isDeleted()).isTrue())
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("removeColumnFromIndex: 마지막 컬럼 제거 시 인덱스도 소프트 삭제된다")
+    void removeColumnFromIndex_lastColumnAlsoDeletesIndex() {
+        Index savedIndex = indexRepository.save(
+                Index.builder()
+                        .tableId("table-1")
+                        .name("idx_to_delete")
+                        .type("BTREE")
+                        .comment("")
+                        .build())
+                .block();
+
+        IndexColumn savedIndexColumn = indexColumnRepository.save(
+                IndexColumn.builder()
+                        .indexId(savedIndex.getId())
+                        .columnId("column-1")
+                        .seqNo(1)
+                        .sortDir("ASC")
+                        .build())
+                .block();
+
+        StepVerifier.create(indexService.removeColumnFromIndex(
+                Validation.RemoveColumnFromIndexRequest.newBuilder()
+                        .setIndexId(savedIndex.getId())
+                        .setIndexColumnId(savedIndexColumn.getId())
+                        .build()))
+                .verifyComplete();
+
+        StepVerifier.create(indexRepository.findById(savedIndex.getId()))
+                .assertNext(found -> assertThat(found.isDeleted()).isTrue())
+                .verifyComplete();
+
+        StepVerifier
+                .create(indexColumnRepository.findById(savedIndexColumn.getId()))
                 .assertNext(found -> assertThat(found.isDeleted()).isTrue())
                 .verifyComplete();
     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -401,6 +401,7 @@ class RelationshipServiceTest {
                                 "be-relationship-id",
                                 "parent-id-col" // 원본 컬럼 ID
                         )),
+                List.of(),
                 List.of(
                         // 전파된 제약조건 컬럼
                         new AffectedMappingResponse.PropagatedConstraintColumn(

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -35,6 +35,7 @@ import reactor.util.function.Tuples;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -373,18 +374,16 @@ class RelationshipServiceTest {
 
         ArgumentCaptor<Validation.Database> afterDbCaptor = ArgumentCaptor
                 .forClass(Validation.Database.class);
-        ArgumentCaptor<Set> excludeIdsCaptor = ArgumentCaptor
-                .forClass(Set.class);
 
         verify(affectedEntitiesSaver).saveAffectedEntities(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("RELATIONSHIP"), excludeIdsCaptor.capture());
+                eq("RELATIONSHIP"), argThat((Set<String> excludeEntityIds) -> {
+                    return excludeEntityIds.contains("fe-relationship-col-1");
+                }));
 
         assertThat(containsRelationshipColumnId(afterDbCaptor.getValue(),
                 "fe-relationship-col-1"))
                         .isTrue();
-        assertThat(excludeIdsCaptor.getValue())
-                .contains("fe-relationship-col-1");
     }
 
     @Test
@@ -604,6 +603,7 @@ class RelationshipServiceTest {
                                     "RELATIONSHIP",
                                     sourceId,
                                     "parent-id-col")),
+                            List.of(),
                             List.of(),
                             List.of(new AffectedMappingResponse.PropagatedConstraintColumn(
                                     "propagated-constraint-col",

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import org.mockito.ArgumentCaptor;
 
 import com.schemafy.core.common.exception.BusinessException;
@@ -28,16 +27,15 @@ import com.schemafy.core.erd.repository.entity.Relationship;
 import com.schemafy.core.erd.repository.entity.RelationshipColumn;
 import com.schemafy.core.validation.client.ValidationClient;
 
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 import validation.Validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -360,7 +358,8 @@ class RelationshipServiceTest {
                                         .empty(),
                                 new IdMappings(Map.of(), Map.of(), Map.of(),
                                         Map.of(), Map.of(), Map.of(), Map.of(),
-                                        Map.of(), Map.of("fe-relationship-col-1",
+                                        Map.of(),
+                                        Map.of("fe-relationship-col-1",
                                                 persistedRelationshipColumnId)))));
 
         StepVerifier.create(result)
@@ -394,7 +393,7 @@ class RelationshipServiceTest {
 
         assertThat(containsRelationshipColumnId(afterDbCaptor.getValue(),
                 "fe-relationship-col-1"))
-                        .isTrue();
+                .isTrue();
         assertThat(excludePropagatedCaptor.getValue())
                 .contains("fe-relationship-col-1");
     }
@@ -1027,15 +1026,18 @@ class RelationshipServiceTest {
                                                 .setSrcTableId("child-table")
                                                 .setTgtTableId("parent-table")
                                                 .setName("fk_parent")
-                                                .setKind(Validation.RelationshipKind.NON_IDENTIFYING)
+                                                .setKind(
+                                                        Validation.RelationshipKind.NON_IDENTIFYING)
                                                 .addColumns(
                                                         Validation.RelationshipColumn
                                                                 .newBuilder()
-                                                                .setId(savedA.getId())
+                                                                .setId(savedA
+                                                                        .getId())
                                                                 .setRelationshipId(
                                                                         "relationship-1")
                                                                 .setFkColumnId(
-                                                                        fkColumnA.getId())
+                                                                        fkColumnA
+                                                                                .getId())
                                                                 .setRefColumnId(
                                                                         "parent-a")
                                                                 .setSeqNo(1)
@@ -1043,11 +1045,13 @@ class RelationshipServiceTest {
                                                 .addColumns(
                                                         Validation.RelationshipColumn
                                                                 .newBuilder()
-                                                                .setId(savedB.getId())
+                                                                .setId(savedB
+                                                                        .getId())
                                                                 .setRelationshipId(
                                                                         "relationship-1")
                                                                 .setFkColumnId(
-                                                                        fkColumnB.getId())
+                                                                        fkColumnB
+                                                                                .getId())
                                                                 .setRefColumnId(
                                                                         "parent-b")
                                                                 .setSeqNo(2)
@@ -1078,15 +1082,18 @@ class RelationshipServiceTest {
                                                 .setSrcTableId("child-table")
                                                 .setTgtTableId("parent-table")
                                                 .setName("fk_parent")
-                                                .setKind(Validation.RelationshipKind.NON_IDENTIFYING)
+                                                .setKind(
+                                                        Validation.RelationshipKind.NON_IDENTIFYING)
                                                 .addColumns(
                                                         Validation.RelationshipColumn
                                                                 .newBuilder()
-                                                                .setId(savedA.getId())
+                                                                .setId(savedA
+                                                                        .getId())
                                                                 .setRelationshipId(
                                                                         "relationship-1")
                                                                 .setFkColumnId(
-                                                                        fkColumnA.getId())
+                                                                        fkColumnA
+                                                                                .getId())
                                                                 .setRefColumnId(
                                                                         "parent-a")
                                                                 .setSeqNo(1)

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -19,6 +19,7 @@ import com.schemafy.core.common.exception.ErrorCode;
 import com.schemafy.core.erd.controller.dto.request.CreateRelationshipRequestWithExtra;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.RelationshipResponse;
+import com.schemafy.core.erd.model.EntityType;
 import com.schemafy.core.erd.repository.ColumnRepository;
 import com.schemafy.core.erd.repository.RelationshipColumnRepository;
 import com.schemafy.core.erd.repository.RelationshipRepository;
@@ -351,7 +352,8 @@ class RelationshipServiceTest {
         // then
         String persistedRelationshipColumnId = "be-relationship-col-1";
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), eq("RELATIONSHIP"), any(), any()))
+                any(), any(), eq(EntityType.RELATIONSHIP.name()), any(),
+                any()))
                 .willReturn(Mono.just(
                         new AffectedEntitiesSaver.SaveResult(
                                 AffectedMappingResponse.PropagatedEntities
@@ -389,7 +391,8 @@ class RelationshipServiceTest {
 
         verify(affectedEntitiesSaver).saveAffectedEntitiesResult(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("RELATIONSHIP"), any(), excludePropagatedCaptor.capture());
+                eq(EntityType.RELATIONSHIP.name()), any(),
+                excludePropagatedCaptor.capture());
 
         assertThat(containsRelationshipColumnId(afterDbCaptor.getValue(),
                 "fe-relationship-col-1"))
@@ -613,7 +616,7 @@ class RelationshipServiceTest {
                                     List.of(new AffectedMappingResponse.PropagatedColumn(
                                             "be-fk-column-id",
                                             "child-table",
-                                            "RELATIONSHIP",
+                                            EntityType.RELATIONSHIP.name(),
                                             sourceId,
                                             "parent-id-col")),
                                     List.of(),
@@ -622,7 +625,7 @@ class RelationshipServiceTest {
                                             "propagated-constraint-col",
                                             "child-pk-constraint",
                                             "be-fk-column-id",
-                                            "RELATIONSHIP",
+                                            EntityType.RELATIONSHIP.name(),
                                             sourceId)),
                                     List.of()),
                             new IdMappings(Map.of(), Map.of(), Map.of(),
@@ -659,7 +662,7 @@ class RelationshipServiceTest {
                     assertThat(propagatedColumn.tableId())
                             .isEqualTo("child-table");
                     assertThat(propagatedColumn.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedColumn.sourceId())
                             .isEqualTo(savedRelationshipId);
                     assertThat(propagatedColumn.sourceColumnId())
@@ -676,7 +679,7 @@ class RelationshipServiceTest {
                     assertThat(propagatedConstraintColumn.columnId())
                             .isEqualTo("be-fk-column-id");
                     assertThat(propagatedConstraintColumn.sourceType())
-                            .isEqualTo("RELATIONSHIP");
+                            .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedConstraintColumn.sourceId())
                             .isEqualTo(savedRelationshipId);
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -83,6 +83,10 @@ class RelationshipServiceTest {
                 any(Validation.Database.class), any(), any(), any()))
                 .willReturn(Mono.just(
                         AffectedMappingResponse.PropagatedEntities.empty()));
+        given(affectedEntitiesSaver.saveAffectedEntities(any(),
+                any(Validation.Database.class), any(), any(), any(), any()))
+                .willReturn(Mono.just(
+                        AffectedMappingResponse.PropagatedEntities.empty()));
     }
 
     @Test
@@ -155,7 +159,7 @@ class RelationshipServiceTest {
                 any(Validation.CreateRelationshipRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntities(any(), any(), any(),
-                any(), any()))
+                any(), any(), any()))
                 .willReturn(Mono
                         .just(AffectedMappingResponse.PropagatedEntities
                                 .empty()));
@@ -417,7 +421,7 @@ class RelationshipServiceTest {
                 any(Validation.CreateRelationshipRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntities(any(), any(), any(),
-                any(), any()))
+                any(), any(), any()))
                 .willReturn(Mono.just(propagatedEntities));
 
         // when

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -106,6 +106,10 @@ class RelationshipServiceTest {
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(),
                 any(Validation.Database.class), any(), any(), any(), any()))
                 .willReturn(Mono.just(emptySaveResult));
+        given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(),
+                any(Validation.Database.class), any(), any(), any(), any(),
+                any()))
+                .willReturn(Mono.just(emptySaveResult));
 
         given(affectedEntitiesSaver.saveAffectedEntities(any(),
                 any(Validation.Database.class)))
@@ -349,7 +353,8 @@ class RelationshipServiceTest {
         // then
         String persistedRelationshipColumnId = "be-relationship-col-1";
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), eq("RELATIONSHIP"))).willReturn(Mono.just(
+                any(), any(), eq("RELATIONSHIP"), any(), any()))
+                .willReturn(Mono.just(
                         new AffectedEntitiesSaver.SaveResult(
                                 AffectedMappingResponse.PropagatedEntities
                                         .empty(),
@@ -380,13 +385,18 @@ class RelationshipServiceTest {
         ArgumentCaptor<Validation.Database> afterDbCaptor = ArgumentCaptor
                 .forClass(Validation.Database.class);
 
+        ArgumentCaptor<Set<String>> excludePropagatedCaptor = ArgumentCaptor
+                .forClass(Set.class);
+
         verify(affectedEntitiesSaver).saveAffectedEntitiesResult(any(),
                 afterDbCaptor.capture(), anyString(), anyString(),
-                eq("RELATIONSHIP"));
+                eq("RELATIONSHIP"), any(), excludePropagatedCaptor.capture());
 
         assertThat(containsRelationshipColumnId(afterDbCaptor.getValue(),
                 "fe-relationship-col-1"))
                         .isTrue();
+        assertThat(excludePropagatedCaptor.getValue())
+                .contains("fe-relationship-col-1");
     }
 
     @Test
@@ -596,7 +606,7 @@ class RelationshipServiceTest {
                 any(Validation.CreateRelationshipRequest.class)))
                 .willReturn(Mono.just(mockResponse));
         given(affectedEntitiesSaver.saveAffectedEntitiesResult(any(), any(),
-                any(), any(), any()))
+                any(), any(), any(), any(), any()))
                 .willAnswer(invocation -> {
                     String sourceId = invocation.getArgument(3);
                     return Mono.just(new AffectedEntitiesSaver.SaveResult(

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/SchemaServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/SchemaServiceTest.java
@@ -46,12 +46,12 @@ class SchemaServiceTest {
         given(validationClient
                 .changeSchemaName(
                         any(Validation.ChangeSchemaNameRequest.class)))
-                .willReturn(Mono.just(validation.Validation.Database
-                        .newBuilder().build()));
+                .willReturn(Mono.just(
+                        Validation.Database.newBuilder().build()));
         given(validationClient
                 .deleteSchema(any(Validation.DeleteSchemaRequest.class)))
                 .willReturn(Mono.just(
-                        validation.Validation.Database.newBuilder().build()));
+                        Validation.Database.newBuilder().build()));
     }
 
     @Test
@@ -177,28 +177,27 @@ class SchemaServiceTest {
     void createSchema_mappingResponse_success() {
         Validation.CreateSchemaRequest request = Validation.CreateSchemaRequest
                 .newBuilder()
-                .setSchema(validation.Validation.Schema.newBuilder()
+                .setSchema(Validation.Schema.newBuilder()
                         .setId("fe-schema-id")
                         .setProjectId("proj-1")
-                        .setDbVendorId(validation.Validation.DbVendor.MYSQL)
+                        .setDbVendorId(Validation.DbVendor.MYSQL)
                         .setName("test-schema")
                         .setCharset("utf8mb4")
                         .setCollation("utf8mb4_general_ci")
                         .setVendorOption("ENGINE=InnoDB")
                         .build())
-                .setDatabase(validation.Validation.Database.newBuilder()
+                .setDatabase(Validation.Database.newBuilder()
                         .setId("proj-1")
                         .build())
                 .build();
 
         // ValidationClient 모킹
-        validation.Validation.Database mockResponse = validation.Validation.Database
-                .newBuilder()
+        Validation.Database mockResponse = Validation.Database.newBuilder()
                 .setId("proj-1")
-                .addSchemas(validation.Validation.Schema.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
                         .setId("be-schema-id")
                         .setProjectId("proj-1")
-                        .setDbVendorId(validation.Validation.DbVendor.MYSQL)
+                        .setDbVendorId(Validation.DbVendor.MYSQL)
                         .setName("test-schema")
                         .setCharset("utf8mb4")
                         .setCollation("utf8mb4_general_ci")

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/TableServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/TableServiceTest.java
@@ -15,7 +15,11 @@ import com.schemafy.core.erd.controller.dto.request.CreateTableRequestWithExtra;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
 import com.schemafy.core.erd.controller.dto.response.TableResponse;
+import com.schemafy.core.erd.repository.ColumnRepository;
+import com.schemafy.core.erd.repository.RelationshipRepository;
 import com.schemafy.core.erd.repository.TableRepository;
+import com.schemafy.core.erd.repository.entity.Column;
+import com.schemafy.core.erd.repository.entity.Relationship;
 import com.schemafy.core.erd.repository.entity.Table;
 import com.schemafy.core.validation.client.ValidationClient;
 
@@ -38,20 +42,29 @@ class TableServiceTest {
     @Autowired
     TableRepository tableRepository;
 
+    @Autowired
+    ColumnRepository columnRepository;
+
+    @Autowired
+    RelationshipRepository relationshipRepository;
+
     @MockitoBean
     ValidationClient validationClient;
 
     @BeforeEach
     void setUp() {
         tableRepository.deleteAll().block();
+        relationshipRepository.deleteAll().block();
+        columnRepository.deleteAll().block();
+
         given(validationClient
                 .changeTableName(any(Validation.ChangeTableNameRequest.class)))
                 .willReturn(Mono.just(
-                        validation.Validation.Database.newBuilder().build()));
+                        Validation.Database.newBuilder().build()));
         given(validationClient
                 .deleteTable(any(Validation.DeleteTableRequest.class)))
                 .willReturn(Mono.just(
-                        validation.Validation.Database.newBuilder().build()));
+                        Validation.Database.newBuilder().build()));
     }
 
     @Test
@@ -59,16 +72,16 @@ class TableServiceTest {
     void createTable_mappingResponse_success() {
         Validation.CreateTableRequest request = Validation.CreateTableRequest
                 .newBuilder()
-                .setTable(validation.Validation.Table.newBuilder()
+                .setTable(Validation.Table.newBuilder()
                         .setId("fe-table-id")
                         .setSchemaId("schema-1")
                         .setName("test-table")
                         .setComment("테스트 테이블")
                         .setTableOptions("ENGINE=InnoDB")
                         .build())
-                .setDatabase(validation.Validation.Database.newBuilder()
+                .setDatabase(Validation.Database.newBuilder()
                         .setId("proj-1")
-                        .addSchemas(validation.Validation.Schema.newBuilder()
+                        .addSchemas(Validation.Schema.newBuilder()
                                 .setId("schema-1")
                                 .setName("test-schema")
                                 .build())
@@ -79,15 +92,15 @@ class TableServiceTest {
                 request, "extra-data");
 
         // ValidationClient 모킹
-        validation.Validation.Database mockResponse = validation.Validation.Database
+        Validation.Database mockResponse = Validation.Database
                 .newBuilder()
                 .setId("proj-1")
                 .setIsAffected(true)
-                .addSchemas(validation.Validation.Schema.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
                         .setId("schema-1")
                         .setName("test-schema")
                         .setIsAffected(true)
-                        .addTables(validation.Validation.Table.newBuilder()
+                        .addTables(Validation.Table.newBuilder()
                                 .setId("be-table-id")
                                 .setSchemaId("schema-1")
                                 .setName("test-table")
@@ -230,6 +243,8 @@ class TableServiceTest {
     @Test
     @DisplayName("deleteTable: 소프트 삭제가 수행된다")
     void deleteTable_softDelete() {
+        String childTableId = "child-table";
+
         Table saved = tableRepository.save(
                 Table.builder()
                         .schemaId("schema-1")
@@ -240,17 +255,138 @@ class TableServiceTest {
                         .build())
                 .block();
 
+        Column tableOwnedColumn = columnRepository.save(
+                Column.builder()
+                        .tableId(saved.getId())
+                        .name("owned_col")
+                        .ordinalPosition(1)
+                        .dataType("INT")
+                        .build())
+                .block();
+
+        Column fkColumnToDelete = columnRepository.save(
+                Column.builder()
+                        .tableId(childTableId)
+                        .name("parent_id")
+                        .ordinalPosition(1)
+                        .dataType("INT")
+                        .build())
+                .block();
+
+        Relationship relationship = relationshipRepository.save(
+                Relationship.builder()
+                        .srcTableId(childTableId)
+                        .tgtTableId(saved.getId())
+                        .name("fk_child_parent")
+                        .kind("NON_IDENTIFYING")
+                        .cardinality("ONE_TO_MANY")
+                        .onDelete("NO_ACTION")
+                        .onUpdate("NO_ACTION")
+                        .extra("")
+                        .build())
+                .block();
+
+        Validation.Database beforeDatabase = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-1")
+                        .setName("schema")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(saved.getId())
+                                .setSchemaId("schema-1")
+                                .setName("to-delete")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(tableOwnedColumn.getId())
+                                        .setTableId(saved.getId())
+                                        .setName("owned_col")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .build())
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setSchemaId("schema-1")
+                                .setName("child")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(fkColumnToDelete.getId())
+                                        .setTableId(childTableId)
+                                        .setName("parent_id")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .addRelationships(
+                                        Validation.Relationship.newBuilder()
+                                                .setId(relationship.getId())
+                                                .setSrcTableId(childTableId)
+                                                .setTgtTableId(saved.getId())
+                                                .setName("fk_child_parent")
+                                                .setKind(
+                                                        Validation.RelationshipKind.NON_IDENTIFYING)
+                                                .setCardinality(
+                                                        Validation.RelationshipCardinality.ONE_TO_MANY)
+                                                .addColumns(
+                                                        Validation.RelationshipColumn
+                                                                .newBuilder()
+                                                                .setId(
+                                                                        "relcol-1")
+                                                                .setRelationshipId(
+                                                                        relationship
+                                                                                .getId())
+                                                                .setFkColumnId(
+                                                                        fkColumnToDelete
+                                                                                .getId())
+                                                                .setRefColumnId(
+                                                                        tableOwnedColumn
+                                                                                .getId())
+                                                                .setSeqNo(1)
+                                                                .build())
+                                                .build())
+                                .build())
+                        .build())
+                .build();
+
+        Validation.Database afterDatabase = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-1")
+                        .setName("schema")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId(childTableId)
+                                .setSchemaId("schema-1")
+                                .setName("child")
+                                .build())
+                        .build())
+                .build();
+
+        given(validationClient
+                .deleteTable(any(Validation.DeleteTableRequest.class)))
+                .willReturn(Mono.just(afterDatabase));
+
         StepVerifier
                 .create(tableService
                         .deleteTable(Validation.DeleteTableRequest.newBuilder()
                                 .setTableId(saved.getId())
                                 .setSchemaId("schema-1")
+                                .setDatabase(beforeDatabase)
                                 .build()))
                 .verifyComplete();
 
         // 삭제 플래그 확인 (deletedAt not null)
         StepVerifier.create(tableRepository.findById(saved.getId()))
                 .assertNext(found -> assertThat(found.isDeleted()).isTrue())
+                .verifyComplete();
+
+        StepVerifier.create(
+                relationshipRepository.findById(relationship.getId()))
+                .assertNext(found -> assertThat(found.isDeleted()).isTrue())
+                .verifyComplete();
+
+        StepVerifier.create(
+                columnRepository.findById(fkColumnToDelete.getId()))
+                .assertNext(found -> assertThat(found.isDeleted()).isTrue())
+                .verifyComplete();
+
+        StepVerifier.create(
+                columnRepository.findById(tableOwnedColumn.getId()))
+                .assertNext(found -> assertThat(found.isDeleted()).isFalse())
                 .verifyComplete();
     }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriterTest.java
@@ -79,8 +79,10 @@ class ValidationDatabaseIdRewriterTest {
                                                         .setId("relcol-old")
                                                         .setRelationshipId(
                                                                 "relationship-old")
-                                                        .setFkColumnId("col-old")
-                                                        .setRefColumnId("col-old")
+                                                        .setFkColumnId(
+                                                                "col-old")
+                                                        .setRefColumnId(
+                                                                "col-old")
                                                         .setSeqNo(1)
                                                         .build())
                                         .build())
@@ -145,5 +147,5 @@ class ValidationDatabaseIdRewriterTest {
         assertThat(relationshipColumn.getFkColumnId()).isEqualTo("col-new");
         assertThat(relationshipColumn.getRefColumnId()).isEqualTo("col-new");
     }
-}
 
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ValidationDatabaseIdRewriterTest.java
@@ -1,0 +1,149 @@
+package com.schemafy.core.erd.service;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import validation.Validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ValidationDatabaseIdRewriter 테스트")
+class ValidationDatabaseIdRewriterTest {
+
+    @Test
+    @DisplayName("rewrite: 모든 id/참조 필드를 매핑으로 치환한다")
+    void rewrite_replacesAllIdsAndReferences() {
+        Validation.Database database = Validation.Database.newBuilder()
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-old")
+                        .setName("schema")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId("table-old")
+                                .setSchemaId("schema-old")
+                                .setName("table")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId("col-old")
+                                        .setTableId("table-old")
+                                        .setName("col")
+                                        .setOrdinalPosition(1)
+                                        .setDataType("INT")
+                                        .build())
+                                .addIndexes(Validation.Index.newBuilder()
+                                        .setId("idx-old")
+                                        .setTableId("table-old")
+                                        .setName("idx")
+                                        .setType(Validation.IndexType.BTREE)
+                                        .setComment("")
+                                        .addColumns(Validation.IndexColumn
+                                                .newBuilder()
+                                                .setId("idxcol-old")
+                                                .setIndexId("idx-old")
+                                                .setColumnId("col-old")
+                                                .setSeqNo(1)
+                                                .setSortDir(
+                                                        Validation.IndexSortDir.ASC)
+                                                .build())
+                                        .build())
+                                .addConstraints(Validation.Constraint
+                                        .newBuilder()
+                                        .setId("constraint-old")
+                                        .setTableId("table-old")
+                                        .setName("pk")
+                                        .setKind(
+                                                Validation.ConstraintKind.PRIMARY_KEY)
+                                        .addColumns(
+                                                Validation.ConstraintColumn
+                                                        .newBuilder()
+                                                        .setId("constraintcol-old")
+                                                        .setConstraintId(
+                                                                "constraint-old")
+                                                        .setColumnId("col-old")
+                                                        .setSeqNo(1)
+                                                        .build())
+                                        .build())
+                                .addRelationships(Validation.Relationship
+                                        .newBuilder()
+                                        .setId("relationship-old")
+                                        .setSrcTableId("table-old")
+                                        .setTgtTableId("table-old")
+                                        .setName("rel")
+                                        .setKind(
+                                                Validation.RelationshipKind.NON_IDENTIFYING)
+                                        .setCardinality(
+                                                Validation.RelationshipCardinality.ONE_TO_MANY)
+                                        .addColumns(
+                                                Validation.RelationshipColumn
+                                                        .newBuilder()
+                                                        .setId("relcol-old")
+                                                        .setRelationshipId(
+                                                                "relationship-old")
+                                                        .setFkColumnId("col-old")
+                                                        .setRefColumnId("col-old")
+                                                        .setSeqNo(1)
+                                                        .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        IdMappings idMappings = new IdMappings(
+                Map.of("schema-old", "schema-new"),
+                Map.of("table-old", "table-new"),
+                Map.of("col-old", "col-new"),
+                Map.of("idx-old", "idx-new"),
+                Map.of("idxcol-old", "idxcol-new"),
+                Map.of("constraint-old", "constraint-new"),
+                Map.of("constraintcol-old", "constraintcol-new"),
+                Map.of("relationship-old", "relationship-new"),
+                Map.of("relcol-old", "relcol-new"));
+
+        Validation.Database rewritten = ValidationDatabaseIdRewriter
+                .rewrite(database, idMappings);
+
+        Validation.Schema schema = rewritten.getSchemas(0);
+        assertThat(schema.getId()).isEqualTo("schema-new");
+
+        Validation.Table table = schema.getTables(0);
+        assertThat(table.getId()).isEqualTo("table-new");
+        assertThat(table.getSchemaId()).isEqualTo("schema-new");
+
+        Validation.Column column = table.getColumns(0);
+        assertThat(column.getId()).isEqualTo("col-new");
+        assertThat(column.getTableId()).isEqualTo("table-new");
+
+        Validation.Index index = table.getIndexes(0);
+        assertThat(index.getId()).isEqualTo("idx-new");
+        assertThat(index.getTableId()).isEqualTo("table-new");
+
+        Validation.IndexColumn indexColumn = index.getColumns(0);
+        assertThat(indexColumn.getId()).isEqualTo("idxcol-new");
+        assertThat(indexColumn.getIndexId()).isEqualTo("idx-new");
+        assertThat(indexColumn.getColumnId()).isEqualTo("col-new");
+
+        Validation.Constraint constraint = table.getConstraints(0);
+        assertThat(constraint.getId()).isEqualTo("constraint-new");
+        assertThat(constraint.getTableId()).isEqualTo("table-new");
+
+        Validation.ConstraintColumn constraintColumn = constraint.getColumns(0);
+        assertThat(constraintColumn.getId()).isEqualTo("constraintcol-new");
+        assertThat(constraintColumn.getConstraintId())
+                .isEqualTo("constraint-new");
+        assertThat(constraintColumn.getColumnId()).isEqualTo("col-new");
+
+        Validation.Relationship relationship = table.getRelationships(0);
+        assertThat(relationship.getId()).isEqualTo("relationship-new");
+        assertThat(relationship.getSrcTableId()).isEqualTo("table-new");
+        assertThat(relationship.getTgtTableId()).isEqualTo("table-new");
+
+        Validation.RelationshipColumn relationshipColumn = relationship
+                .getColumns(0);
+        assertThat(relationshipColumn.getId()).isEqualTo("relcol-new");
+        assertThat(relationshipColumn.getRelationshipId())
+                .isEqualTo("relationship-new");
+        assertThat(relationshipColumn.getFkColumnId()).isEqualTo("col-new");
+        assertThat(relationshipColumn.getRefColumnId()).isEqualTo("col-new");
+    }
+}
+

--- a/packages/validator/src/lib/handlers/constraints.ts
+++ b/packages/validator/src/lib/handlers/constraints.ts
@@ -118,7 +118,16 @@ export const constraintHandlers: ConstraintHandlers = {
             isAffected: true,
             constraints: [
               ...t.constraints,
-              { ...constraint, isAffected: true, tableId },
+              {
+                ...constraint,
+                tableId,
+                isAffected: true,
+                columns: constraint.columns.map((column) => ({
+                  ...column,
+                  constraintId: constraint.id,
+                  isAffected: true,
+                })),
+              },
             ],
           }
         : { ...t, isAffected: true },

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -110,7 +110,15 @@ export const relationshipHandlers: RelationshipHandlers = {
             isAffected: true,
             relationships: [
               ...t.relationships,
-              { ...relationship, isAffected: true },
+              {
+                ...relationship,
+                isAffected: true,
+                columns: relationship.columns.map((column) => ({
+                  ...column,
+                  relationshipId: relationship.id,
+                  isAffected: true,
+                })),
+              },
             ],
           }
         : t,

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -327,18 +327,20 @@ export const deleteCascadingForeignKeys = (
 
       if (fkColumnsToDelete.length === 0) continue;
 
-      const updateIndexes: Index[] = childTable.indexes.map((idx) => ({
-        ...idx,
-        isAffected: idx.columns.some((ic) =>
-          fkColumnsToDelete.includes(ic.columnId),
-        ),
-        columns: idx.columns.filter(
-          (ic) => !fkColumnsToDelete.includes(ic.columnId),
-        ),
-      }));
+      const updateIndexes: Index[] = childTable.indexes
+        .map((idx) => ({
+          ...idx,
+          isAffected: idx.columns.some((ic) =>
+            fkColumnsToDelete.includes(ic.columnId),
+          ),
+          columns: idx.columns.filter(
+            (ic) => !fkColumnsToDelete.includes(ic.columnId),
+          ),
+        }))
+        .filter((idx) => idx.columns.length > 0);
 
-      const updateConstraints: Constraint[] = childTable.constraints.map(
-        (constraint) => ({
+      const updateConstraints: Constraint[] = childTable.constraints
+        .map((constraint) => ({
           ...constraint,
           isAffected: constraint.columns.some((cc) =>
             fkColumnsToDelete.includes(cc.columnId),
@@ -346,11 +348,11 @@ export const deleteCascadingForeignKeys = (
           columns: constraint.columns.filter(
             (cc) => !fkColumnsToDelete.includes(cc.columnId),
           ),
-        }),
-      );
+        }))
+        .filter((constraint) => constraint.columns.length > 0);
 
-      const updateRelationships: Relationship[] = childTable.relationships.map(
-        (relationship) => ({
+      const updateRelationships: Relationship[] = childTable.relationships
+        .map((relationship) => ({
           ...relationship,
           isAffected: relationship.columns.some(
             (rc) =>
@@ -362,8 +364,8 @@ export const deleteCascadingForeignKeys = (
               !fkColumnsToDelete.includes(rc.fkColumnId) &&
               !fkColumnsToDelete.includes(rc.refColumnId),
           ),
-        }),
-      );
+        }))
+        .filter((relationship) => relationship.columns.length > 0);
 
       const updateTables: Table[] = updatedSchema.tables.map((t) =>
         t.id === childTable.id
@@ -650,12 +652,14 @@ export const deleteRelatedColumns = (
               (ic) => !fkColumnsToDelete.has(ic.columnId),
             ),
           })),
-          constraints: table.constraints.map((constraint) => ({
-            ...constraint,
-            columns: constraint.columns.filter(
-              (cc) => !fkColumnsToDelete.has(cc.columnId),
-            ),
-          })),
+          constraints: table.constraints
+            .map((constraint) => ({
+              ...constraint,
+              columns: constraint.columns.filter(
+                (cc) => !fkColumnsToDelete.has(cc.columnId),
+              ),
+            }))
+            .filter((constraint) => constraint.columns.length > 0),
         };
       }
       return table;


### PR DESCRIPTION
## 개요

- 전파/매핑 로직 개선 및 삭제 동기화 보강
- ID 매핑 정합성 확보
- 전파/삭제/관계 컬럼 변경/관계 종류 전환 테스트 보강

### 전파 데이터 ID 매핑 

프론트엔드에서 기존 전파 데이터에 대해서 ID 매핑에 어려움이 생길 수밖에 없던 구조를 개선했습니다.

기존 방식에서는, 프론트엔드 -> 백엔드로 요청 시에 전파 시 생기는 데이터에 대한 ID를 전달하지 않기에 응답 시에 해당 데이터를 백엔드에서 생성한 ID를 키와 값으로 설정하여 전달하였습니다.

이로 인해 프론트엔드에서 여러 컬럼이 동시에 설정될 때 ID를 매핑하기에 어려움이 생기는 구조라고 판단했고 전파된 데이터들에 한해서는 ID 매핑을 전달하는 것이 아닌, 데이터 자체를 전달하도록 수정합니다.

비즈니스 키를 따로 생성해서 식별이 가능하게끔 구현하거나 다른 방식이 있을 텐데, 해당 방식에 프론트엔드에서 직접적으로 바로 사용하기에 편한 방식이라 생각되어 채택했습니다.

## 이슈

- close #126
