### PR TITLE
fix: auto-label condition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,9 +9,11 @@ front-end:
       - any-glob-to-any-file: "apps/frontend/**"
 
 shared:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "!apps/backend/**"
-          - "!apps/validation-server/**"
-          - "!apps/frontend/**"
-          - "**"
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "**"
+      - changed-files:
+          - all-globs-to-all-files:
+              - "!apps/backend/**"
+              - "!apps/validation-server/**"
+              - "!apps/frontend/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,11 +9,8 @@ front-end:
       - any-glob-to-any-file: "apps/frontend/**"
 
 shared:
-  - all:
-      - changed-files:
-          - any-glob-to-any-file: "**"
-      - changed-files:
-          - all-globs-to-all-files:
-              - "!apps/backend/**"
-              - "!apps/validation-server/**"
-              - "!apps/frontend/**"
+  - changed-files:
+      - all-globs-to-any-file:
+          - "!apps/backend/**"
+          - "!apps/validation-server/**"
+          - "!apps/frontend/**"

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,1 +1,3 @@
 ### frontend
+
+test

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,3 +1,1 @@
 ### frontend
-
-test


### PR DESCRIPTION
## 개요
`any-glob-to-any-file`에서 "**" 패턴이 모든 파일과 매치되어, backend나 frontend 파일이 변경되어도 `shared` 라벨이 추가되었습니다.

`all` 조건을 사용해 경로 이외의 파일에 변경이 생겼을 때 `shared` 라벨이 추가되도록 변경했습니다. 

> 해당 PR에는 front-end 파일과 shared 파일을 변경했을 때 두 라벨이 같이 추가되는지 확인하기 위해 front-end 라벨이 추가되어 있습니다. 
