### PR TITLE
feat(#200): Improve WebSocket efficiency with SharedWorker

### DIFF
--- a/apps/frontend/src/components/Collaboration/ChatOverlay.tsx
+++ b/apps/frontend/src/components/Collaboration/ChatOverlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
+import { useReactFlow } from '@xyflow/react';
 import type { ChatMessage } from '@/lib/api/collaboration';
 import { useChatMessages } from '@/hooks';
 
@@ -15,6 +16,7 @@ const FloatingChatMessage = ({
   message,
   onExpire,
 }: FloatingChatMessageProps) => {
+  const { flowToScreenPosition } = useReactFlow();
   const [opacity, setOpacity] = useState(1);
   const onExpireRef = useRef(onExpire);
 
@@ -41,13 +43,15 @@ const FloatingChatMessage = ({
 
   if (!message.position) return null;
 
+  const screenPosition = flowToScreenPosition(message.position);
+
   return (
     <div
       className="fixed pointer-events-none z-50 transition-opacity duration-500"
       style={{
         left: 0,
         top: 0,
-        transform: `translate3d(${message.position.x}px, ${message.position.y}px, 0)`,
+        transform: `translate3d(${screenPosition.x}px, ${screenPosition.y}px, 0)`,
         opacity,
       }}
     >

--- a/apps/frontend/src/components/Collaboration/ChatOverlay.tsx
+++ b/apps/frontend/src/components/Collaboration/ChatOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import type { ChatMessage } from '@/lib/api/collaboration';
 import { useChatMessages } from '@/hooks';
@@ -16,6 +16,11 @@ const FloatingChatMessage = ({
   onExpire,
 }: FloatingChatMessageProps) => {
   const [opacity, setOpacity] = useState(1);
+  const onExpireRef = useRef(onExpire);
+
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
 
   useEffect(() => {
     const fadeTimer = setTimeout(() => {
@@ -23,14 +28,16 @@ const FloatingChatMessage = ({
     }, FADE_OUT_START);
 
     const expireTimer = setTimeout(() => {
-      onExpire();
+      if (onExpireRef.current) {
+        onExpireRef.current();
+      }
     }, DISPLAY_DURATION);
 
     return () => {
       clearTimeout(fadeTimer);
       clearTimeout(expireTimer);
     };
-  }, [onExpire]);
+  }, []);
 
   if (!message.position) return null;
 

--- a/apps/frontend/src/hooks/useChatMessages.ts
+++ b/apps/frontend/src/hooks/useChatMessages.ts
@@ -8,9 +8,13 @@ export const useChatMessages = () => {
 
   useEffect(() => {
     const unsubscribe = collaborationStore.onChatMessage((message) => {
-      console.log(message);
       if (message.position) {
-        setDisplayMessages((prev) => [...prev, message]);
+        setDisplayMessages((prev) => {
+          if (prev.some((msg) => msg.messageId === message.messageId)) {
+            return prev;
+          }
+          return [...prev, message];
+        });
         return;
       }
 
@@ -26,7 +30,12 @@ export const useChatMessages = () => {
         position: { x: cursor.x + 20, y: cursor.y + 20 },
       };
 
-      setDisplayMessages((prev) => [...prev, messageWithPosition]);
+      setDisplayMessages((prev) => {
+        if (prev.some((msg) => msg.messageId === message.messageId)) {
+          return prev;
+        }
+        return [...prev, messageWithPosition];
+      });
     });
 
     return unsubscribe;

--- a/apps/frontend/src/hooks/useChatMessages.ts
+++ b/apps/frontend/src/hooks/useChatMessages.ts
@@ -8,6 +8,12 @@ export const useChatMessages = () => {
 
   useEffect(() => {
     const unsubscribe = collaborationStore.onChatMessage((message) => {
+      console.log(message);
+      if (message.position) {
+        setDisplayMessages((prev) => [...prev, message]);
+        return;
+      }
+
       const cursor = collaborationStore.cursors.get(message.userId);
 
       if (!cursor) {

--- a/apps/frontend/src/lib/api/collaboration/types.ts
+++ b/apps/frontend/src/lib/api/collaboration/types.ts
@@ -59,6 +59,7 @@ export type RecieveChat = {
   userName: string;
   content: string;
   timestamp: string;
+  position?: { x: number; y: number };
 };
 
 export type WebSocketMessage =

--- a/apps/frontend/src/pages/CanvasPage.tsx
+++ b/apps/frontend/src/pages/CanvasPage.tsx
@@ -229,7 +229,11 @@ const CanvasContent = () => {
     const now = Date.now();
     if (now - lastCursorSendTime.current >= CURSOR_THROTTLE_MS) {
       lastCursorSendTime.current = now;
-      collaborationStore.sendCursor(position.x, position.y);
+      const flowPosition = screenToFlowPosition({
+        x: position.x,
+        y: position.y,
+      });
+      collaborationStore.sendCursor(flowPosition.x, flowPosition.y);
     }
   };
 

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -59,6 +59,13 @@ export class CollaborationStore {
         }, 3000);
       } else if (type === 'WS_ERROR') {
         console.error('WebSocket error from SharedWorker:', event.data.error);
+      } else if (type === 'INITIAL_STATE') {
+        const { cursors } = event.data;
+        runInAction(() => {
+          cursors.forEach((cursor) => {
+            this.cursors.set(cursor.userId, cursor);
+          });
+        });
       }
     };
 

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -80,7 +80,7 @@ export class CollaborationStore {
   }
 
   connect(projectId: string) {
-    if (this.projectId === projectId && (this.worker || this.port)) {
+    if (this.projectId === projectId && this.worker && this.port) {
       return;
     }
 

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -63,7 +63,7 @@ export class CollaborationStore {
           if (!this.projectId) return;
 
           this.reconnectTimeoutId = null;
-          this.connect(this.projectId);
+          this.connect(this.projectId, true);
         }, 3000);
       } else if (type === 'WS_ERROR') {
         console.error('WebSocket error from Worker:', event.data.error);
@@ -98,8 +98,13 @@ export class CollaborationStore {
     }, 30000);
   }
 
-  connect(projectId: string) {
-    if (this.projectId === projectId && this.worker && this.port) {
+  connect(projectId: string, isReconnect = false) {
+    if (
+      !isReconnect &&
+      this.projectId === projectId &&
+      this.worker &&
+      this.port
+    ) {
       return;
     }
 
@@ -136,8 +141,6 @@ export class CollaborationStore {
         this.setupWorkerListeners();
       }
 
-      const accessToken = AuthStore.getInstance().accessToken ?? '';
-
       if (!this.currentUser) {
         console.error('user info is empty');
         return;
@@ -151,7 +154,6 @@ export class CollaborationStore {
       const message: WorkerMessage = {
         type: 'CONNECT',
         projectId,
-        token: accessToken,
         userInfo,
       };
 

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -12,7 +12,7 @@ import type {
 import type { UserInfo, WorkerMessage, WorkerResponse } from '@/worker/types';
 import { AuthStore } from './auth.store';
 
-const SHARED_WORKER_ENABLE = typeof SharedWorkerGlobalScope !== 'undefined';
+const SHARED_WORKER_ENABLE = typeof SharedWorker !== 'undefined';
 
 export class CollaborationStore {
   private static instance: CollaborationStore;

--- a/apps/frontend/src/worker/collaboration.worker.ts
+++ b/apps/frontend/src/worker/collaboration.worker.ts
@@ -1,0 +1,161 @@
+/// <reference lib="webworker" />
+
+import type { WorkerMessage, WorkerResponse } from './types';
+
+declare const self: SharedWorkerGlobalScope;
+
+const sockets = new Map<string, WebSocket>();
+const subscribers = new Map<string, MessagePort[]>();
+const portHeartbeats = new Map<MessagePort, number>();
+
+const WEBSOCKET_URL =
+  import.meta.env.VITE_BFF_WS_URL || 'ws://localhost:4000/ws/collaboration';
+
+const HEARTBEAT_INTERVAL = 30000;
+const HEARTBEAT_TIMEOUT = 60000;
+
+setInterval(() => {
+  const now = Date.now();
+  portHeartbeats.forEach((lastBeat, port) => {
+    if (now - lastBeat > HEARTBEAT_TIMEOUT) {
+      closePort(port);
+    }
+  });
+}, HEARTBEAT_INTERVAL);
+
+function closePort(port: MessagePort) {
+  portHeartbeats.delete(port);
+
+  subscribers.forEach((ports, projectId) => {
+    const nextPorts = ports.filter((p) => p !== port);
+    subscribers.set(projectId, nextPorts);
+    if (nextPorts.length === 0) {
+      const ws = sockets.get(projectId);
+      if (ws) {
+        ws.close();
+        sockets.delete(projectId);
+      }
+      subscribers.delete(projectId);
+    }
+  });
+}
+
+self.onconnect = (e: MessageEvent) => {
+  const port = e.ports[0];
+
+  portHeartbeats.set(port, Date.now());
+
+  port.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
+    portHeartbeats.set(port, Date.now());
+
+    const { type } = event.data;
+
+    if (type === 'CONNECT') {
+      const { projectId } = event.data;
+      handleConnect(projectId, port);
+    } else if (type === 'DISCONNECT') {
+      closePort(port);
+    } else if (type === 'SEND_MESSAGE') {
+      const { projectId, payload } = event.data;
+      const ws = sockets.get(projectId);
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(payload));
+      } else {
+        console.warn(
+          '[SharedWorker] WebSocket not ready, state:',
+          ws?.readyState,
+        );
+      }
+    }
+  });
+
+  port.start();
+};
+
+function handleConnect(projectId: string, port: MessagePort) {
+  if (!subscribers.has(projectId)) {
+    subscribers.set(projectId, []);
+  }
+  const ports = subscribers.get(projectId)!;
+  if (!ports.includes(port)) {
+    ports.push(port);
+  }
+
+  if (!sockets.has(projectId)) {
+    const wsUrl = `${WEBSOCKET_URL}?projectId=${projectId}`;
+
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      const message: WorkerResponse = {
+        type: 'WS_OPEN',
+        projectId,
+      };
+
+      broadcast(projectId, message);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        const message: WorkerResponse = {
+          type: 'WS_MESSAGE',
+          projectId,
+          payload,
+        };
+
+        broadcast(projectId, message);
+      } catch (error) {
+        console.error('[SharedWorker] Parse error', error);
+      }
+    };
+
+    ws.onclose = () => {
+      const message: WorkerResponse = {
+        type: 'WS_CLOSE',
+        projectId,
+      };
+
+      broadcast(projectId, message);
+      sockets.delete(projectId);
+    };
+
+    ws.onerror = (event) => {
+      console.error('[SharedWorker] WebSocket ERROR:', event);
+
+      const message: WorkerResponse = {
+        type: 'WS_ERROR',
+        projectId,
+        error: 'WebSocket error occurred',
+      };
+
+      broadcast(projectId, message);
+    };
+
+    sockets.set(projectId, ws);
+  } else {
+    const ws = sockets.get(projectId);
+    if (ws?.readyState === WebSocket.OPEN) {
+      const message: WorkerResponse = {
+        type: 'WS_OPEN',
+        projectId,
+      };
+
+      port.postMessage(message);
+    }
+  }
+}
+
+function broadcast(projectId: string, message: WorkerResponse) {
+  const ports = subscribers.get(projectId);
+  if (ports) {
+    ports.forEach((port) => {
+      try {
+        port.postMessage(message);
+      } catch (e: unknown) {
+        console.error(e);
+        closePort(port);
+      }
+    });
+  }
+}

--- a/apps/frontend/src/worker/collaboration.worker.ts
+++ b/apps/frontend/src/worker/collaboration.worker.ts
@@ -114,12 +114,13 @@ function handlePort(port: WorkerPort) {
 }
 
 if (SHARED_WORKER_ENABLE && self instanceof SharedWorkerGlobalScope) {
+  console.log('[Worker] SharedWorkerGlobalScope');
   self.onconnect = (e: MessageEvent) => {
     const port = e.ports[0];
     handlePort(port);
   };
-} else if (self instanceof DedicatedWorkerGlobalScope) {
-  handlePort(self);
+} else {
+  handlePort(self as DedicatedWorkerGlobalScope);
 }
 
 function handleConnect(projectId: string, port: WorkerPort) {

--- a/apps/frontend/src/worker/types.ts
+++ b/apps/frontend/src/worker/types.ts
@@ -17,7 +17,6 @@ export type WorkerMessage =
   | {
       type: 'CONNECT';
       projectId: string;
-      token: string;
       userInfo: UserInfo;
     }
   | { type: 'DISCONNECT'; projectId: string }

--- a/apps/frontend/src/worker/types.ts
+++ b/apps/frontend/src/worker/types.ts
@@ -14,7 +14,12 @@ export type UserInfo = {
 };
 
 export type WorkerMessage =
-  | { type: 'CONNECT'; projectId: string; token: string }
+  | {
+      type: 'CONNECT';
+      projectId: string;
+      token: string;
+      userInfo: UserInfo;
+    }
   | { type: 'DISCONNECT'; projectId: string }
   | { type: 'SEND_MESSAGE'; projectId: string; payload: OutgoingMessage };
 

--- a/apps/frontend/src/worker/types.ts
+++ b/apps/frontend/src/worker/types.ts
@@ -1,0 +1,19 @@
+import type {
+  PostChat,
+  PostCursor,
+  PostSchemaFocus,
+  WebSocketMessage,
+} from '../lib/api/collaboration/types';
+
+export type OutgoingMessage = PostCursor | PostSchemaFocus | PostChat;
+
+export type WorkerMessage =
+  | { type: 'CONNECT'; projectId: string; token: string }
+  | { type: 'DISCONNECT'; projectId: string }
+  | { type: 'SEND_MESSAGE'; projectId: string; payload: OutgoingMessage };
+
+export type WorkerResponse =
+  | { type: 'WS_MESSAGE'; projectId: string; payload: WebSocketMessage }
+  | { type: 'WS_OPEN'; projectId: string }
+  | { type: 'WS_CLOSE'; projectId: string }
+  | { type: 'WS_ERROR'; projectId: string; error: string };

--- a/apps/frontend/src/worker/types.ts
+++ b/apps/frontend/src/worker/types.ts
@@ -21,7 +21,8 @@ export type WorkerMessage =
       userInfo: UserInfo;
     }
   | { type: 'DISCONNECT'; projectId: string }
-  | { type: 'SEND_MESSAGE'; projectId: string; payload: OutgoingMessage };
+  | { type: 'SEND_MESSAGE'; projectId: string; payload: OutgoingMessage }
+  | { type: 'PING'; projectId: string };
 
 export type WorkerResponse =
   | { type: 'WS_MESSAGE'; projectId: string; payload: WebSocketMessage }

--- a/apps/frontend/src/worker/types.ts
+++ b/apps/frontend/src/worker/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CursorPosition,
   PostChat,
   PostCursor,
   PostSchemaFocus,
@@ -6,6 +7,11 @@ import type {
 } from '../lib/api/collaboration/types';
 
 export type OutgoingMessage = PostCursor | PostSchemaFocus | PostChat;
+
+export type UserInfo = {
+  userId: string;
+  userName: string;
+};
 
 export type WorkerMessage =
   | { type: 'CONNECT'; projectId: string; token: string }
@@ -16,4 +22,10 @@ export type WorkerResponse =
   | { type: 'WS_MESSAGE'; projectId: string; payload: WebSocketMessage }
   | { type: 'WS_OPEN'; projectId: string }
   | { type: 'WS_CLOSE'; projectId: string }
-  | { type: 'WS_ERROR'; projectId: string; error: string };
+  | { type: 'WS_ERROR'; projectId: string; error: string }
+  | {
+      type: 'INITIAL_STATE';
+      projectId: string;
+      cursors: CursorPosition[];
+      users: UserInfo[];
+    };


### PR DESCRIPTION
## 개요
- 저번 회의 시간 때 sessionId를 서버에서 준다는 말을 듣고 최적화를 생각해 보았습니다.
- sessionId가 필요한 이유는 같은 계정으로 여러 개의 브라우저나 탭이 로그인 될 경우를 고려한다고 생각하였고, 만약 여러 탭이 로그인 되어서 프로젝트에 들어가 있으면 웹소켓은 각각의 탭마다 연결이 진행되면서 서버에 부하가 갈거라고 판단하였습니다.

### 참고 자료
이 때 예전에 토스 면접 준비 과정에서 재밌게 봤던 SLASH24 영상이 생각났습니다
https://www.youtube.com/watch?v=SVt1-Opp3Wo 

토스증권 PC 버전이 출시되면서 유저들이 여러 브라우저 탭을 동시에 열어 사용하게되면서 서버 트래픽이 증가하고, 이를 해결하기 위해 SharedWorker를 이용한 최적화를 진행했다는 내용입니다.
이 방식을 현재 프로젝트에 적용해 보기로 하였습니다.

기존 방식의 웹소켓 연결은 다음과 같습니다
<img width="526" height="313" alt="websocket-다음에서-변환-svg" src="https://github.com/user-attachments/assets/ffce1223-c794-4040-914c-020ecf06d6b4" />
각각의 탭마다 웹소켓이 연결됩니다.

교체된 방식은 다음과 같습니다
<img width="722" height="312" alt="sharedworker-다음에서-변환-svg" src="https://github.com/user-attachments/assets/7e1f98fb-7b13-496e-bbf4-6c981e959240" />

SharedWorker를 놓음으로써 유저가 아무리 탭을 여러개 켜놔도 웹소켓 연결은 하나로 관리되기에, 그만큼 서버에 드는 부하가 줄어듭니다.

<img width="809" height="154" alt="스크린샷 2026-01-24 오후 5 15 48" src="https://github.com/user-attachments/assets/3a97b7a5-1b2f-4ae1-9957-0c2ea89c5fe6" />

이처럼 기존 방식은 웹소켓 연결량이 사용자가 한 명임에도 불구하고 계속 늘어났고 SharedWorker를 사용함으로써 다음과 같이 웹소켓 연결을 단축시킬수 있었습니다.

<img width="1470" height="956" alt="스크린샷 2026-01-24 오후 5 06 53" src="https://github.com/user-attachments/assets/332356ef-928e-4889-aeb2-6f51542db881" />

하지만 SharedWorker는 지원되지 않는 브라우저가 존재하였기에, 존재하지 않는 브라우저의 경우 DedicatedWorker를 사용하여, 기존 로직은 재활용하면서 서비스 장애를 막았습니다


### 추가 수정사항
- 채팅이 여러 개 연속으로 들어올 시, 리렌더링으로 인하여 사라지게 만들기 위해 사용했던 타이머가 초기화되는 문제가 있어 수정하였습니다.

- close #200