### PR TITLE
feat(#175): logout api

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/common/security/jwt/JwtTokenIssuer.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/security/jwt/JwtTokenIssuer.java
@@ -1,14 +1,13 @@
 package com.schemafy.core.common.security.jwt;
 
-import java.time.Duration;
-import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
+import java.time.Duration;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -63,6 +62,35 @@ public class JwtTokenIssuer {
     return ResponseEntity.ok()
         .headers(headers)
         .body(body);
+  }
+
+  public HttpHeaders expireTokens() {
+    boolean cookieSecure = jwtProperties.getCookie().isSecure();
+    String cookieSameSite = jwtProperties.getCookie().getSameSite();
+
+    ResponseCookie refreshTokenCookie = ResponseCookie
+        .from(REFRESH_TOKEN_COOKIE_NAME, "")
+        .httpOnly(true)
+        .secure(cookieSecure)
+        .path("/")
+        .maxAge(0) // 즉시 만료
+        .sameSite(cookieSameSite)
+        .build();
+
+    ResponseCookie accessTokenCookie = ResponseCookie
+        .from(ACCESS_TOKEN_COOKIE_NAME, "")
+        .httpOnly(true)
+        .secure(cookieSecure)
+        .path("/")
+        .maxAge(0) // 즉시 만료
+        .sameSite(cookieSameSite)
+        .build();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+    headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+
+    return headers;
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/security/jwt/JwtTokenIssuer.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/security/jwt/JwtTokenIssuer.java
@@ -1,13 +1,13 @@
 package com.schemafy.core.common.security.jwt;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
-
 import java.time.Duration;
 import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -23,8 +23,7 @@ public class JwtTokenIssuer {
   private final JwtProvider jwtProvider;
   private final JwtProperties jwtProperties;
 
-  public <T> ResponseEntity<T> issueTokens(String userId, String userName,
-      T body) {
+  public HttpHeaders issueTokens(String userId, String userName) {
     long now = System.currentTimeMillis();
     Map<String, Object> claims = Map.of(CLAIM_NAME, userName);
 
@@ -59,9 +58,7 @@ public class JwtTokenIssuer {
     headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
 
-    return ResponseEntity.ok()
-        .headers(headers)
-        .body(body);
+    return headers;
   }
 
   public HttpHeaders expireTokens() {

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/AuthController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/AuthController.java
@@ -72,6 +72,14 @@ public class AuthController {
             BaseResponse.success(null)));
   }
 
+  /** 로그아웃 API 쿠키에 저장된 토큰을 만료시킵니다. */
+  @PostMapping("/users/logout")
+  public Mono<ResponseEntity<BaseResponse<Void>>> logout() {
+    return Mono.just(ResponseEntity.ok()
+                    .headers(jwtTokenIssuer.expireTokens())
+                    .body(BaseResponse.success(null)));
+  }
+
   /** HTTP 요청의 쿠키에서 Refresh Token을 추출합니다. */
   private String extractRefreshTokenFromCookie(ServerHttpRequest request) {
     var refreshTokenCookie = request.getCookies().getFirst("refreshToken");

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/controller/AuthController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/controller/AuthController.java
@@ -37,10 +37,9 @@ public class AuthController {
   public Mono<ResponseEntity<BaseResponse<UserInfoResponse>>> signUp(
       @Valid @RequestBody SignUpRequest request) {
     return userService.signUp(request.toCommand())
-        .map(user -> jwtTokenIssuer.issueTokens(
-            user.getId(),
-            user.getName(),
-            BaseResponse.success(UserInfoResponse.from(user))));
+        .map(user -> ResponseEntity.ok()
+            .headers(jwtTokenIssuer.issueTokens(user.getId(), user.getName()))
+            .body(BaseResponse.success(UserInfoResponse.from(user))));
   }
 
   /** 사용자 인증 후 JWT 토큰을 발급합니다.
@@ -51,10 +50,9 @@ public class AuthController {
   public Mono<ResponseEntity<BaseResponse<UserInfoResponse>>> login(
       @Valid @RequestBody LoginRequest request) {
     return userService.login(request.toCommand())
-        .map(user -> jwtTokenIssuer.issueTokens(
-            user.getId(),
-            user.getName(),
-            BaseResponse.success(UserInfoResponse.from(user))));
+        .map(user -> ResponseEntity.ok()
+            .headers(jwtTokenIssuer.issueTokens(user.getId(), user.getName()))
+            .body(BaseResponse.success(UserInfoResponse.from(user))));
   }
 
   /** Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급합니다.
@@ -66,18 +64,9 @@ public class AuthController {
       ServerHttpRequest request) {
     return Mono.fromCallable(() -> extractRefreshTokenFromCookie(request))
         .flatMap(userService::getUserFromRefreshToken)
-        .map(user -> jwtTokenIssuer.issueTokens(
-            user.getId(),
-            user.getName(),
-            BaseResponse.success(null)));
-  }
-
-  /** 로그아웃 API 쿠키에 저장된 토큰을 만료시킵니다. */
-  @PostMapping("/users/logout")
-  public Mono<ResponseEntity<BaseResponse<Void>>> logout() {
-    return Mono.just(ResponseEntity.ok()
-                    .headers(jwtTokenIssuer.expireTokens())
-                    .body(BaseResponse.success(null)));
+        .map(user -> ResponseEntity.ok()
+            .headers(jwtTokenIssuer.issueTokens(user.getId(), user.getName()))
+            .body(BaseResponse.success(null)));
   }
 
   /** HTTP 요청의 쿠키에서 Refresh Token을 추출합니다. */

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/AuthControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/AuthControllerTest.java
@@ -296,4 +296,21 @@ class AuthControllerTest {
         .isEqualTo(ErrorCode.MISSING_REFRESH_TOKEN.getCode());
   }
 
+  @Test
+  @DisplayName("로그아웃에 성공한다")
+  void logoutSuccess() {
+    webTestClient.post().uri(API_BASE_PATH + "/users/logout")
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.success").isEqualTo(true)
+        .consumeWith(result -> {
+          var cookies = result.getResponseHeaders().get("Set-Cookie");
+          assertThat(cookies).isNotNull();
+          assertThat(cookies).anyMatch(c -> c.contains("accessToken=;"));
+          assertThat(cookies).anyMatch(c -> c.contains("refreshToken=;"));
+          assertThat(cookies).allMatch(c -> c.contains("Max-Age=0"));
+        });
+  }
+
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/AuthControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/AuthControllerTest.java
@@ -296,21 +296,4 @@ class AuthControllerTest {
         .isEqualTo(ErrorCode.MISSING_REFRESH_TOKEN.getCode());
   }
 
-  @Test
-  @DisplayName("로그아웃에 성공한다")
-  void logoutSuccess() {
-    webTestClient.post().uri(API_BASE_PATH + "/users/logout")
-        .exchange()
-        .expectStatus().isOk()
-        .expectBody()
-        .jsonPath("$.success").isEqualTo(true)
-        .consumeWith(result -> {
-          var cookies = result.getResponseHeaders().get("Set-Cookie");
-          assertThat(cookies).isNotNull();
-          assertThat(cookies).anyMatch(c -> c.contains("accessToken=;"));
-          assertThat(cookies).anyMatch(c -> c.contains("refreshToken=;"));
-          assertThat(cookies).allMatch(c -> c.contains("Max-Age=0"));
-        });
-  }
-
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/controller/UserControllerTest.java
@@ -239,6 +239,10 @@ class UserControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .consumeWith(document("user-logout",
+            logoutRequestHeaders(),
+            logoutResponseHeaders(),
+            logoutResponse()))
         .jsonPath("$.success").isEqualTo(true)
         .consumeWith(result -> {
           var cookies = result.getResponseHeaders().get("Set-Cookie");

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/docs/UserApiSnippets.java
@@ -8,6 +8,7 @@ import com.schemafy.core.common.docs.RestDocsSnippets;
 
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -98,6 +99,23 @@ public class UserApiSnippets extends RestDocsSnippets {
   }
 
   public static Snippet refreshTokenResponse() {
+    return createResponseFieldsSnippet(
+        successResponseFieldsWithNullResult());
+  }
+
+  // ========== 로그아웃 API ==========
+
+  public static Snippet logoutRequestHeaders() {
+    return createRequestHeadersSnippet(authorizationHeader());
+  }
+
+  public static Snippet logoutResponseHeaders() {
+    return createResponseHeadersSnippet(
+        headerWithName("Set-Cookie")
+            .description("만료된 accessToken 및 refreshToken 쿠키 (Max-Age=0)"));
+  }
+
+  public static Snippet logoutResponse() {
     return createResponseFieldsSnippet(
         successResponseFieldsWithNullResult());
   }


### PR DESCRIPTION
## 개요
기존에 누락되어 있던 로그아웃 API 구현 내용입니다
헤더의 쿠키를 지우는 정도로 구현했습니다.

현재는 리프레시 토큰의 저장도 쿠키에 담아 보내고 있기에 리프레시 토큰 만료 기능은 빠져있는 상태입니다.
리프레시 토큰에 대한 관리가 필요한 경우 이를 위해 코드 변경이 필요해 보입니다.
이 작업은 따로 이슈를 빼서 논의 후 작업하는게 적절해 보여 이 작업은 진행하지 않았습니다.

## 스크린샷

## 이슈


- close #175