### PR TITLE
fix(#146): support column type propagation and relationship kind changes

### DIFF
--- a/apps/backend/core/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/core/src/docs/asciidoc/api-guide.adoc
@@ -886,6 +886,38 @@ include::{snippets}/relationship-update-cardinality/response-fields.adoc[]
 
 ---
 
+==== Relationship 종류 변경
+
+Relationship의 종류(식별/비식별)를 변경합니다.
+
+[source]
+----
+PUT /api/v1.0/relationships/{relationshipId}/kind
+----
+
+[discrete]
+==== 요청
+
+include::{snippets}/relationship-update-kind/http-request.adoc[]
+include::{snippets}/relationship-update-kind/path-parameters.adoc[]
+include::{snippets}/relationship-update-kind/request-headers.adoc[]
+include::{snippets}/relationship-update-kind/request-fields.adoc[]
+include::{snippets}/relationship-update-kind/curl-request.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/relationship-update-kind/response-headers.adoc[]
+include::{snippets}/relationship-update-kind/response-body.adoc[]
+include::{snippets}/relationship-update-kind/http-response.adoc[]
+
+[discrete]
+==== 응답 필드
+
+include::{snippets}/relationship-update-kind/response-fields.adoc[]
+
+---
+
 ==== Relationship에 컬럼 추가
 
 관계에 컬럼을 추가합니다.

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/ColumnController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/ColumnController.java
@@ -14,6 +14,7 @@ import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.common.exception.ErrorCode;
 import com.schemafy.core.common.type.BaseResponse;
+import com.schemafy.core.erd.controller.dto.response.AffectedColumnsResponse;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.ColumnResponse;
 import com.schemafy.core.erd.service.ColumnService;
@@ -64,7 +65,7 @@ public class ColumnController {
 
     @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
     @PutMapping("/columns/{columnId}/type")
-    public Mono<BaseResponse<ColumnResponse>> updateColumnType(
+    public Mono<BaseResponse<AffectedColumnsResponse>> updateColumnType(
             @PathVariable String columnId,
             @RequestBody ChangeColumnTypeRequest request) {
         if (!columnId.equals(request.getColumnId())) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/RelationshipController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/RelationshipController.java
@@ -87,6 +87,19 @@ public class RelationshipController {
     }
 
     @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
+    @PutMapping("/relationships/{relationshipId}/kind")
+    public Mono<BaseResponse<RelationshipResponse>> updateRelationshipKind(
+            @PathVariable String relationshipId,
+            @RequestBody Validation.ChangeRelationshipKindRequest request) {
+        if (!relationshipId.equals(request.getRelationshipId())) {
+            return Mono.error(
+                    new BusinessException(ErrorCode.COMMON_INVALID_PARAMETER));
+        }
+        return relationshipService.updateRelationshipKind(request)
+                .map(BaseResponse::success);
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
     @PostMapping("/relationships/{relationshipId}/columns")
     public Mono<BaseResponse<AffectedMappingResponse>> addColumnToRelationship(
             @PathVariable String relationshipId,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedColumnsResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedColumnsResponse.java
@@ -1,0 +1,6 @@
+package com.schemafy.core.erd.controller.dto.response;
+
+import java.util.List;
+
+public record AffectedColumnsResponse(List<ColumnResponse> columns) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/AffectedMappingResponse.java
@@ -69,6 +69,7 @@ public record AffectedMappingResponse(
             String constraintColumnId,
             String constraintId,
             String columnId,
+            int seqNo,
             String sourceType,
             String sourceId) {
     }
@@ -77,6 +78,7 @@ public record AffectedMappingResponse(
             String indexColumnId,
             String indexId,
             String columnId,
+            int seqNo,
             String sourceType,
             String sourceId) {
     }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/RelationshipRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/repository/RelationshipRepository.java
@@ -13,7 +13,7 @@ public interface RelationshipRepository
 
     public Mono<Relationship> findByIdAndDeletedAtIsNull(String id);
 
-    @Query("SELECT * FROM db_relationships WHERE deleted_at IS NULL AND src_table_id = :tableId OR tgt_table_id = :tableId")
+    @Query("SELECT * FROM db_relationships WHERE deleted_at IS NULL AND (src_table_id = :tableId OR tgt_table_id = :tableId)")
     public Flux<Relationship> findByTableIdAndDeletedAtIsNull(String tableId);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -427,6 +427,8 @@ public class AffectedEntitiesSaver {
                                                                         .getIndexId(),
                                                                 entity
                                                                         .getColumnId(),
+                                                                entity
+                                                                        .getSeqNo(),
                                                                 sourceType,
                                                                 sourceId));
                                             }
@@ -468,6 +470,8 @@ public class AffectedEntitiesSaver {
                                                                         .getConstraintId(),
                                                                 entity
                                                                         .getColumnId(),
+                                                                entity
+                                                                        .getSeqNo(),
                                                                 sourceType,
                                                                 sourceId));
                                             }
@@ -742,3 +746,4 @@ public class AffectedEntitiesSaver {
     }
 
 }
+

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -140,6 +140,8 @@ public class AffectedEntitiesSaver {
             Set<String> excludedPropagatedIds = excludePropagatedEntityIds != null
                     ? excludePropagatedEntityIds
                     : Set.of();
+            boolean isPropagationContext = sourceId != null
+                    && sourceType != null;
 
             List<PropagatedColumn> propagatedColumns = new ArrayList<>();
             List<PropagatedRelationshipColumn> propagatedRelationshipColumns = new ArrayList<>();
@@ -285,11 +287,10 @@ public class AffectedEntitiesSaver {
                                             columnIdMap.put(column.getId(),
                                                     savedColumn.getId());
 
-                                            if (sourceId != null
-                                                    && sourceType != null
-                                                    && !excludedPropagatedIds
-                                                            .contains(
-                                                                    column.getId())) {
+                                            if (shouldTrackPropagation(
+                                                    isPropagationContext,
+                                                    excludedPropagatedIds,
+                                                    column.getId())) {
                                                 savedPropagatedColumns.add(
                                                         new SavedPropagatedColumn(
                                                                 savedColumn
@@ -304,7 +305,7 @@ public class AffectedEntitiesSaver {
 
             Mono<Void> populatePropagatedColumnsTask = saveColumnsTask.then(
                     Mono.fromRunnable(() -> {
-                        if (sourceId == null || sourceType == null) {
+                        if (!isPropagationContext) {
                             return;
                         }
 
@@ -354,11 +355,10 @@ public class AffectedEntitiesSaver {
                                                     constraint.getId(),
                                                     savedConstraint.getId());
 
-                                            if (sourceId != null
-                                                    && sourceType != null
-                                                    && !excludedPropagatedIds
-                                                            .contains(constraint
-                                                                    .getId())) {
+                                            if (shouldTrackPropagation(
+                                                    isPropagationContext,
+                                                    excludedPropagatedIds,
+                                                    constraint.getId())) {
                                                 propagatedConstraints
                                                         .add(new PropagatedConstraint(
                                                                 savedConstraint
@@ -415,12 +415,10 @@ public class AffectedEntitiesSaver {
                                             indexColumnIdMap.put(
                                                     indexColumn.getId(),
                                                     savedIndexColumn.getId());
-                                            if (sourceId != null
-                                                    && sourceType != null
-                                                    && !excludedPropagatedIds
-                                                            .contains(
-                                                                    indexColumn
-                                                                            .getId())) {
+                                            if (shouldTrackPropagation(
+                                                    isPropagationContext,
+                                                    excludedPropagatedIds,
+                                                    indexColumn.getId())) {
                                                 propagatedIndexColumns
                                                         .add(new PropagatedIndexColumn(
                                                                 savedIndexColumn
@@ -458,12 +456,10 @@ public class AffectedEntitiesSaver {
                                                     constraintColumn.getId(),
                                                     savedConstraintColumn
                                                             .getId());
-                                            if (sourceId != null
-                                                    && sourceType != null
-                                                    && !excludedPropagatedIds
-                                                            .contains(
-                                                                    constraintColumn
-                                                                            .getId())) {
+                                            if (shouldTrackPropagation(
+                                                    isPropagationContext,
+                                                    excludedPropagatedIds,
+                                                    constraintColumn.getId())) {
                                                 propagatedConstraintColumns
                                                         .add(new PropagatedConstraintColumn(
                                                                 savedConstraintColumn
@@ -511,12 +507,11 @@ public class AffectedEntitiesSaver {
                                                     relationshipColumn.getId(),
                                                     savedRelationshipColumn
                                                             .getId());
-                                            if (sourceId != null
-                                                    && sourceType != null
-                                                    && !excludedPropagatedIds
-                                                            .contains(
-                                                                    relationshipColumn
-                                                                            .getId())) {
+                                            if (shouldTrackPropagation(
+                                                    isPropagationContext,
+                                                    excludedPropagatedIds,
+                                                    relationshipColumn
+                                                            .getId())) {
                                                 propagatedRelationshipColumns
                                                         .add(new PropagatedRelationshipColumn(
                                                                 savedRelationshipColumn
@@ -569,6 +564,14 @@ public class AffectedEntitiesSaver {
             Map<String, String> idMap) {
         String mappedId = idMap.get(originalId);
         return mappedId != null ? mappedId : originalId;
+    }
+
+    private static boolean shouldTrackPropagation(
+            boolean isPropagationContext,
+            Set<String> excludedPropagatedIds,
+            String entityId) {
+        return isPropagationContext
+                && !excludedPropagatedIds.contains(entityId);
     }
 
     private Set<String> collectAllEntityIds(
@@ -654,15 +657,7 @@ public class AffectedEntitiesSaver {
 
             for (Validation.RelationshipColumn relationshipColumn : relationship
                     .getColumnsList()) {
-                if (relationshipColumn.getFkColumnId().isBlank()) {
-                    continue;
-                }
-
-                fkToRefMap.put(
-                        remapId(relationshipColumn.getFkColumnId(),
-                                columnIdMap),
-                        remapId(relationshipColumn.getRefColumnId(),
-                                columnIdMap));
+                addFkToRefMapping(fkToRefMap, relationshipColumn, columnIdMap);
             }
             return fkToRefMap;
         }
@@ -689,16 +684,8 @@ public class AffectedEntitiesSaver {
                                 continue;
                             }
 
-                            if (relationshipColumn.getFkColumnId().isBlank()) {
-                                continue;
-                            }
-
-                            fkToRefMap.put(remapId(
-                                    relationshipColumn.getFkColumnId(),
-                                    columnIdMap),
-                                    remapId(
-                                            relationshipColumn.getRefColumnId(),
-                                            columnIdMap));
+                            addFkToRefMapping(fkToRefMap, relationshipColumn,
+                                    columnIdMap);
                         }
                     }
                 }
@@ -706,6 +693,20 @@ public class AffectedEntitiesSaver {
         }
 
         return fkToRefMap;
+    }
+
+    private static void addFkToRefMapping(
+            Map<String, String> fkToRefMap,
+            Validation.RelationshipColumn relationshipColumn,
+            Map<String, String> columnIdMap) {
+        String fkColumnId = relationshipColumn.getFkColumnId();
+        if (fkColumnId.isBlank()) {
+            return;
+        }
+
+        fkToRefMap.put(
+                remapId(fkColumnId, columnIdMap),
+                remapId(relationshipColumn.getRefColumnId(), columnIdMap));
     }
 
     private static Validation.Relationship findRelationshipById(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/AffectedEntitiesSaver.java
@@ -746,4 +746,3 @@ public class AffectedEntitiesSaver {
     }
 
 }
-

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ColumnService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/ColumnService.java
@@ -1,10 +1,14 @@
 package com.schemafy.core.erd.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.common.exception.ErrorCode;
+import com.schemafy.core.erd.controller.dto.response.AffectedColumnsResponse;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.ColumnResponse;
 import com.schemafy.core.erd.mapper.ErdMapper;
@@ -67,17 +71,51 @@ public class ColumnService {
                 .map(ColumnResponse::from);
     }
 
-    public Mono<ColumnResponse> updateColumnType(
+    public Mono<AffectedColumnsResponse> updateColumnType(
             Validation.ChangeColumnTypeRequest request) {
         return columnRepository
                 .findByIdAndDeletedAtIsNull(request.getColumnId())
                 .switchIfEmpty(Mono.error(
                         new BusinessException(ErrorCode.ERD_COLUMN_NOT_FOUND)))
-                .delayUntil(
-                        ignore -> validationClient.changeColumnType(request))
-                .doOnNext(column -> column.setDataType(request.getDataType()))
-                .flatMap(columnRepository::save)
-                .map(ColumnResponse::from);
+                .flatMap(ignore -> validationClient.changeColumnType(request)
+                        .flatMap(afterDatabase -> transactionalOperator
+                                .transactional(saveAffectedColumns(
+                                        afterDatabase))));
+    }
+
+    private Mono<AffectedColumnsResponse> saveAffectedColumns(
+            Validation.Database afterDatabase) {
+        List<Validation.Column> affectedColumns = collectAffectedColumns(
+                afterDatabase);
+
+        return Flux.fromIterable(affectedColumns)
+                .concatMap(column -> columnRepository
+                        .findByIdAndDeletedAtIsNull(column.getId())
+                        .switchIfEmpty(Mono.error(new BusinessException(
+                                ErrorCode.ERD_COLUMN_NOT_FOUND)))
+                        .doOnNext(entity -> {
+                            entity.setDataType(column.getDataType());
+                            entity.setLengthScale(column.getLengthScale());
+                        })
+                        .flatMap(columnRepository::save)
+                        .map(ColumnResponse::from))
+                .collectList()
+                .map(AffectedColumnsResponse::new);
+    }
+
+    private static List<Validation.Column> collectAffectedColumns(
+            Validation.Database database) {
+        List<Validation.Column> affectedColumns = new ArrayList<>();
+        for (Validation.Schema schema : database.getSchemasList()) {
+            for (Validation.Table table : schema.getTablesList()) {
+                for (Validation.Column column : table.getColumnsList()) {
+                    if (column.getIsAffected()) {
+                        affectedColumns.add(column);
+                    }
+                }
+            }
+        }
+        return affectedColumns;
     }
 
     public Mono<ColumnResponse> updateColumnPosition(

--- a/apps/backend/core/src/main/java/com/schemafy/core/validation/client/ValidationClient.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/validation/client/ValidationClient.java
@@ -31,6 +31,7 @@ import validation.Validation.ChangeColumnTypeRequest;
 import validation.Validation.ChangeConstraintNameRequest;
 import validation.Validation.ChangeIndexNameRequest;
 import validation.Validation.ChangeRelationshipCardinalityRequest;
+import validation.Validation.ChangeRelationshipKindRequest;
 import validation.Validation.ChangeRelationshipNameRequest;
 import validation.Validation.ChangeSchemaNameRequest;
 import validation.Validation.ChangeTableNameRequest;
@@ -187,6 +188,13 @@ public class ValidationClient {
         return executeValidation(
                 () -> withDeadline().changeRelationshipCardinality(request),
                 "changeRelationshipCardinality");
+    }
+
+    public Mono<Database> changeRelationshipKind(
+            ChangeRelationshipKindRequest request) {
+        return executeValidation(
+                () -> withDeadline().changeRelationshipKind(request),
+                "changeRelationshipKind");
     }
 
     public Mono<Database> addColumnToRelationship(

--- a/apps/backend/core/src/main/proto/validation.proto
+++ b/apps/backend/core/src/main/proto/validation.proto
@@ -328,6 +328,13 @@ message ChangeRelationshipCardinalityRequest {
     RelationshipCardinality cardinality = 4;
 }
 
+message ChangeRelationshipKindRequest {
+    Database database = 1;
+    string schemaId = 2;
+    string relationshipId = 3;
+    RelationshipKind kind = 4;
+}
+
 message AddColumnToRelationshipRequest {
     Database database = 1;
     string schemaId = 2;
@@ -426,6 +433,7 @@ service ValidationService {
     rpc DeleteRelationship (DeleteRelationshipRequest) returns (ValidateResult);
     rpc ChangeRelationshipName (ChangeRelationshipNameRequest) returns (ValidateResult);
     rpc ChangeRelationshipCardinality (ChangeRelationshipCardinalityRequest) returns (ValidateResult);
+    rpc ChangeRelationshipKind (ChangeRelationshipKindRequest) returns (ValidateResult);
     rpc AddColumnToRelationship (AddColumnToRelationshipRequest) returns (ValidateResult);
     rpc RemoveColumnFromRelationship (RemoveColumnFromRelationshipRequest) returns (ValidateResult);
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ColumnControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/ColumnControllerTest.java
@@ -1,5 +1,7 @@
 package com.schemafy.core.erd.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -19,6 +21,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import com.schemafy.core.common.constant.ApiPath;
 import com.schemafy.core.common.security.WithMockCustomUser;
+import com.schemafy.core.erd.controller.dto.response.AffectedColumnsResponse;
 import com.schemafy.core.erd.controller.dto.response.AffectedMappingResponse;
 import com.schemafy.core.erd.controller.dto.response.ColumnResponse;
 import com.schemafy.core.erd.service.ColumnService;
@@ -540,7 +543,7 @@ class ColumnControllerTest {
                         builder);
         Validation.ChangeColumnTypeRequest request = builder.build();
 
-        ColumnResponse mockResponse = objectMapper.treeToValue(
+        ColumnResponse columnResponse = objectMapper.treeToValue(
                 objectMapper
                         .readTree(
                                 """
@@ -563,6 +566,9 @@ class ColumnControllerTest {
                         .get("result"),
                 ColumnResponse.class);
 
+        AffectedColumnsResponse mockResponse = new AffectedColumnsResponse(
+                List.of(columnResponse));
+
         given(columnService.updateColumnType(request))
                 .willReturn(Mono.just(mockResponse));
 
@@ -576,9 +582,11 @@ class ColumnControllerTest {
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.success").isEqualTo(true)
-                .jsonPath("$.result.id").isEqualTo("06D6W90RSE1VPFRMM4XPKYGM9M")
-                .jsonPath("$.result.name").isEqualTo("uid")
-                .jsonPath("$.result.dataType").isEqualTo("INTEGER")
+                .jsonPath("$.result.columns[0].id")
+                .isEqualTo("06D6W90RSE1VPFRMM4XPKYGM9M")
+                .jsonPath("$.result.columns[0].name").isEqualTo("uid")
+                .jsonPath("$.result.columns[0].dataType")
+                .isEqualTo("INTEGER")
                 .consumeWith(document("column-update-type",
                         pathParameters(
                                 parameterWithName("columnId")
@@ -608,26 +616,30 @@ class ColumnControllerTest {
                                 fieldWithPath("success")
                                         .description("요청 성공 여부"),
                                 fieldWithPath("result")
-                                        .description("수정된 컬럼 정보"),
-                                fieldWithPath("result.id")
+                                        .description("변경된 컬럼 목록"),
+                                fieldWithPath("result.columns")
+                                        .description("영향받은 컬럼 정보"),
+                                fieldWithPath("result.columns[].id")
                                         .description("컬럼 ID"),
-                                fieldWithPath("result.tableId")
+                                fieldWithPath("result.columns[].tableId")
                                         .description("테이블 ID"),
-                                fieldWithPath("result.name")
+                                fieldWithPath("result.columns[].name")
                                         .description("컬럼 이름"),
-                                fieldWithPath("result.dataType")
+                                fieldWithPath("result.columns[].dataType")
                                         .description("변경된 데이터 타입"),
-                                fieldWithPath("result.lengthScale")
+                                fieldWithPath("result.columns[].lengthScale")
                                         .description("길이/스케일"),
-                                fieldWithPath("result.isAutoIncrement")
+                                fieldWithPath(
+                                        "result.columns[].isAutoIncrement")
                                         .description("자동 증가 여부"),
-                                fieldWithPath("result.charset")
+                                fieldWithPath("result.columns[].charset")
                                         .description("문자 집합"),
-                                fieldWithPath("result.collation")
+                                fieldWithPath("result.columns[].collation")
                                         .description("정렬 규칙"),
-                                fieldWithPath("result.comment")
+                                fieldWithPath("result.columns[].comment")
                                         .description("컬럼 설명"),
-                                fieldWithPath("result.ordinalPosition")
+                                fieldWithPath(
+                                        "result.columns[].ordinalPosition")
                                         .description("컬럼 위치"))));
     }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
@@ -776,6 +776,131 @@ class RelationshipControllerTest {
     }
 
     @Test
+    @DisplayName("관계 종류 변경 API 문서화")
+    void updateRelationshipKind() throws Exception {
+        Validation.ChangeRelationshipKindRequest.Builder builder = Validation.ChangeRelationshipKindRequest
+                .newBuilder();
+        JsonFormat.parser()
+                .ignoringUnknownFields()
+                .merge("""
+                        {
+                            "database": {
+                                "id": "06D4K6TTEWXW8VQR8EZXDPWP3C",
+                                "schemas": [
+                                    {
+                                        "id": "06D6VZBWHSDJBBG0H7D156YZ98",
+                                        "projectId": "06D4K6TTEWXW8VQR8EZXDPWP3C",
+                                        "dbVendorId": "MYSQL",
+                                        "name": "test",
+                                        "charset": "utf8mb4",
+                                        "collation": "utf8mb4_unicode_ci",
+                                        "vendorOption": "",
+                                        "canvasViewport": null,
+                                        "tables": [
+                                            {
+                                                "id": "06D6W8HDY79QFZX39RMX62KSX4",
+                                                "schemaId": "06D6VZBWHSDJBBG0H7D156YZ98",
+                                                "name": "users",
+                                                "comment": "사용자 테이블",
+                                                "tableOptions": "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+                                                "columns": [],
+                                                "indexes": [],
+                                                "constraints": [],
+                                                "relationships": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "schemaId": "06D6VZBWHSDJBBG0H7D156YZ98",
+                            "relationshipId": "06D6WCH677C3FCC2Q9SD5M1Y5W",
+                            "kind": "IDENTIFYING"
+                        }
+                        """,
+                        builder);
+        Validation.ChangeRelationshipKindRequest request = builder.build();
+
+        String mockResponseJson = """
+                {
+                    "id": "06D6WCH677C3FCC2Q9SD5M1Y5W",
+                    "srcTableId": "06D6W8HDY79QFZX39RMX62KSX4",
+                    "tgtTableId": "06D6W8HDY79QFZX39RMX62KSX4",
+                    "name": "FK_recommend_other_user",
+                    "kind": "IDENTIFYING",
+                    "cardinality": "ONE_TO_ONE",
+                    "onDelete": "CASCADE",
+                    "onUpdate": "CASCADE_UPDATE",
+                    "extra": "{}",
+                    "columns": []
+                }
+                """;
+
+        when(relationshipService.updateRelationshipKind(
+                any(Validation.ChangeRelationshipKindRequest.class)))
+                .thenReturn(Mono
+                        .just(objectMapper.readValue(mockResponseJson,
+                                RelationshipResponse.class)));
+
+        webTestClient.put()
+                .uri(API_BASE_PATH + "/relationships/{relationshipId}/kind",
+                        "06D6WCH677C3FCC2Q9SD5M1Y5W")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(toJson(request))
+                .header("Accept", "application/json")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.success").isEqualTo(true)
+                .jsonPath("$.result.id").isEqualTo("06D6WCH677C3FCC2Q9SD5M1Y5W")
+                .jsonPath("$.result.kind").isEqualTo("IDENTIFYING")
+                .jsonPath("$.result.name").isEqualTo("FK_recommend_other_user")
+                .consumeWith(document("relationship-update-kind",
+                        pathParameters(
+                                parameterWithName("relationshipId")
+                                        .description("관계 ID")),
+                        requestHeaders(
+                                headerWithName("Content-Type")
+                                        .description("요청 본문 타입"),
+                                headerWithName("Accept").description("응답 포맷")),
+                        relaxedRequestFields(
+                                fieldWithPath("database.id")
+                                        .description("데이터베이스 ID"),
+                                fieldWithPath("schemaId")
+                                        .description("스키마 ID"),
+                                fieldWithPath("relationshipId")
+                                        .description("변경할 관계 ID"),
+                                fieldWithPath("kind")
+                                        .description("변경할 관계 종류")),
+                        responseHeaders(
+                                headerWithName("Content-Type")
+                                        .description("응답 컨텐츠 타입")),
+                        responseFields(
+                                fieldWithPath("success")
+                                        .description("요청 성공 여부"),
+                                fieldWithPath("result")
+                                        .description("수정된 관계 정보"),
+                                fieldWithPath("result.id").description("관계 ID"),
+                                fieldWithPath("result.srcTableId")
+                                        .description("소스 테이블 ID"),
+                                fieldWithPath("result.tgtTableId")
+                                        .description("타겟 테이블 ID"),
+                                fieldWithPath("result.name")
+                                        .description("관계 이름"),
+                                fieldWithPath("result.kind")
+                                        .description("변경된 관계 종류"),
+                                fieldWithPath("result.cardinality")
+                                        .description("카디널리티"),
+                                fieldWithPath("result.onDelete")
+                                        .description("DELETE 액션"),
+                                fieldWithPath("result.onUpdate")
+                                        .description("UPDATE 액션"),
+                                fieldWithPath("result.extra")
+                                        .description("추가 정보"),
+                                fieldWithPath("result.columns")
+                                        .description("관계 컬럼 목록"))));
+    }
+
+    @Test
     @DisplayName("관계에 컬럼 추가 API 문서화")
     void addColumnToRelationship() throws Exception {
         Validation.AddColumnToRelationshipRequest.Builder builder = Validation.AddColumnToRelationshipRequest

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/AffectedEntitiesSaverTest.java
@@ -854,6 +854,10 @@ class AffectedEntitiesSaverTest {
                             .get(0)
                             .constraintId())
                             .isEqualTo(savedConstraintId);
+                    assertThat(saveResult.propagated().constraintColumns()
+                            .get(0)
+                            .seqNo())
+                            .isEqualTo(2);
                 })
                 .verifyComplete();
     }
@@ -955,6 +959,8 @@ class AffectedEntitiesSaverTest {
                             .isEqualTo(savedIndexId);
                     assertThat(propagatedIndexColumn.columnId())
                             .isEqualTo(savedColumnId);
+                    assertThat(propagatedIndexColumn.seqNo())
+                            .isEqualTo(1);
                     assertThat(propagatedIndexColumn.sourceType())
                             .isEqualTo(EntityType.RELATIONSHIP.name());
                     assertThat(propagatedIndexColumn.sourceId())

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ColumnServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ColumnServiceTest.java
@@ -249,14 +249,40 @@ class ColumnServiceTest {
                         .build())
                 .block();
 
+        Validation.Database validationResponse = Validation.Database
+                .newBuilder()
+                .setId("db-1")
+                .addSchemas(Validation.Schema.newBuilder()
+                        .setId("schema-1")
+                        .addTables(Validation.Table.newBuilder()
+                                .setId("table-1")
+                                .addColumns(Validation.Column.newBuilder()
+                                        .setId(saved.getId())
+                                        .setTableId("table-1")
+                                        .setName("test_column")
+                                        .setDataType("TEXT")
+                                        .setOrdinalPosition(1)
+                                        .setIsAffected(true)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        given(validationClient.changeColumnType(
+                any(Validation.ChangeColumnTypeRequest.class)))
+                .willReturn(Mono.just(validationResponse));
+
         StepVerifier.create(columnService.updateColumnType(
                 Validation.ChangeColumnTypeRequest.newBuilder()
                         .setColumnId(saved.getId())
                         .setDataType("TEXT")
                         .build()))
                 .assertNext(updated -> {
-                    assertThat(updated.getId()).isEqualTo(saved.getId());
-                    assertThat(updated.getDataType()).isEqualTo("TEXT");
+                    assertThat(updated.columns()).hasSize(1);
+                    assertThat(updated.columns().get(0).getId())
+                            .isEqualTo(saved.getId());
+                    assertThat(updated.columns().get(0).getDataType())
+                            .isEqualTo("TEXT");
                 })
                 .verifyComplete();
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/ConstraintServiceTest.java
@@ -545,6 +545,7 @@ class ConstraintServiceTest {
                                             "propagated-constraint-col",
                                             "child-pk-constraint",
                                             "propagated-parent-id-col",
+                                            1,
                                             EntityType.CONSTRAINT.name(),
                                             sourceId)),
                                     List.of()),

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -78,6 +78,10 @@ class RelationshipServiceTest {
                 any(Validation.ChangeRelationshipCardinalityRequest.class)))
                 .willReturn(Mono.just(
                         Validation.Database.newBuilder().build()));
+        given(validationClient.changeRelationshipKind(
+                any(Validation.ChangeRelationshipKindRequest.class)))
+                .willReturn(Mono.just(
+                        Validation.Database.newBuilder().build()));
         given(validationClient.addColumnToRelationship(
                 any(Validation.AddColumnToRelationshipRequest.class)))
                 .willReturn(Mono.just(
@@ -858,6 +862,43 @@ class RelationshipServiceTest {
         StepVerifier.create(relationshipRepository.findById(saved.getId()))
                 .assertNext(found -> assertThat(found.getCardinality())
                         .isEqualTo("ONE_TO_ONE"))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("updateRelationshipKind: 관계 종류를 변경한다")
+    void updateRelationshipKind_success() {
+        Relationship saved = relationshipRepository.save(
+                Relationship.builder()
+                        .srcTableId("table-1")
+                        .tgtTableId("table-2")
+                        .name("fk_test")
+                        .kind("NON_IDENTIFYING")
+                        .cardinality("ONE_TO_MANY")
+                        .onDelete("NO_ACTION")
+                        .onUpdate("NO_ACTION")
+                        .extra("")
+                        .build())
+                .block();
+
+        StepVerifier.create(relationshipService.updateRelationshipKind(
+                Validation.ChangeRelationshipKindRequest.newBuilder()
+                        .setDatabase(
+                                Validation.Database.newBuilder().setId("db-1")
+                                        .build())
+                        .setSchemaId("schema-1")
+                        .setRelationshipId(saved.getId())
+                        .setKind(Validation.RelationshipKind.IDENTIFYING)
+                        .build()))
+                .assertNext(updated -> {
+                    assertThat(updated.getId()).isEqualTo(saved.getId());
+                    assertThat(updated.getKind()).isEqualTo("IDENTIFYING");
+                })
+                .verifyComplete();
+
+        StepVerifier.create(relationshipRepository.findById(saved.getId()))
+                .assertNext(found -> assertThat(found.getKind())
+                        .isEqualTo("IDENTIFYING"))
                 .verifyComplete();
     }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/RelationshipServiceTest.java
@@ -629,6 +629,7 @@ class RelationshipServiceTest {
                                             "propagated-constraint-col",
                                             "child-pk-constraint",
                                             "be-fk-column-id",
+                                            1,
                                             EntityType.RELATIONSHIP.name(),
                                             sourceId)),
                                     List.of()),

--- a/apps/validation-server/protos/validation.proto
+++ b/apps/validation-server/protos/validation.proto
@@ -328,6 +328,13 @@ message ChangeRelationshipCardinalityRequest {
     RelationshipCardinality cardinality = 4;
 }
 
+message ChangeRelationshipKindRequest {
+    Database database = 1;
+    string schemaId = 2;
+    string relationshipId = 3;
+    RelationshipKind kind = 4;
+}
+
 message AddColumnToRelationshipRequest {
     Database database = 1;
     string schemaId = 2;
@@ -426,6 +433,7 @@ service ValidationService {
     rpc DeleteRelationship (DeleteRelationshipRequest) returns (ValidateResult);
     rpc ChangeRelationshipName (ChangeRelationshipNameRequest) returns (ValidateResult);
     rpc ChangeRelationshipCardinality (ChangeRelationshipCardinalityRequest) returns (ValidateResult);
+    rpc ChangeRelationshipKind (ChangeRelationshipKindRequest) returns (ValidateResult);
     rpc AddColumnToRelationship (AddColumnToRelationshipRequest) returns (ValidateResult);
     rpc RemoveColumnFromRelationship (RemoveColumnFromRelationshipRequest) returns (ValidateResult);
 

--- a/apps/validation-server/src/validations/relationships/dto/change-relationship-kind.dto.ts
+++ b/apps/validation-server/src/validations/relationships/dto/change-relationship-kind.dto.ts
@@ -1,0 +1,8 @@
+import type { Database, Relationship, Schema } from '@schemafy/validator';
+
+export interface ChangeRelationshipKindDto {
+  database: Database;
+  schemaId: Schema['id'];
+  relationshipId: Relationship['id'];
+  kind: Relationship['kind'];
+}

--- a/apps/validation-server/src/validations/relationships/dto/index.ts
+++ b/apps/validation-server/src/validations/relationships/dto/index.ts
@@ -2,5 +2,6 @@ export * from './create-relationship.dto';
 export * from './delete-relationship.dto';
 export * from './change-relationship-name.dto';
 export * from './change-relationship-cardinality.dto';
+export * from './change-relationship-kind.dto';
 export * from './add-column-to-relationship.dto';
 export * from './remove-column-from-relationship.dto';

--- a/apps/validation-server/src/validations/relationships/relationships.controller.ts
+++ b/apps/validation-server/src/validations/relationships/relationships.controller.ts
@@ -6,6 +6,7 @@ import { RelationshipsService } from './relationships.service';
 import type {
   AddColumnToRelationshipDto,
   ChangeRelationshipCardinalityDto,
+  ChangeRelationshipKindDto,
   ChangeRelationshipNameDto,
   CreateRelationshipDto,
   DeleteRelationshipDto,
@@ -50,6 +51,17 @@ export class RelationshipsController {
       schemaId,
       relationshipId,
       cardinality,
+    );
+  }
+
+  @GrpcMethod('ValidationService', 'ChangeRelationshipKind')
+  changeRelationshipKind(req: ChangeRelationshipKindDto): ValidateResult {
+    const { database, schemaId, relationshipId, kind } = req;
+    return this.service.changeRelationshipKind(
+      database,
+      schemaId,
+      relationshipId,
+      kind,
     );
   }
 

--- a/apps/validation-server/src/validations/relationships/relationships.service.ts
+++ b/apps/validation-server/src/validations/relationships/relationships.service.ts
@@ -116,6 +116,32 @@ export class RelationshipsService {
     }
   }
 
+  changeRelationshipKind(
+    database: Database,
+    schemaId: Schema['id'],
+    relationshipId: Relationship['id'],
+    kind: Relationship['kind'],
+  ): ValidateResult {
+    try {
+      const updated = ERD_VALIDATOR.changeRelationshipKind(
+        database,
+        schemaId,
+        relationshipId,
+        kind,
+      );
+      this.logger.log(
+        `ChangeRelationshipKind request successfully validated, schemaId: ${schemaId}, relationshipId: ${relationshipId}, kind: ${kind}`,
+      );
+      return { success: { database: updated } };
+    } catch (err) {
+      this.logger.error(
+        `ChangeRelationshipKind request failed, schemaId: ${schemaId}, relationshipId: ${relationshipId}, kind: ${kind}`,
+        err,
+      );
+      return { failure: { errors: toErrorDetails(err) } };
+    }
+  }
+
   addColumnToRelationship(
     database: Database,
     schemaId: Schema['id'],

--- a/packages/validator/src/lib/builder.ts
+++ b/packages/validator/src/lib/builder.ts
@@ -197,7 +197,7 @@ class ColumnBuilder {
   private charset: string = "utf8mb4";
   private collation: string = "utf8mb4_general_ci";
   private comment: string | null = null;
-  private ordinalPosition: number = 1;
+  private ordinalPosition: number = 0;
 
   constructor() {}
 
@@ -263,7 +263,7 @@ class ConstraintColumnBuilder {
   private constraintId: string;
   private columnName?: string;
   private columnId: string | null = null;
-  private seqNo: number = 1;
+  private seqNo: number = 0;
 
   constructor(constraintId: string) {
     this.constraintId = constraintId;
@@ -384,7 +384,7 @@ class IndexColumnBuilder {
   private indexId: string;
   private columnName?: string;
   private columnId: string | null = null;
-  private seqNo: number = 1;
+  private seqNo: number = 0;
   private sortDir: IndexSortDir = "ASC";
 
   constructor(indexId: string) {
@@ -504,7 +504,7 @@ class RelationshipColumnBuilder {
   private relationshipId: string;
   private fkColumnId: string | null = null;
   private refColumnId: string | null = null;
-  private seqNo: number = 1;
+  private seqNo: number = 0;
 
   constructor(relationshipId: string) {
     this.relationshipId = relationshipId;

--- a/packages/validator/src/lib/handlers/columns.ts
+++ b/packages/validator/src/lib/handlers/columns.ts
@@ -266,20 +266,38 @@ export const columnHandlers: ColumnHandlers = {
     const column = table.columns.find((c) => c.id === columnId);
     if (!column) throw new ColumnNotExistError(columnId, tableId);
 
-    const changeColumns: Column[] = table.columns.map((c) =>
-      c.id === columnId
-        ? {
+    const nextLengthScale = lengthScale ?? column.lengthScale;
+
+    const fkColumnIds = new Set<string>();
+    for (const currentTable of schema.tables) {
+      for (const relationship of currentTable.relationships) {
+        for (const relationshipColumn of relationship.columns) {
+          if (relationshipColumn.refColumnId === columnId) {
+            fkColumnIds.add(relationshipColumn.fkColumnId);
+          }
+        }
+      }
+    }
+
+    const changeTables: Table[] = schema.tables.map((t) => {
+      let isTableAffected = false;
+      const changeColumns: Column[] = t.columns.map((c) => {
+        if (c.id === columnId || fkColumnIds.has(c.id)) {
+          isTableAffected = true;
+          return {
             ...c,
             isAffected: true,
             dataType,
-            lengthScale: lengthScale || c.lengthScale,
-          }
-        : c,
-    );
+            lengthScale: nextLengthScale,
+          };
+        }
+        return c;
+      });
 
-    const changeTables: Table[] = schema.tables.map((t) =>
-      t.id === tableId ? { ...t, isAffected: true, columns: changeColumns } : t,
-    );
+      return isTableAffected
+        ? { ...t, isAffected: true, columns: changeColumns }
+        : t;
+    });
 
     const changeSchemas: Schema[] = database.schemas.map((s) =>
       s.id === schemaId ? { ...s, isAffected: true, tables: changeTables } : s,

--- a/packages/validator/src/lib/handlers/indexes.ts
+++ b/packages/validator/src/lib/handlers/indexes.ts
@@ -10,7 +10,8 @@ import {
   SchemaNotExistError,
   TableNotExistError,
 } from "../errors";
-import { Database, INDEX, Index, IndexColumn, Schema, Table } from "../types";
+import { INDEX } from "../types";
+import type { Database, Index, IndexColumn, Schema, Table } from "../types";
 
 export interface IndexHandlers {
   createIndex: (

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -328,7 +328,7 @@ export const relationshipHandlers: RelationshipHandlers = {
               isAffected: true,
               constraintId: pkConstraint.id,
               columnId,
-              seqNo: pkConstraint.columns.length + index + 1,
+              seqNo: pkConstraint.columns.length + index,
             }));
 
             const updatedPkConstraint: Constraint = {
@@ -347,7 +347,7 @@ export const relationshipHandlers: RelationshipHandlers = {
               isAffected: true,
               constraintId: newPkConstraintId,
               columnId,
-              seqNo: index + 1,
+              seqNo: index,
             }));
 
             const newPkConstraint: Constraint = {
@@ -380,7 +380,7 @@ export const relationshipHandlers: RelationshipHandlers = {
               const resequencedColumns = remainingColumns.map(
                 (column, index) => ({
                   ...column,
-                  seqNo: index + 1,
+                  seqNo: index,
                   isAffected: true,
                 }),
               );

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -419,16 +419,18 @@ export const relationshipHandlers: RelationshipHandlers = {
 
     if (kind === "IDENTIFYING" && addedPkColumnIds.length > 0) {
       for (const columnId of addedPkColumnIds) {
-        const parentTable = updatedSchema.tables.find(
+        const tableWithNewPk = updatedSchema.tables.find(
           (t) => t.id === relationship.srcTableId,
         );
-        const pkColumn = parentTable?.columns.find((c) => c.id === columnId);
-        if (!pkColumn) continue;
+        const newPkColumn = tableWithNewPk?.columns.find(
+          (c) => c.id === columnId,
+        );
+        if (!newPkColumn) continue;
 
         updatedSchema = helper.propagateNewPrimaryKey(
           structuredClone(updatedSchema),
           relationship.srcTableId,
-          pkColumn,
+          newPkColumn,
         );
       }
     }

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -89,15 +89,11 @@ export const relationshipHandlers: RelationshipHandlers = {
       );
 
     if (relationship.kind === "IDENTIFYING") {
-      const cycle = helper.detectIdentifyingCycleInSchema(
-        schema,
-        undefined,
-        {
-          srcTableId: relationship.srcTableId,
-          tgtTableId: relationship.tgtTableId,
-          kind: relationship.kind,
-        },
-      );
+      const cycle = helper.detectIdentifyingCycleInSchema(schema, undefined, {
+        srcTableId: relationship.srcTableId,
+        tgtTableId: relationship.tgtTableId,
+        kind: relationship.kind,
+      });
       if (cycle) {
         throw new RelationshipCyclicReferenceError(cycle[0], cycle[1]);
       }

--- a/packages/validator/src/lib/handlers/relationships.ts
+++ b/packages/validator/src/lib/handlers/relationships.ts
@@ -88,18 +88,19 @@ export const relationshipHandlers: RelationshipHandlers = {
         relationship.tgtTableId,
       );
 
-    if (
-      relationship.kind === "IDENTIFYING" &&
-      helper.detectCircularReference(
+    if (relationship.kind === "IDENTIFYING") {
+      const cycle = helper.detectIdentifyingCycleInSchema(
         schema,
-        relationship.tgtTableId,
-        relationship.srcTableId,
-      )
-    ) {
-      throw new RelationshipCyclicReferenceError(
-        relationship.tgtTableId,
-        relationship.srcTableId,
+        undefined,
+        {
+          srcTableId: relationship.srcTableId,
+          tgtTableId: relationship.tgtTableId,
+          kind: relationship.kind,
+        },
       );
+      if (cycle) {
+        throw new RelationshipCyclicReferenceError(cycle[0], cycle[1]);
+      }
     }
 
     const duplicateRelationship = sourceTable.relationships.find(
@@ -285,18 +286,14 @@ export const relationshipHandlers: RelationshipHandlers = {
 
     if (!relationship) throw new RelationshipNotExistError(relationshipId);
 
-    if (
-      kind === "IDENTIFYING" &&
-      helper.detectCircularReference(
-        schema,
-        relationship.tgtTableId,
-        relationship.srcTableId,
-      )
-    ) {
-      throw new RelationshipCyclicReferenceError(
-        relationship.tgtTableId,
-        relationship.srcTableId,
-      );
+    if (kind === "IDENTIFYING") {
+      const cycle = helper.detectIdentifyingCycleInSchema(schema, {
+        relationshipId,
+        newKind: kind,
+      });
+      if (cycle) {
+        throw new RelationshipCyclicReferenceError(cycle[0], cycle[1]);
+      }
     }
 
     const updatedRelationship: Relationship = {

--- a/packages/validator/src/lib/handlers/tables.ts
+++ b/packages/validator/src/lib/handlers/tables.ts
@@ -4,7 +4,8 @@ import {
   TableNotExistError,
   TableNameNotInvalidError,
 } from "../errors";
-import { Database, Schema, TABLE, Table } from "../types";
+import { TABLE } from "../types";
+import type { Database, Schema, Table } from "../types";
 import { relationshipHandlers } from "./relationships";
 
 export interface TableHandlers {

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -45,10 +45,7 @@ export const detectIdentifyingCycleInSchema = (
   const visited = new Set<string>();
   const recursionStack = new Set<string>();
 
-  const dfs = (
-    tableId: string,
-    path: string[],
-  ): [string, string] | null => {
+  const dfs = (tableId: string, path: string[]): [string, string] | null => {
     if (recursionStack.has(tableId)) {
       return [path[path.length - 1], tableId];
     }

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -77,42 +77,6 @@ export const detectIdentifyingCycleInSchema = (
   return null;
 };
 
-export const detectCircularReference = (
-  schema: Schema,
-  fromTableId: Table["id"],
-  toTableId: Table["id"],
-  visited: Set<Table["id"]> = new Set(),
-): boolean => {
-  if (visited.has(fromTableId)) return true;
-  if (fromTableId === toTableId) return true;
-
-  visited.add(fromTableId);
-
-  const referencedTables = new Set<Table["id"]>();
-  schema.tables.forEach((table) => {
-    table.relationships.forEach((rel) => {
-      if (rel.srcTableId === fromTableId) {
-        referencedTables.add(rel.tgtTableId);
-      }
-    });
-  });
-
-  for (const referencedTableId of referencedTables) {
-    if (
-      detectCircularReference(
-        schema,
-        referencedTableId,
-        toTableId,
-        new Set(visited),
-      )
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
 export const isValidColumnName = (str: string): boolean => {
   if (/-/.test(str)) {
     return false;

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -189,7 +189,7 @@ export const propagateNewPrimaryKey = (
         id: newFkColumnId,
         tableId: childTable.id,
         name: columnName,
-        ordinalPosition: childTable.columns.length + 1,
+        ordinalPosition: childTable.columns.length,
       };
 
       updatedSchema = {
@@ -216,7 +216,7 @@ export const propagateNewPrimaryKey = (
             id: `${ulid()}`,
             isAffected: true,
             columnId: newFkColumnId,
-            seqNo: childPkConstraint.columns.length + 1,
+            seqNo: childPkConstraint.columns.length,
             constraintId: childPkConstraint.id,
           };
 
@@ -252,7 +252,7 @@ export const propagateNewPrimaryKey = (
                 id: `${ulid()}`,
                 isAffected: true,
                 columnId: newFkColumnId,
-                seqNo: 1,
+                seqNo: 0,
                 constraintId: newPkConstraintId,
               },
             ],
@@ -283,7 +283,7 @@ export const propagateNewPrimaryKey = (
           relationshipId: rel.id,
           fkColumnId: newFkColumnId,
           refColumnId: newPkColumn.id,
-          seqNo: rel.columns.length + 1,
+          seqNo: rel.columns.length,
           isAffected: true,
         };
 
@@ -378,7 +378,7 @@ export const deleteCascadingForeignKeys = (
             constraint.kind === "PRIMARY_KEY"
               ? remainingColumns.map((cc, index) => ({
                   ...cc,
-                  seqNo: index + 1,
+                  seqNo: index,
                   isAffected: true,
                 }))
               : remainingColumns;
@@ -505,7 +505,7 @@ export const propagateKeysToChildren = (
           id: newColumnId,
           tableId: childTable.id,
           name: columnName,
-          ordinalPosition: childTable.columns.length + 1,
+          ordinalPosition: childTable.columns.length,
         };
 
         updatedChildTable = {
@@ -522,7 +522,7 @@ export const propagateKeysToChildren = (
             relationshipId: rel.id,
             fkColumnId: newColumnId,
             refColumnId: pkColumn.id,
-            seqNo: rel.columns.length + 1,
+            seqNo: rel.columns.length,
             isAffected: true,
           };
 
@@ -575,7 +575,7 @@ export const propagateKeysToChildren = (
             isAffected: true,
             constraintId: childPkConstraint.id,
             columnId: fkColumn.id,
-            seqNo: childPkConstraint.columns.length + newPkColumns.length + 1,
+            seqNo: childPkConstraint.columns.length + newPkColumns.length,
           });
         }
 
@@ -610,7 +610,7 @@ export const propagateKeysToChildren = (
             isAffected: true,
             constraintId: newPkConstraintId,
             columnId: fkColumn.id,
-            seqNo: newPkColumns.length + 1,
+            seqNo: newPkColumns.length,
           });
         }
 
@@ -702,12 +702,12 @@ export const deleteRelatedColumns = (
 
               const finalColumns =
                 constraint.kind === "PRIMARY_KEY"
-                  ? remainingColumns.map((cc, index) => ({
-                      ...cc,
-                      seqNo: index + 1,
-                      isAffected: true,
-                    }))
-                  : remainingColumns;
+              ? remainingColumns.map((cc, index) => ({
+                  ...cc,
+                  seqNo: index,
+                  isAffected: true,
+                }))
+              : remainingColumns;
 
               return {
                 ...constraint,

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -1,5 +1,5 @@
 import { ulid } from "ulid";
-import {
+import type {
   Column,
   Constraint,
   Index,

--- a/packages/validator/src/lib/helper.ts
+++ b/packages/validator/src/lib/helper.ts
@@ -702,12 +702,12 @@ export const deleteRelatedColumns = (
 
               const finalColumns =
                 constraint.kind === "PRIMARY_KEY"
-              ? remainingColumns.map((cc, index) => ({
-                  ...cc,
-                  seqNo: index,
-                  isAffected: true,
-                }))
-              : remainingColumns;
+                  ? remainingColumns.map((cc, index) => ({
+                      ...cc,
+                      seqNo: index,
+                      isAffected: true,
+                    }))
+                  : remainingColumns;
 
               return {
                 ...constraint,

--- a/packages/validator/src/lib/types.ts
+++ b/packages/validator/src/lib/types.ts
@@ -37,7 +37,7 @@ export const COLUMN = z.object({
   id: ULID,
   tableId: ULID,
   name: z.string().min(1).max(40),
-  ordinalPosition: z.number().positive(),
+  ordinalPosition: z.number().nonnegative(),
   dataType: z.string().nullable().optional(),
   lengthScale: z.string(),
   isAutoIncrement: z.boolean(),
@@ -51,7 +51,7 @@ export const INDEX_COLUMN = z.object({
   id: ULID,
   indexId: ULID,
   columnId: ULID,
-  seqNo: z.number().positive(),
+  seqNo: z.number().nonnegative(),
   sortDir: INDEX_SORT_DIR,
   isAffected: z.boolean().default(false),
 });
@@ -70,7 +70,7 @@ export const CONSTRAINT_COLUMN = z.object({
   id: ULID,
   constraintId: ULID,
   columnId: ULID,
-  seqNo: z.number().positive(),
+  seqNo: z.number().nonnegative(),
   isAffected: z.boolean().default(false),
 });
 
@@ -100,7 +100,7 @@ export const RELATIONSHIP_COLUMN = z.object({
   relationshipId: ULID,
   fkColumnId: ULID,
   refColumnId: ULID,
-  seqNo: z.number().positive(),
+  seqNo: z.number().nonnegative(),
   isAffected: z.boolean().default(false),
 });
 

--- a/packages/validator/src/lib/utils.ts
+++ b/packages/validator/src/lib/utils.ts
@@ -1,18 +1,20 @@
 import {
   schemaHandlers,
-  SchemaHandlers,
   tableHandlers,
-  TableHandlers,
   columnHandlers,
-  ColumnHandlers,
   indexHandlers,
-  IndexHandlers,
   constraintHandlers,
-  ConstraintHandlers,
   relationshipHandlers,
+} from "./handlers";
+import type {
+  SchemaHandlers,
+  TableHandlers,
+  ColumnHandlers,
+  IndexHandlers,
+  ConstraintHandlers,
   RelationshipHandlers,
 } from "./handlers";
-import { Database } from "./types";
+import type { Database } from "./types";
 import {
   SchemaNameInvalidError,
   SchemaNameNotUniqueError,

--- a/packages/validator/tests/constraint.validation.spec.ts
+++ b/packages/validator/tests/constraint.validation.spec.ts
@@ -125,15 +125,15 @@ describe('Constraint validation', () => {
     const ukConstraint1 = createConstraintBuilder()
       .withName('uk_1_2')
       .withKind('UNIQUE')
-      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(1))
-      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(2))
+      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(0))
+      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(1))
       .build();
 
     const ukConstraint2 = createConstraintBuilder()
       .withName('uk_2_1')
       .withKind('UNIQUE')
-      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(1))
-      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(2))
+      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(0))
+      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(1))
       .build();
 
     expect(() => ERD_VALIDATOR.createConstraint(db, 'schema-1', 'table-1', ukConstraint1)).not.toThrow();
@@ -155,15 +155,15 @@ describe('Constraint validation', () => {
     const ukConstraint1 = createConstraintBuilder()
       .withName('uk_duplicate_1')
       .withKind('UNIQUE')
-      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(1))
-      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(2))
+      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(0))
+      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(1))
       .build();
 
     const ukConstraint2 = createConstraintBuilder()
       .withName('uk_duplicate_2')
       .withKind('UNIQUE')
-      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(1))
-      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(2))
+      .withColumn((cc) => cc.withColumnId('col1').withSeqNo(0))
+      .withColumn((cc) => cc.withColumnId('col2').withSeqNo(1))
       .build();
 
     expect(() => ERD_VALIDATOR.createConstraint(db, 'schema-1', 'table-1', ukConstraint1)).not.toThrow();

--- a/packages/validator/tests/index.validation.spec.ts
+++ b/packages/validator/tests/index.validation.spec.ts
@@ -88,7 +88,7 @@ describe('Index validation', () => {
     expect(() =>
       ERD_VALIDATOR.addColumnToIndex(db, 'schema-1', 'table-1', 'index-1', {
         columnId: 'column-1',
-        seqNo: 1,
+        seqNo: 0,
         sortDir: 'ASC',
         id: 'index-column-1',
         isAffected: false,
@@ -115,8 +115,8 @@ describe('Index validation', () => {
     // 동일한 인덱스는 조회 성능에 이점 없이 쓰기 성능 저하와 공간 낭비만 유발하므로 금지해야 한다.
     const newIndex = createIndexBuilder()
       .withName('idx_name_2')
-      .withColumn((ic) => ic.withColumnId('name-col').withSeqNo(1))
-      .withColumn((ic) => ic.withColumnId('email-col').withSeqNo(2))
+      .withColumn((ic) => ic.withColumnId('name-col').withSeqNo(0))
+      .withColumn((ic) => ic.withColumnId('email-col').withSeqNo(1))
       .build();
 
     const db = createTestDatabase()
@@ -130,8 +130,8 @@ describe('Index validation', () => {
             .withIndex((i) =>
               i
                 .withName('idx_name_1')
-                .withColumn((ic) => ic.withColumnId('name-col').withSeqNo(1))
-                .withColumn((ic) => ic.withColumnId('email-col').withSeqNo(2))
+                .withColumn((ic) => ic.withColumnId('name-col').withSeqNo(0))
+                .withColumn((ic) => ic.withColumnId('email-col').withSeqNo(1))
             )
         )
       )

--- a/packages/validator/tests/relationship.validation.spec.ts
+++ b/packages/validator/tests/relationship.validation.spec.ts
@@ -1336,7 +1336,7 @@ describe('Relationship validation', () => {
                   c
                     .withName('pk_child')
                     .withKind('PRIMARY_KEY')
-                    .withColumn((cc) => cc.withColumnId(childOwnPkColumnId).withSeqNo(1))
+                    .withColumn((cc) => cc.withColumnId(childOwnPkColumnId).withSeqNo(0))
                 )
             )
         )
@@ -1370,7 +1370,7 @@ describe('Relationship validation', () => {
 
       expect(pkConstraint).toBeDefined();
       expect(pkConstraint?.columns).toHaveLength(1);
-      expect(pkConstraint?.columns[0].seqNo).toBe(1);
+      expect(pkConstraint?.columns[0].seqNo).toBe(0);
       expect(pkConstraint?.columns[0].columnId).toBe(childOwnPkColumnId);
     });
 
@@ -1398,8 +1398,8 @@ describe('Relationship validation', () => {
                 .withColumn((c) => c.withId('c2').withName('c2').withDataType('INT'))
                 .withConstraint((c) =>
                   c.withKind('PRIMARY_KEY')
-                    .withColumn((cc) => cc.withColumnId('c1').withSeqNo(1))
-                    .withColumn((cc) => cc.withColumnId('c2').withSeqNo(2))
+                    .withColumn((cc) => cc.withColumnId('c1').withSeqNo(0))
+                    .withColumn((cc) => cc.withColumnId('c2').withSeqNo(1))
                 )
             )
         )
@@ -1423,8 +1423,8 @@ describe('Relationship validation', () => {
       const pkConstraint = childTable?.constraints.find((c: Constraint) => c.kind === 'PRIMARY_KEY');
 
       expect(pkConstraint?.columns).toHaveLength(2);
-      expect(pkConstraint?.columns.find(c => c.columnId === 'c1')?.seqNo).toBe(1);
-      expect(pkConstraint?.columns.find(c => c.columnId === 'c2')?.seqNo).toBe(2);
+      expect(pkConstraint?.columns.find(c => c.columnId === 'c1')?.seqNo).toBe(0);
+      expect(pkConstraint?.columns.find(c => c.columnId === 'c2')?.seqNo).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## 개요

- 컬럼 타입 변경 시 연관 컬럼까지 전파
- 관계 타입 변경 API 추가
- 전파된 제약조건의 컬럼 순서 추가

### 주요 변경사항

- 컬럼 타입 변경 시 affected 컬럼을 저장/반환하도록 수정
- 관계 종류 변경 시 사이클 검증 및 PK 제약/컬럼 처리 보강
  - 기존 사이클 탐지 로직이 전체 관계에 대해서 파악하지 않아, IDENTIFYING 흐름을 그래프로 만들어, 해당 부분 탐색하도록 수정
- 전파 로직 정리 및 FK 삭제 시 PK 시퀀싱 보완
  - PK 시퀀싱 매번 인덱싱하도록 수정
- 전파된 제약조건의 컬럼 순서 필드 추가

## 이슈

- close #146