### PR TITLE
feat(#144): add auto labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+back-end:
+  - changed-files:
+      - any-glob-to-any-file: "apps/backend/**"
+
+front-end:
+  - changed-files:
+      - any-glob-to-any-file: "apps/frontend/**"
+
+shared:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**"
+          - "!apps/backend/**"
+          - "!apps/frontend/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,8 @@
 back-end:
   - changed-files:
-      - any-glob-to-any-file: "apps/backend/**"
+      - any-glob-to-any-file:
+          - "apps/backend/**"
+          - "apps/validation-server/**"
 
 front-end:
   - changed-files:

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,18 @@
+name: Auto Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
## 개요
`path` 기준 자동 라벨 워크플로우 작성
- apps/backend/** 변경 → `back-end`
- apps/frontend/** 변경 → `front-end`
- 그 외 → `shared`

여러 경로를 동시에 수정하면 해당하는 모든 라벨이 추가됩니다.

## 이슈


- close #144