### PR TITLE
refactor(#93): stop tracking generated validation.proto and use relative path symlink

### DIFF
--- a/apps/backend/core/build.gradle
+++ b/apps/backend/core/build.gradle
@@ -190,15 +190,18 @@ tasks.register('linkProtos') {
 		def targetFile = new File(targetProtoDir, 'validation.proto')
 
 		if (!targetFile.exists()) {
+			def relativeSourcePath = targetProtoDir.toPath().relativize(sourceFile.toPath()).toString()
 			if (System.properties['os.name'].toLowerCase().contains('windows')) {
 				exec {
+					workingDir targetProtoDir
 					commandLine 'cmd', '/c', 'mklink',
-						targetFile.absolutePath, sourceFile.absolutePath
+						targetFile.name, relativeSourcePath
 				}
 			} else {
 				exec {
+					workingDir targetProtoDir
 					commandLine 'ln', '-sf',
-						sourceFile.absolutePath, targetFile.absolutePath
+						relativeSourcePath, targetFile.name
 				}
 			}
 		}

--- a/apps/backend/core/src/main/proto/validation.proto
+++ b/apps/backend/core/src/main/proto/validation.proto
@@ -1,1 +1,0 @@
-/Users/cjm/projects/schemafy/packages/proto-validation/protos/validation.proto


### PR DESCRIPTION
## 개요

- 이전 PR에서 tracking 되던 파일 제거
- 절대 경로 -> 상대 경로 수정

## 이슈

- close #93 