### PR TITLE
feat(#123): mysql ddl utils

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
@@ -1,0 +1,13 @@
+package com.schemafy.core.erd.service.util;
+
+import java.util.List;
+
+import com.schemafy.core.erd.controller.dto.response.SchemaDetailResponse;
+import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+
+public interface DdlGenerator {
+
+  String generateSchemaDdl(SchemaDetailResponse schema,
+      List<TableDetailResponse> tables);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -1,0 +1,187 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.schemafy.core.common.exception.BusinessException;
+import com.schemafy.core.common.exception.ErrorCode;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MySqlDdlUtils {
+
+  private static final Set<String> VALID_SORT_DIRECTIONS = Set.of("ASC", "DESC");
+
+  private static final Set<String> VALID_INDEX_TYPES = Set.of(
+      "BTREE", "HASH", "FULLTEXT", "SPATIAL");
+
+  public static String escapeIdentifier(String identifier) {
+    if (identifier == null)
+      return "";
+    return identifier.replace("`", "``");
+  }
+
+  public static void requireNonBlank(String value, String fieldName) {
+    if (value == null || value.isBlank()) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+  }
+
+  public static String escapeString(String str) {
+    if (str == null)
+      return "";
+    return str.replace("\\", "\\\\").replace("'", "''");
+  }
+
+  public static String sanitizeDataType(String dataType) {
+    if (dataType == null || dataType.isEmpty()) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    String normalized = dataType.toUpperCase().trim();
+    if (!isValidDataType(normalized)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return normalized;
+  }
+
+  public static Optional<String> sanitizeLengthScale(String lengthScale) {
+    if (lengthScale == null || lengthScale.isEmpty())
+      return Optional.empty();
+
+    String trimmed = lengthScale.trim();
+    if (!isValidLengthScale(trimmed)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeCharset(String charset) {
+    if (charset == null || charset.isEmpty())
+      return Optional.empty();
+
+    String trimmed = charset.trim();
+    if (!isValidIdentifierFormat(trimmed)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeCollation(String collation) {
+    if (collation == null || collation.isEmpty())
+      return Optional.empty();
+
+    String trimmed = collation.trim();
+    if (!isValidIdentifierFormat(trimmed)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(trimmed);
+  }
+
+  public static Optional<String> sanitizeIndexType(String indexType) {
+    if (indexType == null || indexType.isEmpty())
+      return Optional.empty();
+
+    String normalized = indexType.toUpperCase().trim();
+    if (!VALID_INDEX_TYPES.contains(normalized)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(normalized);
+  }
+
+  public static Optional<String> sanitizeSortDirection(String sortDir) {
+    if (sortDir == null || sortDir.isEmpty())
+      return Optional.empty();
+
+    String normalized = sortDir.toUpperCase().trim();
+    if (!VALID_SORT_DIRECTIONS.contains(normalized)) {
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(normalized);
+  }
+
+  public static String quoteColumn(Map<String, String> columnIdToName,
+      String columnId) {
+    String name = columnIdToName.get(columnId);
+    if (name == null) {
+      throw new BusinessException(ErrorCode.ERD_COLUMN_NOT_FOUND);
+    }
+    return "`" + escapeIdentifier(name) + "`";
+  }
+
+  private static boolean isValidDataType(String value) {
+    if (value.isEmpty())
+      return false;
+
+    char first = value.charAt(0);
+    if (first < 'A' || first > 'Z')
+      return false;
+
+    for (int i = 1; i < value.length(); i++) {
+      char c = value.charAt(i);
+      boolean valid = (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || c == '_'
+          || c == ' ';
+      if (!valid)
+        return false;
+    }
+    return true;
+  }
+
+  private static boolean isValidLengthScale(String value) {
+    if (value.isEmpty())
+      return false;
+
+    int commaIndex = value.indexOf(',');
+
+    if (commaIndex == -1) {
+      return isDigitsOnly(value);
+    }
+
+    if (commaIndex == 0 || commaIndex == value.length() - 1)
+      return false;
+
+    String before = value.substring(0, commaIndex);
+    String after = value.substring(commaIndex + 1);
+
+    return isDigitsOnly(before) && isDigitsOnly(after);
+  }
+
+  private static boolean isDigitsOnly(String value) {
+    if (value.isEmpty())
+      return false;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9')
+        return false;
+    }
+    return true;
+  }
+
+  private static boolean isValidIdentifierFormat(String value) {
+    if (value.isEmpty())
+      return false;
+
+    char first = value.charAt(0);
+    boolean validFirst = (first >= 'a' && first <= 'z')
+        || (first >= 'A' && first <= 'Z');
+    if (!validFirst)
+      return false;
+
+    for (int i = 1; i < value.length(); i++) {
+      char c = value.charAt(i);
+      boolean valid = (c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || c == '_';
+      if (!valid)
+        return false;
+    }
+    return true;
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
@@ -1,0 +1,148 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.schemafy.core.common.exception.BusinessException;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MySqlDdlUtilsTest {
+
+  @Test
+  void escapeIdentifier_withNull_returnsEmptyString() {
+    assertEquals("", MySqlDdlUtils.escapeIdentifier(null));
+  }
+
+  @Test
+  void escapeIdentifier_withBacktick_escapesCorrectly() {
+    assertEquals("table``name", MySqlDdlUtils.escapeIdentifier("table`name"));
+  }
+
+  @Test
+  void escapeIdentifier_withNormalString_returnsAsIs() {
+    assertEquals("users", MySqlDdlUtils.escapeIdentifier("users"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   ", "\t"})
+  void requireNonBlank_withBlankValues_throwsException(String value) {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.requireNonBlank(value, "field"));
+  }
+
+  @Test
+  void requireNonBlank_withValidValue_doesNotThrow() {
+    assertDoesNotThrow(() -> MySqlDdlUtils.requireNonBlank("value", "field"));
+  }
+
+  @Test
+  void escapeString_withNull_returnsEmptyString() {
+    assertEquals("", MySqlDdlUtils.escapeString(null));
+  }
+
+  @Test
+  void escapeString_escapesBackslashAndQuote() {
+    assertEquals("test\\\\value''s", MySqlDdlUtils.escapeString("test\\value's"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"VARCHAR", "INT", "BIGINT", "TEXT", "DECIMAL"})
+  void sanitizeDataType_withValidTypes_returnsNormalized(String type) {
+    assertEquals(type, MySqlDdlUtils.sanitizeDataType(type.toLowerCase()));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void sanitizeDataType_withNullOrEmpty_throwsException(String type) {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.sanitizeDataType(type));
+  }
+
+  @Test
+  void sanitizeDataType_withInvalidFormat_throwsException() {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.sanitizeDataType("123invalid"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"10,10", "'10,2','10,2'"})
+  void sanitizeLengthScale_withValidFormats_returnsOptional(String input, String expected) {
+    assertEquals(Optional.of(expected), MySqlDdlUtils.sanitizeLengthScale(input));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void sanitizeLengthScale_withNullOrEmpty_returnsEmpty(String input) {
+    assertEquals(Optional.empty(), MySqlDdlUtils.sanitizeLengthScale(input));
+  }
+
+  @Test
+  void sanitizeLengthScale_withInvalidFormat_throwsException() {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.sanitizeLengthScale("abc"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"utf8", "utf8mb4", "latin1"})
+  void sanitizeCharset_withValidCharsets_returnsOptional(String charset) {
+    assertEquals(Optional.of(charset), MySqlDdlUtils.sanitizeCharset(charset));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void sanitizeCharset_withNullOrEmpty_returnsEmpty(String charset) {
+    assertEquals(Optional.empty(), MySqlDdlUtils.sanitizeCharset(charset));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"BTREE", "HASH", "FULLTEXT", "SPATIAL"})
+  void sanitizeIndexType_withValidTypes_returnsOptional(String type) {
+    assertEquals(Optional.of(type), MySqlDdlUtils.sanitizeIndexType(type.toLowerCase()));
+  }
+
+  @Test
+  void sanitizeIndexType_withInvalidType_throwsException() {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.sanitizeIndexType("INVALID"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ASC", "DESC"})
+  void sanitizeSortDirection_withValidDirections_returnsOptional(String dir) {
+    assertEquals(Optional.of(dir), MySqlDdlUtils.sanitizeSortDirection(dir.toLowerCase()));
+  }
+
+  @Test
+  void sanitizeSortDirection_withInvalidDirection_throwsException() {
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.sanitizeSortDirection("INVALID"));
+  }
+
+  @Test
+  void quoteColumn_withValidColumnId_returnsQuotedName() {
+    Map<String, String> columnMap = Map.of("col1", "user_name");
+    assertEquals("`user_name`", MySqlDdlUtils.quoteColumn(columnMap, "col1"));
+  }
+
+  @Test
+  void quoteColumn_withColumnNotFound_throwsException() {
+    Map<String, String> columnMap = Map.of("col1", "user_name");
+    assertThrows(BusinessException.class,
+        () -> MySqlDdlUtils.quoteColumn(columnMap, "col2"));
+  }
+
+  @Test
+  void quoteColumn_escapesBackticksInColumnName() {
+    Map<String, String> columnMap = Map.of("col1", "user`name");
+    assertEquals("`user``name`", MySqlDdlUtils.quoteColumn(columnMap, "col1"));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
@@ -1,5 +1,8 @@
 package com.schemafy.core.erd.service.util.mysql;
 
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -7,9 +10,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.schemafy.core.common.exception.BusinessException;
-
-import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,7 +32,7 @@ class MySqlDdlUtilsTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  @ValueSource(strings = {"   ", "\t"})
+  @ValueSource(strings = { "   ", "\t" })
   void requireNonBlank_withBlankValues_throwsException(String value) {
     assertThrows(BusinessException.class,
         () -> MySqlDdlUtils.requireNonBlank(value, "field"));
@@ -54,7 +54,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"VARCHAR", "INT", "BIGINT", "TEXT", "DECIMAL"})
+  @ValueSource(strings = { "VARCHAR", "INT", "BIGINT", "TEXT", "DECIMAL" })
   void sanitizeDataType_withValidTypes_returnsNormalized(String type) {
     assertEquals(type, MySqlDdlUtils.sanitizeDataType(type.toLowerCase()));
   }
@@ -73,7 +73,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"10,10", "'10,2','10,2'"})
+  @CsvSource({ "10,10", "'10,2','10,2'" })
   void sanitizeLengthScale_withValidFormats_returnsOptional(String input, String expected) {
     assertEquals(Optional.of(expected), MySqlDdlUtils.sanitizeLengthScale(input));
   }
@@ -91,7 +91,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"utf8", "utf8mb4", "latin1"})
+  @ValueSource(strings = { "utf8", "utf8mb4", "latin1" })
   void sanitizeCharset_withValidCharsets_returnsOptional(String charset) {
     assertEquals(Optional.of(charset), MySqlDdlUtils.sanitizeCharset(charset));
   }
@@ -103,7 +103,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"BTREE", "HASH", "FULLTEXT", "SPATIAL"})
+  @ValueSource(strings = { "BTREE", "HASH", "FULLTEXT", "SPATIAL" })
   void sanitizeIndexType_withValidTypes_returnsOptional(String type) {
     assertEquals(Optional.of(type), MySqlDdlUtils.sanitizeIndexType(type.toLowerCase()));
   }
@@ -115,7 +115,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ASC", "DESC"})
+  @ValueSource(strings = { "ASC", "DESC" })
   void sanitizeSortDirection_withValidDirections_returnsOptional(String dir) {
     assertEquals(Optional.of(dir), MySqlDdlUtils.sanitizeSortDirection(dir.toLowerCase()));
   }


### PR DESCRIPTION
## 개요

ddl 작성에 있어서 필요한 util문 먼저 구현

## MySqlDdlUtils 검증 함수 정리
  ## Public 검증 함수

  | 메서드 | 용도 | 반환 |
  |--------|------|------|
  | `requireNonBlank(value, fieldName)` | null/blank 체크 | `void` (예외 발생) |
  | `sanitizeDataType(dataType)` | 데이터 타입 검증 (대문자 변환) | `String` |
  | `sanitizeLengthScale(lengthScale)` | 길이/스케일 형식 검증 (예: `10`, `10,2`) | `Optional<String>` |
  | `sanitizeCharset(charset)` | 문자셋 형식 검증 | `Optional<String>` |
  | `sanitizeCollation(collation)` | 콜레이션 형식 검증 | `Optional<String>` |
  | `sanitizeIndexType(indexType)` | 인덱스 타입 검증 (`BTREE`, `HASH`, `FULLTEXT`, `SPATIAL`) |
  `Optional<String>` |
  | `sanitizeSortDirection(sortDir)` | 정렬 방향 검증 (`ASC`, `DESC`) | `Optional<String>` |
  | `sanitizeReferentialAction(action)` | FK 참조 액션 검증 (`CASCADE`, `SET NULL`, `SET DEFAULT`, `RESTRICT`,
   `NO ACTION`) | `Optional<String>` |

  ## Public 헬퍼 함수

  | 메서드 | 용도 | 반환 |
  |--------|------|------|
  | `escapeIdentifier(identifier)` | 백틱 이스케이프 (`` ` `` → ``` `` ```) | `String` |
  | `escapeString(str)` | 문자열 이스케이프 (`\`, `'`) | `String` |
  | `quoteColumn(columnIdToName, columnId)` | 컬럼 ID → 백틱 감싼 이름 | `String` |

  ## Private 검증 함수

  | 메서드 | 용도 | 반환 |
  |--------|------|------|
  | `isValidDataType(value)` | 데이터 타입 형식 검사 (대문자 시작, 영문+숫자+_+공백) | `boolean` |
  | `isValidLengthScale(value)` | 숫자 또는 `숫자,숫자` 형식 검사 | `boolean` |
  | `isDigitsOnly(value)` | 숫자만 포함 여부 | `boolean` |
  | `isValidIdentifierFormat(value)` | 식별자 형식 검사 (영문 시작, 영문+숫자+_) | `boolean` |

  ## 이슈

- close #123 