### PR TITLE
feat(#109): implement CacheType-base router

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/cache/config/CacheProperties.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/cache/config/CacheProperties.java
@@ -10,9 +10,28 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "cache")
 public class CacheProperties {
 
-    private CacheType type = CacheType.CAFFEINE;
-    private long maximumSize = 10000;
-    private int expireAfterWriteMinutes = 30;
-    private int expireAfterAccessMinutes = 10;
+    private CaffeineProperties caffeine = new CaffeineProperties();
+    private RedisProperties redis = new RedisProperties();
+
+    @Getter
+    @Setter
+    public static class CaffeineProperties {
+
+        private boolean enabled = true;
+        private long maximumSize = 10000;
+        private int expireAfterWriteMinutes = 30;
+        private int expireAfterAccessMinutes = 10;
+
+    }
+
+    @Getter
+    @Setter
+    public static class RedisProperties {
+
+        private boolean enabled = true;
+        private int defaultTtlMinutes = 30;
+        private String keyPrefix = "cache::";
+
+    }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CacheRouter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CacheRouter.java
@@ -1,0 +1,57 @@
+package com.schemafy.core.cache.service;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.cache.config.CacheType;
+import com.schemafy.core.cache.service.dto.CacheStatsDto;
+
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class CacheRouter {
+
+    private final CacheService caffeineCacheService;
+    private final ObjectProvider<CacheService> redisCacheServiceProvider;
+
+    public CacheRouter(
+            CacheService caffeineCacheService,
+            @Lazy @Qualifier("redisCacheService") ObjectProvider<CacheService> redisCacheServiceProvider) {
+        this.caffeineCacheService = caffeineCacheService;
+        this.redisCacheServiceProvider = redisCacheServiceProvider;
+        log.info("CacheRouter initialized with Caffeine and Redis caches");
+    }
+
+    public Mono<String> get(String key, CacheType cacheType) {
+        return selectCache(cacheType).get(key);
+    }
+
+    public Mono<Void> put(String key, String value, CacheType cacheType) {
+        return selectCache(cacheType).put(key, value);
+    }
+
+    public Mono<Void> evict(String key, CacheType cacheType) {
+        return selectCache(cacheType).evict(key);
+    }
+
+    public Mono<Boolean> exists(String key, CacheType cacheType) {
+        return selectCache(cacheType).exists(key);
+    }
+
+    public Mono<CacheStatsDto> getStats(CacheType cacheType) {
+        return selectCache(cacheType).getStats();
+    }
+
+    private CacheService selectCache(CacheType cacheType) {
+        return switch (cacheType) {
+        case CAFFEINE -> caffeineCacheService;
+        case REDIS -> redisCacheServiceProvider
+                .getIfAvailable(() -> caffeineCacheService);
+        };
+    }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CacheRouter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CacheRouter.java
@@ -1,8 +1,6 @@
 package com.schemafy.core.cache.service;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.core.cache.config.CacheType;
@@ -16,13 +14,13 @@ import reactor.core.publisher.Mono;
 public class CacheRouter {
 
     private final CacheService caffeineCacheService;
-    private final ObjectProvider<CacheService> redisCacheServiceProvider;
+    private final CacheService redisCacheService;
 
     public CacheRouter(
             CacheService caffeineCacheService,
-            @Lazy @Qualifier("redisCacheService") ObjectProvider<CacheService> redisCacheServiceProvider) {
+            @Qualifier("redisCacheService") CacheService redisCacheService) {
         this.caffeineCacheService = caffeineCacheService;
-        this.redisCacheServiceProvider = redisCacheServiceProvider;
+        this.redisCacheService = redisCacheService;
         log.info("CacheRouter initialized with Caffeine and Redis caches");
     }
 
@@ -49,8 +47,7 @@ public class CacheRouter {
     private CacheService selectCache(CacheType cacheType) {
         return switch (cacheType) {
         case CAFFEINE -> caffeineCacheService;
-        case REDIS -> redisCacheServiceProvider
-                .getIfAvailable(() -> caffeineCacheService);
+        case REDIS -> redisCacheService;
         };
     }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CaffeineCacheService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/cache/service/CaffeineCacheService.java
@@ -3,6 +3,7 @@ package com.schemafy.core.cache.service;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -13,18 +14,20 @@ import com.schemafy.core.cache.service.dto.CacheStatsDto;
 
 import reactor.core.publisher.Mono;
 
-@Service
-@ConditionalOnProperty(name = "cache.type", havingValue = "CAFFEINE", matchIfMissing = true)
+@Primary
+@Service("caffeineCacheService")
+@ConditionalOnProperty(name = "cache.caffeine.enabled", havingValue = "true", matchIfMissing = true)
 public class CaffeineCacheService implements CacheService {
 
     private final Cache<String, String> cache;
 
     public CaffeineCacheService(CacheProperties properties) {
+        CacheProperties.CaffeineProperties caffeine = properties.getCaffeine();
         this.cache = Caffeine.newBuilder()
-                .maximumSize(properties.getMaximumSize())
-                .expireAfterWrite(properties.getExpireAfterWriteMinutes(),
+                .maximumSize(caffeine.getMaximumSize())
+                .expireAfterWrite(caffeine.getExpireAfterWriteMinutes(),
                         TimeUnit.MINUTES)
-                .expireAfterAccess(properties.getExpireAfterAccessMinutes(),
+                .expireAfterAccess(caffeine.getExpireAfterAccessMinutes(),
                         TimeUnit.MINUTES)
                 .recordStats()
                 .build();

--- a/apps/backend/core/src/main/java/com/schemafy/core/cache/service/RedisCacheService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/cache/service/RedisCacheService.java
@@ -1,0 +1,83 @@
+package com.schemafy.core.cache.service;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.cache.config.CacheProperties;
+import com.schemafy.core.cache.service.dto.CacheStatsDto;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service("redisCacheService")
+@ConditionalOnRedisEnabled
+@RequiredArgsConstructor
+public class RedisCacheService implements CacheService {
+
+    private final ReactiveStringRedisTemplate redisTemplate;
+    private final CacheProperties cacheProperties;
+
+    private final AtomicLong hitCount = new AtomicLong(0);
+    private final AtomicLong missCount = new AtomicLong(0);
+
+    @Override
+    public Mono<String> get(String key) {
+        String prefixedKey = getPrefixedKey(key);
+        return redisTemplate.opsForValue()
+                .get(prefixedKey)
+                .doOnNext(v -> hitCount.incrementAndGet())
+                .switchIfEmpty(Mono.defer(() -> {
+                    missCount.incrementAndGet();
+                    return Mono.empty();
+                }));
+    }
+
+    @Override
+    public Mono<Void> put(String key, String value) {
+        String prefixedKey = getPrefixedKey(key);
+        Duration ttl = Duration
+                .ofMinutes(cacheProperties.getRedis().getDefaultTtlMinutes());
+        return redisTemplate.opsForValue()
+                .set(prefixedKey, value, ttl)
+                .then();
+    }
+
+    @Override
+    public Mono<Void> evict(String key) {
+        String prefixedKey = getPrefixedKey(key);
+        return redisTemplate.delete(prefixedKey).then();
+    }
+
+    @Override
+    public Mono<Boolean> exists(String key) {
+        String prefixedKey = getPrefixedKey(key);
+        return redisTemplate.hasKey(prefixedKey);
+    }
+
+    @Override
+    public Mono<CacheStatsDto> getStats() {
+        return redisTemplate.execute(connection -> connection.serverCommands()
+                .dbSize())
+                .next()
+                .defaultIfEmpty(0L)
+                .map(size -> {
+                    long hits = hitCount.get();
+                    long misses = missCount.get();
+                    double hitRate = (hits + misses > 0)
+                            ? (double) hits / (hits + misses)
+                            : 0.0;
+                    return new CacheStatsDto(hits, misses, hitRate, size);
+                });
+    }
+
+    private String getPrefixedKey(String key) {
+        return cacheProperties.getRedis().getKeyPrefix() + key;
+    }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/ulid/service/UlidService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/ulid/service/UlidService.java
@@ -2,7 +2,8 @@ package com.schemafy.core.ulid.service;
 
 import org.springframework.stereotype.Service;
 
-import com.schemafy.core.cache.service.CacheService;
+import com.schemafy.core.cache.config.CacheType;
+import com.schemafy.core.cache.service.CacheRouter;
 import com.schemafy.core.ulid.generator.UlidGenerator;
 
 import lombok.RequiredArgsConstructor;
@@ -12,13 +13,14 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class UlidService {
 
-    private final CacheService cacheService;
+    private final CacheRouter cacheRouter;
 
     private static final String ULID_PREFIX = "ulid::";
 
     public Mono<String> generateTemporaryUlid() {
         return Mono.fromCallable(UlidGenerator::generate)
-                .flatMap(ulid -> cacheService.put(ULID_PREFIX + ulid, "valid")
+                .flatMap(ulid -> cacheRouter
+                        .put(ULID_PREFIX + ulid, "valid", CacheType.CAFFEINE)
                         .thenReturn(ulid));
     }
 

--- a/apps/backend/core/src/main/resources/application-local.yml
+++ b/apps/backend/core/src/main/resources/application-local.yml
@@ -20,10 +20,15 @@ spring:
       mode: always
 
 cache:
-  type: CAFFEINE
-  maximum-size: 10000
-  expire-after-write-minutes: 30
-  expire-after-access-minutes: 10
+  caffeine:
+    enabled: true
+    maximum-size: 10000
+    expire-after-write-minutes: 30
+    expire-after-access-minutes: 10
+  redis:
+    enabled: true
+    default-ttl-minutes: 30
+    key-prefix: "cache::"
 
 jwt:
   secret: my-super-secret-key-for-jwt-token-generation-min-256-bits-required

--- a/apps/backend/core/src/main/resources/application-server.yml
+++ b/apps/backend/core/src/main/resources/application-server.yml
@@ -20,10 +20,15 @@ spring:
       schema-locations: classpath:db/schema/mariadb/**/*.sql
 
 cache:
-  type: CAFFEINE
-  maximum-size: 10000
-  expire-after-write-minutes: 30
-  expire-after-access-minutes: 10
+  caffeine:
+    enabled: true
+    maximum-size: 10000
+    expire-after-write-minutes: 30
+    expire-after-access-minutes: 10
+  redis:
+    enabled: true
+    default-ttl-minutes: 30
+    key-prefix: "cache::"
 
 jwt:
   secret: ${JWT_SECRET:my-super-secret-key-for-jwt-token-generation-min-256-bits-required}

--- a/apps/backend/core/src/main/resources/application.yml
+++ b/apps/backend/core/src/main/resources/application.yml
@@ -36,10 +36,15 @@ grpc:
     deadline-seconds: 30
 
 cache:
-  type: CAFFEINE
-  maximum-size: 10000
-  expire-after-write-minutes: 30
-  expire-after-access-minutes: 10
+  caffeine:
+    enabled: true
+    maximum-size: 10000
+    expire-after-write-minutes: 30
+    expire-after-access-minutes: 10
+  redis:
+    enabled: true
+    default-ttl-minutes: 30
+    key-prefix: "cache::"
 
 management:
   endpoints:

--- a/apps/backend/core/src/test/java/com/schemafy/core/cache/config/TestCacheConfig.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/cache/config/TestCacheConfig.java
@@ -1,0 +1,48 @@
+package com.schemafy.core.cache.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.schemafy.core.cache.service.CacheService;
+import com.schemafy.core.cache.service.dto.CacheStatsDto;
+
+import reactor.core.publisher.Mono;
+
+@Configuration
+@Profile({ "test", "dev" })
+public class TestCacheConfig {
+
+    @Bean("redisCacheService")
+    public CacheService mockRedisCacheService() {
+        return new CacheService() {
+
+            @Override
+            public Mono<String> get(String key) {
+                return Mono.empty();
+            }
+
+            @Override
+            public Mono<Void> put(String key, String value) {
+                return Mono.empty();
+            }
+
+            @Override
+            public Mono<Void> evict(String key) {
+                return Mono.empty();
+            }
+
+            @Override
+            public Mono<Boolean> exists(String key) {
+                return Mono.just(false);
+            }
+
+            @Override
+            public Mono<CacheStatsDto> getStats() {
+                return Mono.just(new CacheStatsDto(0L, 0L, 0.0, 0L));
+            }
+
+        };
+    }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/cache/service/CacheRouterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/cache/service/CacheRouterTest.java
@@ -1,0 +1,76 @@
+package com.schemafy.core.cache.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.schemafy.core.cache.config.CacheType;
+
+import reactor.test.StepVerifier;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CacheRouterTest {
+
+    @Autowired
+    private CacheRouter cacheRouter;
+
+    @Test
+    void testPutAndGetWithCaffeine() {
+        String key = "test-caffeine-key";
+        String value = "test-caffeine-value";
+
+        StepVerifier.create(
+                cacheRouter.put(key, value, CacheType.CAFFEINE)
+                        .then(cacheRouter.get(key, CacheType.CAFFEINE)))
+                .expectNext(value)
+                .verifyComplete();
+    }
+
+    @Test
+    void testPutAndGetWithRedis_ShouldFallbackToCaffeine() {
+        // Redis is disabled in test, should fallback to Caffeine
+        String key = "test-redis-key";
+        String value = "test-redis-value";
+
+        StepVerifier.create(
+                cacheRouter.put(key, value, CacheType.REDIS)
+                        .then(cacheRouter.get(key, CacheType.REDIS)))
+                .expectNext(value)
+                .verifyComplete();
+    }
+
+    @Test
+    void testEvictWithCaffeine() {
+        String key = "test-evict-key";
+        String value = "test-evict-value";
+
+        StepVerifier.create(
+                cacheRouter.put(key, value, CacheType.CAFFEINE)
+                        .then(cacheRouter.evict(key, CacheType.CAFFEINE))
+                        .then(cacheRouter.exists(key, CacheType.CAFFEINE)))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void testExistsWithCaffeine() {
+        String key = "test-exists-key";
+        String value = "test-exists-value";
+
+        StepVerifier.create(
+                cacheRouter.put(key, value, CacheType.CAFFEINE)
+                        .then(cacheRouter.exists(key, CacheType.CAFFEINE)))
+                .expectNext(true)
+                .verifyComplete();
+    }
+
+    @Test
+    void testGetStats() {
+        StepVerifier.create(cacheRouter.getStats(CacheType.CAFFEINE))
+                .expectNextMatches(stats -> stats != null)
+                .verifyComplete();
+    }
+
+}

--- a/apps/backend/core/src/test/resources/application.yml
+++ b/apps/backend/core/src/test/resources/application.yml
@@ -49,10 +49,13 @@ cors:
   allowed-origins: http://localhost:3000
 
 cache:
-  type: CAFFEINE
-  maximum-size: 1000
-  expire-after-write-minutes: 5
-  expire-after-access-minutes: 2
+  caffeine:
+    enabled: true
+    maximum-size: 1000
+    expire-after-write-minutes: 5
+    expire-after-access-minutes: 2
+  redis:
+    enabled: false
 
 logging:
   level:

--- a/apps/backend/core/src/test/resources/application.yml
+++ b/apps/backend/core/src/test/resources/application.yml
@@ -9,6 +9,9 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
 
+  main:
+    allow-bean-definition-overriding: true
+
   data:
     redis:
       enabled: false


### PR DESCRIPTION
## 개요

현재 cache.type 조건으로 CacheService 구현이 하나만 빈으로 생성되어, Caffeine 또는 Redis 중 하나만 선택적으로 사용 가능함. 용도별로 로컬 캐시(Caffeine)와 분산 캐시(Redis)를 선택해 쓸 수 있도록 하였습니다.

`CacheRouter`에 `caffeine`과 `redis`를 등록한 후 CacheType 에 따라서 원하는 캐시를 활용하도록 하였습니다.

주요 변경사항
- `CacheRouter` 구현
- `CacheRouter`에 `caffeine`과 `redis` 등록

## 이슈

- close #109 