### PR TITLE
fix(#162): change memo deletion logic to only delete when all comments are deleted

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/MemoService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/MemoService.java
@@ -287,7 +287,8 @@ public class MemoService {
         return memoCommentRepository.save(comment).then();
     }
 
-    private Mono<Boolean> isLastRemainingComment(String memoId, String commentId) {
+    private Mono<Boolean> isLastRemainingComment(String memoId,
+            String commentId) {
         return memoCommentRepository
                 .findByMemoIdAndDeletedAtIsNullOrderByIdAsc(memoId)
                 .collectList()

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/MemoServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/MemoServiceTest.java
@@ -551,54 +551,6 @@ class MemoServiceTest {
     }
 
     @Test
-    @DisplayName("deleteComment: 첫 댓글 삭제 시 메모만 삭제된다 (댓글은 유지)")
-    void deleteComment_firstCommentDeletesMemo() {
-        String authorId = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
-        Memo memo = memoRepository.save(Memo.builder()
-                .schemaId("06D6VZBWHSDJBBG0H7D156YZ98")
-                .authorId(authorId)
-                .positions("{}")
-                .build()).block();
-
-        MemoComment firstComment = memoCommentRepository.save(
-                MemoComment.builder()
-                        .memoId(memo.getId())
-                        .authorId(authorId)
-                        .body("본문")
-                        .build())
-                .block();
-
-        MemoComment reply = memoCommentRepository.save(MemoComment.builder()
-                .memoId(memo.getId())
-                .authorId("06D6W8HDY79QFZX39RMX62KSX4")
-                .body("답글")
-                .build()).block();
-
-        AuthenticatedUser user = AuthenticatedUser.of(authorId);
-
-        StepVerifier.create(
-                memoService.deleteComment(memo.getId(), firstComment.getId(),
-                        user))
-                .verifyComplete();
-
-        // 메모 삭제 확인
-        StepVerifier.create(memoRepository.findById(memo.getId()))
-                .assertNext(m -> assertThat(m.getDeletedAt()).isNotNull())
-                .verifyComplete();
-
-        // 첫 댓글은 삭제되지 않음 (상위 계층 삭제 시 하위 계층 유지 정책)
-        StepVerifier
-                .create(memoCommentRepository.findById(firstComment.getId()))
-                .assertNext(c -> assertThat(c.getDeletedAt()).isNull())
-                .verifyComplete();
-
-        // 나머지 댓글도 삭제되지 않음
-        StepVerifier.create(memoCommentRepository.findById(reply.getId()))
-                .assertNext(c -> assertThat(c.getDeletedAt()).isNull())
-                .verifyComplete();
-    }
-
-    @Test
     @DisplayName("deleteComment: 경로 memoId와 댓글 memoId가 다르면 INVALID_PARAMETER를 반환한다")
     void deleteComment_memoMismatch() {
         String authorId = "01ARZ3NDEKTSV4RRFFQ69G5FAV";


### PR DESCRIPTION
## 개요

기존 메모 작성시 첫번째 코멘트가 본문처럼 보일 것으로 기대하였던 작업된 조건을 수정합니다. 

- 코멘트 제거 시 메모 삭제 조건 변경
  - "첫 번째 코멘트인가?" -> "마지막 남은 코멘트인가?"

## 이슈

- close #162