### PR TITLE
feat(#123): add DDL generator utilities and constraint generators

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
@@ -1,0 +1,13 @@
+package com.schemafy.core.erd.service.util;
+
+import java.util.List;
+
+import com.schemafy.core.erd.controller.dto.response.SchemaDetailResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+public interface DdlGenerator {
+
+  String generateSchemaDdl(SchemaDetailResponse schema,
+      List<TableDetailResponse> tables);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -1,8 +1,12 @@
 package com.schemafy.core.erd.service.util.mysql;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.util.Optional;
 import java.util.Set;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MySqlDdlUtils {
 
   private static final Set<String> VALID_REFERENTIAL_ACTIONS = Set.of(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -1,10 +1,10 @@
 package com.schemafy.core.erd.service.util.mysql;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import java.util.Optional;
 import java.util.Set;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MySqlDdlUtils {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -1,0 +1,117 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public final class MySqlDdlUtils {
+
+  private static final Pattern VALID_DATA_TYPE_PATTERN = Pattern
+      .compile("^[A-Z][A-Z0-9_ ]*$");
+
+  private static final Pattern VALID_LENGTH_SCALE_PATTERN = Pattern
+      .compile("^[0-9]+(,[0-9]+)?$");
+
+  private static final Pattern VALID_CHARSET_PATTERN = Pattern
+      .compile("^[a-zA-Z][a-zA-Z0-9_]*$");
+
+  private static final Set<String> VALID_REFERENTIAL_ACTIONS = Set.of(
+      "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION");
+
+  private static final Set<String> VALID_SORT_DIRECTIONS = Set.of("ASC", "DESC");
+
+  private static final Set<String> VALID_INDEX_TYPES = Set.of(
+      "BTREE", "HASH", "FULLTEXT", "SPATIAL");
+
+  public static String escapeIdentifier(String identifier) {
+    if (identifier == null) return "";
+    return identifier.replace("`", "``");
+  }
+
+  public static void requireNonBlank(String value, String fieldName) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(fieldName + " is required");
+    }
+  }
+
+  public static String escapeString(String str) {
+    if (str == null) return "";
+    return str.replace("\\", "\\\\").replace("'", "''");
+  }
+
+  public static String sanitizeDataType(String dataType) {
+    if (dataType == null || dataType.isEmpty())
+      throw new IllegalArgumentException("Data type cannot be null or empty");
+
+    String normalized = dataType.toUpperCase().trim();
+    if (!VALID_DATA_TYPE_PATTERN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid data type format: " + dataType);
+    }
+    return normalized;
+  }
+
+  public static Optional<String> sanitizeLengthScale(String lengthScale) {
+    if (lengthScale == null || lengthScale.isEmpty()) return Optional.empty();
+
+    String trimmed = lengthScale.trim();
+    if (!VALID_LENGTH_SCALE_PATTERN.matcher(trimmed).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid length/scale format: " + lengthScale);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeCharset(String charset) {
+    if (charset == null || charset.isEmpty()) return Optional.empty();
+
+    String trimmed = charset.trim();
+    if (!VALID_CHARSET_PATTERN.matcher(trimmed).matches()) {
+      throw new IllegalArgumentException("Invalid charset format: " + charset);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeCollation(String collation) {
+    if (collation == null || collation.isEmpty()) return Optional.empty();
+
+    String trimmed = collation.trim();
+    if (!VALID_CHARSET_PATTERN.matcher(trimmed).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid collation format: " + collation);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeIndexType(String indexType) {
+    if (indexType == null || indexType.isEmpty()) return Optional.empty();
+
+    String normalized = indexType.toUpperCase().trim();
+    if (!VALID_INDEX_TYPES.contains(normalized)) {
+      throw new IllegalArgumentException("Invalid index type: " + indexType);
+    }
+    return Optional.of(normalized);
+  }
+
+  public static Optional<String> sanitizeSortDirection(String sortDir) {
+    if (sortDir == null || sortDir.isEmpty()) return Optional.empty();
+
+    String normalized = sortDir.toUpperCase().trim();
+    if (!VALID_SORT_DIRECTIONS.contains(normalized)) {
+      throw new IllegalArgumentException("Invalid sort direction: " + sortDir);
+    }
+    return Optional.of(normalized);
+  }
+
+  public static Optional<String> sanitizeReferentialAction(String action) {
+    if (action == null || action.isEmpty()) return Optional.empty();
+
+    String normalized = action.toUpperCase().trim();
+    if (!VALID_REFERENTIAL_ACTIONS.contains(normalized)) {
+      throw new IllegalArgumentException(
+          "Invalid referential action: " + action);
+    }
+    return Optional.of(normalized);
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.erd.service.util.mysql;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -115,6 +116,15 @@ public final class MySqlDdlUtils {
           "Invalid referential action: " + action);
     }
     return Optional.of(normalized);
+  }
+
+  public static String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new IllegalStateException("Column not found: " + columnId);
+    }
+    return "`" + escapeIdentifier(name) + "`";
   }
 
   // ^[A-Z][A-Z0-9_ ]*$

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -14,7 +14,8 @@ public final class MySqlDdlUtils {
       "BTREE", "HASH", "FULLTEXT", "SPATIAL");
 
   public static String escapeIdentifier(String identifier) {
-    if (identifier == null) return "";
+    if (identifier == null)
+      return "";
     return identifier.replace("`", "``");
   }
 
@@ -25,7 +26,8 @@ public final class MySqlDdlUtils {
   }
 
   public static String escapeString(String str) {
-    if (str == null) return "";
+    if (str == null)
+      return "";
     return str.replace("\\", "\\\\").replace("'", "''");
   }
 
@@ -43,7 +45,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeLengthScale(String lengthScale) {
-    if (lengthScale == null || lengthScale.isEmpty()) return Optional.empty();
+    if (lengthScale == null || lengthScale.isEmpty())
+      return Optional.empty();
 
     String trimmed = lengthScale.trim();
     if (!isValidLengthScale(trimmed)) {
@@ -54,7 +57,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeCharset(String charset) {
-    if (charset == null || charset.isEmpty()) return Optional.empty();
+    if (charset == null || charset.isEmpty())
+      return Optional.empty();
 
     String trimmed = charset.trim();
     if (!isValidIdentifierFormat(trimmed)) {
@@ -64,7 +68,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeCollation(String collation) {
-    if (collation == null || collation.isEmpty()) return Optional.empty();
+    if (collation == null || collation.isEmpty())
+      return Optional.empty();
 
     String trimmed = collation.trim();
     if (!isValidIdentifierFormat(trimmed)) {
@@ -75,7 +80,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeIndexType(String indexType) {
-    if (indexType == null || indexType.isEmpty()) return Optional.empty();
+    if (indexType == null || indexType.isEmpty())
+      return Optional.empty();
 
     String normalized = indexType.toUpperCase().trim();
     if (!VALID_INDEX_TYPES.contains(normalized)) {
@@ -85,7 +91,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeSortDirection(String sortDir) {
-    if (sortDir == null || sortDir.isEmpty()) return Optional.empty();
+    if (sortDir == null || sortDir.isEmpty())
+      return Optional.empty();
 
     String normalized = sortDir.toUpperCase().trim();
     if (!VALID_SORT_DIRECTIONS.contains(normalized)) {
@@ -95,7 +102,8 @@ public final class MySqlDdlUtils {
   }
 
   public static Optional<String> sanitizeReferentialAction(String action) {
-    if (action == null || action.isEmpty()) return Optional.empty();
+    if (action == null || action.isEmpty())
+      return Optional.empty();
 
     String normalized = action.toUpperCase().trim();
     if (!VALID_REFERENTIAL_ACTIONS.contains(normalized)) {
@@ -107,10 +115,12 @@ public final class MySqlDdlUtils {
 
   // ^[A-Z][A-Z0-9_ ]*$
   private static boolean isValidDataType(String value) {
-    if (value.isEmpty()) return false;
+    if (value.isEmpty())
+      return false;
 
     char first = value.charAt(0);
-    if (first < 'A' || first > 'Z') return false;
+    if (first < 'A' || first > 'Z')
+      return false;
 
     for (int i = 1; i < value.length(); i++) {
       char c = value.charAt(i);
@@ -118,14 +128,16 @@ public final class MySqlDdlUtils {
           || (c >= '0' && c <= '9')
           || c == '_'
           || c == ' ';
-      if (!valid) return false;
+      if (!valid)
+        return false;
     }
     return true;
   }
 
   // ^[0-9]+(,[0-9]+)?$
   private static boolean isValidLengthScale(String value) {
-    if (value.isEmpty()) return false;
+    if (value.isEmpty())
+      return false;
 
     int commaIndex = value.indexOf(',');
 
@@ -133,7 +145,8 @@ public final class MySqlDdlUtils {
       return isDigitsOnly(value);
     }
 
-    if (commaIndex == 0 || commaIndex == value.length() - 1) return false;
+    if (commaIndex == 0 || commaIndex == value.length() - 1)
+      return false;
 
     String before = value.substring(0, commaIndex);
     String after = value.substring(commaIndex + 1);
@@ -142,22 +155,26 @@ public final class MySqlDdlUtils {
   }
 
   private static boolean isDigitsOnly(String value) {
-    if (value.isEmpty()) return false;
+    if (value.isEmpty())
+      return false;
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
-      if (c < '0' || c > '9') return false;
+      if (c < '0' || c > '9')
+        return false;
     }
     return true;
   }
 
   // ^[a-zA-Z][a-zA-Z0-9_]*$
   private static boolean isValidIdentifierFormat(String value) {
-    if (value.isEmpty()) return false;
+    if (value.isEmpty())
+      return false;
 
     char first = value.charAt(0);
     boolean validFirst = (first >= 'a' && first <= 'z')
         || (first >= 'A' && first <= 'Z');
-    if (!validFirst) return false;
+    if (!validFirst)
+      return false;
 
     for (int i = 1; i < value.length(); i++) {
       char c = value.charAt(i);
@@ -165,7 +182,8 @@ public final class MySqlDdlUtils {
           || (c >= 'A' && c <= 'Z')
           || (c >= '0' && c <= '9')
           || c == '_';
-      if (!valid) return false;
+      if (!valid)
+        return false;
     }
     return true;
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
@@ -13,6 +13,7 @@ import com.schemafy.core.erd.controller.dto.response.RelationshipResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
 
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.quoteColumn;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeReferentialAction;
 
@@ -102,15 +103,6 @@ public class MySqlForeignKeyGenerator {
 
     sanitizeReferentialAction(relationship.getOnUpdate())
         .ifPresent(action -> sql.append(" ON UPDATE ").append(action));
-  }
-
-  private String quoteColumn(Map<String, String> columnIdToName,
-      String columnId) {
-    String name = columnIdToName.get(columnId);
-    if (name == null) {
-      throw new IllegalStateException("Column not found: " + columnId);
-    }
-    return "`" + escapeIdentifier(name) + "`";
   }
 
   private List<RelationshipResponse> getRelationships(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
@@ -82,7 +82,13 @@ public class MySqlForeignKeyGenerator {
 
   private String buildPkColumnList(RelationshipResponse relationship,
       Map<String, String> pkColumnIdToName) {
-    return getColumns(relationship).stream()
+    List<RelationshipColumnResponse> cols = getColumns(relationship);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Foreign key must have at least one referenced column: " + relationship.getName());
+    }
+
+    return cols.stream()
         .sorted(Comparator.comparing(RelationshipColumnResponse::getSeqNo,
             Comparator.nullsLast(Comparator.naturalOrder())))
         .map(rc -> quoteColumn(pkColumnIdToName, rc.getPkColumnId()))

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
@@ -1,0 +1,124 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeReferentialAction;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.erd.controller.dto.response.RelationshipColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.RelationshipResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+@Component
+public class MySqlForeignKeyGenerator {
+
+  public List<String> generate(TableDetailResponse table,
+      Map<String, String> tableIdToName,
+      Map<String, String> columnIdToName,
+      Map<String, Map<String, String>> tableColumnMaps) {
+    requireNonBlank(table.getName(), "Table name");
+
+    return getRelationships(table).stream()
+        .filter(r -> table.getId().equals(r.getFkTableId()))
+        .map(r -> generateAlter(table.getName(), r, tableIdToName,
+            columnIdToName, tableColumnMaps))
+        .toList();
+  }
+
+  private String generateAlter(String tableName,
+      RelationshipResponse relationship,
+      Map<String, String> tableIdToName,
+      Map<String, String> columnIdToName,
+      Map<String, Map<String, String>> tableColumnMaps) {
+    requireNonBlank(relationship.getName(), "Foreign key name");
+
+    String pkTableName = tableIdToName.get(relationship.getPkTableId());
+    if (pkTableName == null) {
+      throw new IllegalStateException(
+          "Referenced table not found: " + relationship.getPkTableId());
+    }
+
+    StringBuilder sql = new StringBuilder("ALTER TABLE `");
+    sql.append(escapeIdentifier(tableName)).append("` ADD CONSTRAINT `");
+    sql.append(escapeIdentifier(relationship.getName()))
+        .append("` FOREIGN KEY (");
+
+    sql.append(buildFkColumnList(relationship, columnIdToName));
+    sql.append(") REFERENCES `");
+    sql.append(escapeIdentifier(pkTableName)).append("` (");
+
+    Map<String, String> pkColumnIdToName = tableColumnMaps.getOrDefault(
+        relationship.getPkTableId(), Collections.emptyMap());
+    sql.append(buildPkColumnList(relationship, pkColumnIdToName));
+    sql.append(")");
+
+    appendReferentialActions(sql, relationship);
+    sql.append(";");
+
+    return sql.toString();
+  }
+
+  private String buildFkColumnList(RelationshipResponse relationship,
+      Map<String, String> columnIdToName) {
+    List<RelationshipColumnResponse> cols = getColumns(relationship);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Foreign key must have at least one column: " + relationship.getName());
+    }
+
+    return cols.stream()
+        .sorted(Comparator.comparing(RelationshipColumnResponse::getSeqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(rc -> quoteColumn(columnIdToName, rc.getFkColumnId()))
+        .collect(Collectors.joining(", "));
+  }
+
+  private String buildPkColumnList(RelationshipResponse relationship,
+      Map<String, String> pkColumnIdToName) {
+    return getColumns(relationship).stream()
+        .sorted(Comparator.comparing(RelationshipColumnResponse::getSeqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(rc -> quoteColumn(pkColumnIdToName, rc.getPkColumnId()))
+        .collect(Collectors.joining(", "));
+  }
+
+  private void appendReferentialActions(StringBuilder sql,
+      RelationshipResponse relationship) {
+    sanitizeReferentialAction(relationship.getOnDelete())
+        .ifPresent(action -> sql.append(" ON DELETE ").append(action));
+
+    sanitizeReferentialAction(relationship.getOnUpdate())
+        .ifPresent(action -> sql.append(" ON UPDATE ").append(action));
+  }
+
+  private String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new IllegalStateException("Column not found: " + columnId);
+    }
+    return "`" + escapeIdentifier(name) + "`";
+  }
+
+  private List<RelationshipResponse> getRelationships(
+      TableDetailResponse table) {
+    return table.getRelationships() != null
+        ? table.getRelationships()
+        : Collections.emptyList();
+  }
+
+  private List<RelationshipColumnResponse> getColumns(
+      RelationshipResponse relationship) {
+    return relationship.getColumns() != null
+        ? relationship.getColumns()
+        : Collections.emptyList();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlForeignKeyGenerator.java
@@ -1,9 +1,5 @@
 package com.schemafy.core.erd.service.util.mysql;
 
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeReferentialAction;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -15,6 +11,10 @@ import org.springframework.stereotype.Component;
 import com.schemafy.core.erd.controller.dto.response.RelationshipColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.RelationshipResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeReferentialAction;
 
 @Component
 public class MySqlForeignKeyGenerator {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
@@ -1,0 +1,110 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeIndexType;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeSortDirection;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.erd.controller.dto.response.IndexColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.IndexResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+@Component
+public class MySqlIndexGenerator {
+
+  public List<String> generate(TableDetailResponse table,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(table.getName(), "Table name");
+
+    return getIndexes(table).stream()
+        .map(idx -> generateAlter(table.getName(), idx, columnIdToName))
+        .toList();
+  }
+
+  private String generateAlter(String tableName, IndexResponse index,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(index.getName(), "Index name");
+
+    StringBuilder sql = new StringBuilder("ALTER TABLE `");
+    sql.append(escapeIdentifier(tableName)).append("` ADD ");
+
+    String type = sanitizeIndexType(index.getType()).orElse("BTREE");
+
+    appendIndexPrefix(sql, type);
+    sql.append("INDEX `").append(escapeIdentifier(index.getName()))
+        .append("` (");
+    sql.append(buildColumnList(index, columnIdToName));
+    sql.append(")");
+    appendUsing(sql, type);
+    sql.append(";");
+
+    return sql.toString();
+  }
+
+  private void appendIndexPrefix(StringBuilder sql, String type) {
+    if ("FULLTEXT".equals(type)) {
+      sql.append("FULLTEXT ");
+    } else if ("SPATIAL".equals(type)) {
+      sql.append("SPATIAL ");
+    }
+  }
+
+  private void appendUsing(StringBuilder sql, String type) {
+    if ("BTREE".equals(type) || "HASH".equals(type)) {
+      sql.append(" USING ").append(type);
+    }
+  }
+
+  private String buildColumnList(IndexResponse index,
+      Map<String, String> columnIdToName) {
+    List<IndexColumnResponse> cols = getColumns(index);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Index must have at least one column: " + index.getName());
+    }
+
+    return cols.stream()
+        .sorted(Comparator.comparing(IndexColumnResponse::getSeqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(ic -> formatColumn(ic, columnIdToName))
+        .collect(Collectors.joining(", "));
+  }
+
+  private String formatColumn(IndexColumnResponse ic,
+      Map<String, String> columnIdToName) {
+    String col = quoteColumn(columnIdToName, ic.getColumnId());
+    return sanitizeSortDirection(ic.getSortDir())
+        .map(dir -> col + " " + dir)
+        .orElse(col);
+  }
+
+  private String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new IllegalStateException("Column not found: " + columnId);
+    }
+    return "`" + escapeIdentifier(name) + "`";
+  }
+
+  private List<IndexResponse> getIndexes(TableDetailResponse table) {
+    return table.getIndexes() != null
+        ? table.getIndexes()
+        : Collections.emptyList();
+  }
+
+  private List<IndexColumnResponse> getColumns(IndexResponse index) {
+    return index.getColumns() != null
+        ? index.getColumns()
+        : Collections.emptyList();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
@@ -1,10 +1,5 @@
 package com.schemafy.core.erd.service.util.mysql;
 
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeIndexType;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeSortDirection;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -16,6 +11,11 @@ import org.springframework.stereotype.Component;
 import com.schemafy.core.erd.controller.dto.response.IndexColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.IndexResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeIndexType;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeSortDirection;
 
 @Component
 public class MySqlIndexGenerator {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlIndexGenerator.java
@@ -13,6 +13,7 @@ import com.schemafy.core.erd.controller.dto.response.IndexResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
 
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.quoteColumn;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeIndexType;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.sanitizeSortDirection;
@@ -84,15 +85,6 @@ public class MySqlIndexGenerator {
     return sanitizeSortDirection(ic.getSortDir())
         .map(dir -> col + " " + dir)
         .orElse(col);
-  }
-
-  private String quoteColumn(Map<String, String> columnIdToName,
-      String columnId) {
-    String name = columnIdToName.get(columnId);
-    if (name == null) {
-      throw new IllegalStateException("Column not found: " + columnId);
-    }
-    return "`" + escapeIdentifier(name) + "`";
   }
 
   private List<IndexResponse> getIndexes(TableDetailResponse table) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -1,8 +1,5 @@
 package com.schemafy.core.erd.service.util.mysql;
 
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -15,6 +12,9 @@ import org.springframework.stereotype.Component;
 import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 
 @Component
 public class MySqlPrimaryKeyGenerator {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -55,13 +55,13 @@ public class MySqlPrimaryKeyGenerator {
     return "`" + escapeIdentifier(name) + "`";
   }
 
-  private List<ConstraintResponse> getConstraints(TableDetailResponse table) {
+  public static List<ConstraintResponse> getConstraints(TableDetailResponse table) {
     return table.getConstraints() != null
         ? table.getConstraints()
         : Collections.emptyList();
   }
 
-  private List<ConstraintColumnResponse> getColumns(ConstraintResponse c) {
+  public static List<ConstraintColumnResponse> getColumns(ConstraintResponse c) {
     return c.getColumns() != null ? c.getColumns() : Collections.emptyList();
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -14,6 +14,7 @@ import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
 
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.quoteColumn;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 
 @Component
@@ -44,15 +45,6 @@ public class MySqlPrimaryKeyGenerator {
 
     return String.format("ALTER TABLE `%s` ADD PRIMARY KEY (%s);",
         escapeIdentifier(tableName), columns);
-  }
-
-  private String quoteColumn(Map<String, String> columnIdToName,
-      String columnId) {
-    String name = columnIdToName.get(columnId);
-    if (name == null) {
-      throw new IllegalStateException("Column not found: " + columnId);
-    }
-    return "`" + escapeIdentifier(name) + "`";
   }
 
   public static List<ConstraintResponse> getConstraints(TableDetailResponse table) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -1,0 +1,68 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+@Component
+public class MySqlPrimaryKeyGenerator {
+
+  public Optional<String> generate(TableDetailResponse table,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(table.getName(), "Table name");
+
+    return getConstraints(table).stream()
+        .filter(c -> "PRIMARY_KEY".equals(c.getKind()))
+        .findFirst()
+        .map(pk -> generateAlter(table.getName(), pk, columnIdToName));
+  }
+
+  private String generateAlter(String tableName, ConstraintResponse pk,
+      Map<String, String> columnIdToName) {
+    List<ConstraintColumnResponse> cols = getColumns(pk);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException("Primary key must have at least one column");
+    }
+
+    String columns = cols.stream()
+        .sorted(Comparator.comparing(ConstraintColumnResponse::getSeqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(cc -> quoteColumn(columnIdToName, cc.getColumnId()))
+        .collect(Collectors.joining(", "));
+
+    return String.format("ALTER TABLE `%s` ADD PRIMARY KEY (%s);",
+        escapeIdentifier(tableName), columns);
+  }
+
+  private String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new IllegalStateException("Column not found: " + columnId);
+    }
+    return "`" + escapeIdentifier(name) + "`";
+  }
+
+  private List<ConstraintResponse> getConstraints(TableDetailResponse table) {
+    return table.getConstraints() != null
+        ? table.getConstraints()
+        : Collections.emptyList();
+  }
+
+  private List<ConstraintColumnResponse> getColumns(ConstraintResponse c) {
+    return c.getColumns() != null ? c.getColumns() : Collections.emptyList();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
@@ -1,0 +1,72 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+@Component
+public class MySqlUniqueKeyGenerator {
+
+  public List<String> generate(TableDetailResponse table,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(table.getName(), "Table name");
+
+    return getConstraints(table).stream()
+        .filter(c -> "UNIQUE".equals(c.getKind()))
+        .map(c -> generateAlter(table.getName(), c, columnIdToName))
+        .toList();
+  }
+
+  private String generateAlter(String tableName, ConstraintResponse constraint,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(constraint.getName(), "Unique constraint name");
+
+    List<ConstraintColumnResponse> cols = getColumns(constraint);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unique constraint must have at least one column: " + constraint.getName());
+    }
+
+    String columns = cols.stream()
+        .sorted(Comparator.comparing(ConstraintColumnResponse::getSeqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(cc -> quoteColumn(columnIdToName, cc.getColumnId()))
+        .collect(Collectors.joining(", "));
+
+    return String.format("ALTER TABLE `%s` ADD UNIQUE KEY `%s` (%s);",
+        escapeIdentifier(tableName),
+        escapeIdentifier(constraint.getName()),
+        columns);
+  }
+
+  private String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new IllegalStateException("Column not found: " + columnId);
+    }
+    return "`" + escapeIdentifier(name) + "`";
+  }
+
+  private List<ConstraintResponse> getConstraints(TableDetailResponse table) {
+    return table.getConstraints() != null
+        ? table.getConstraints()
+        : Collections.emptyList();
+  }
+
+  private List<ConstraintColumnResponse> getColumns(ConstraintResponse c) {
+    return c.getColumns() != null ? c.getColumns() : Collections.emptyList();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
@@ -1,8 +1,5 @@
 package com.schemafy.core.erd.service.util.mysql;
 
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
-import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -14,6 +11,9 @@ import org.springframework.stereotype.Component;
 import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 
 @Component
 public class MySqlUniqueKeyGenerator {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlUniqueKeyGenerator.java
@@ -13,6 +13,7 @@ import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
 
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.quoteColumn;
 import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
 
 @Component
@@ -48,15 +49,6 @@ public class MySqlUniqueKeyGenerator {
         escapeIdentifier(tableName),
         escapeIdentifier(constraint.getName()),
         columns);
-  }
-
-  private String quoteColumn(Map<String, String> columnIdToName,
-      String columnId) {
-    String name = columnIdToName.get(columnId);
-    if (name == null) {
-      throw new IllegalStateException("Column not found: " + columnId);
-    }
-    return "`" + escapeIdentifier(name) + "`";
   }
 
   private List<ConstraintResponse> getConstraints(TableDetailResponse table) {


### PR DESCRIPTION
## 개요

ddl export 에 있어서 `create` 부분과 `alter` 부분을 나누어서 구현했습니다.

추후 create 와 alter 문을 합치는 파일과 test 파일을 업로드 할 예정입니다. 

### 구조

utils - SQL Injection 방어 및 입력값 검증
PRIMARY KEY, UNIQUE KEY, INDEX, FOREIGN KEY Generators 구현체를 작성했습니다.

### 이슈

- close #123 