### PR TITLE
refactor: improve PR review workflow trigger and comment policy

### DIFF
--- a/.github/prompts/cursor-pr-review.md
+++ b/.github/prompts/cursor-pr-review.md
@@ -31,28 +31,14 @@ Commenting policy:
 - Post comments only on changed lines in the PR.
 - Use GitHub PR review comment endpoint (line comment), not issue-level comments.
 
-Required replacement behavior:
-
-1. Before creating new comments, delete previous bot review comments containing marker
-   `<!-- cursor-pr-review:v1 -->`.
-2. Delete target:
-    - author login = `github-actions[bot]`
-    - body contains marker
-3. Use PR review comments API endpoint for deletion:
-    - `DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}`
-
 Suggested command flow:
 
 1. Read files changed:
     - `gh pr diff "$PR_NUMBER" --name-only`
 2. Filter by allowed extensions and exclusions.
-3. Delete previous marker comments:
-    - list comments via `gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments?per_page=100" --paginate`
-    - filter with `jq`
-    - delete each matching comment via `gh api --method DELETE "repos/$GITHUB_REPOSITORY/pulls/comments/$id"`
-4. Analyze diff and identify High/Medium issues only.
-5. For each issue, confirm target line exists in changed lines of the current diff.
-6. Create line comment:
+3. Analyze diff and identify High/Medium issues only.
+4. For each issue, confirm target line exists in changed lines of the current diff.
+5. Create line comment:
     - `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments`
     - payload fields must include:
         - `body` (Korean text + marker)

--- a/.github/prompts/cursor-pr-review.md
+++ b/.github/prompts/cursor-pr-review.md
@@ -63,6 +63,14 @@ Required output format to stdout (final lines):
 - `요약: High=<number>, Medium=<number>, Comments=<number>`
 - `완료: cursor-pr-review:v1`
 
+Formatting requirements (strict):
+
+- Emit marker lines exactly as plain text (no indentation, no extra characters):
+  - `PR_OVERALL_COMMENT_BEGIN`, `PR_OVERALL_COMMENT_END`
+  - `LINE_COMMENTS_BEGIN`, `LINE_COMMENTS_END`
+- Do not wrap the final output section in markdown code fences.
+- For `LINE_COMMENTS` section, output a valid JSON array only (for no issues, exactly `[]`).
+
 Quality bar:
 
 - Focus on concrete defects and meaningful risks:

--- a/.github/prompts/cursor-pr-review.md
+++ b/.github/prompts/cursor-pr-review.md
@@ -2,7 +2,7 @@ You are running inside GitHub Actions to review a pull request with Cursor CLI.
 
 Task:
 
-1. Review this PR diff and post line-level review comments for High/Medium severity issues only.
+1. Review this PR diff and identify line-level issues of High/Medium severity only.
 2. Use Korean for all comment text.
 3. Keep workflow non-blocking. Do not fail intentionally.
 4. Do not edit files, commit, or push.
@@ -26,10 +26,11 @@ Review scope rules:
 Commenting policy:
 
 - Severity: only `High` and `Medium`.
-- Every posted comment body must include this marker on a separate line:
+- Every comment body must include this marker on a separate line:
     - `<!-- cursor-pr-review:v1 -->`
-- Post comments only on changed lines in the PR.
-- Use GitHub PR review comment endpoint (line comment), not issue-level comments.
+- Target only changed lines in the PR.
+- Line comments are optional. If no High/Medium issues exist, skip line comments entirely.
+- Do NOT post comments via GitHub API. Output them as structured JSON to stdout instead.
 
 Suggested command flow:
 
@@ -38,14 +39,7 @@ Suggested command flow:
 2. Filter by allowed extensions and exclusions.
 3. Analyze diff and identify High/Medium issues only.
 4. For each issue, confirm target line exists in changed lines of the current diff.
-5. Create line comment:
-    - `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments`
-    - payload fields must include:
-        - `body` (Korean text + marker)
-        - `commit_id` = `PR_HEAD_SHA`
-        - `path`
-        - `line`
-        - `side` = `"RIGHT"`
+5. Output line comments as JSON to stdout (see output format below). Do NOT call any GitHub API to post comments.
 
 Required output format to stdout (final lines):
 
@@ -58,6 +52,14 @@ Required output format to stdout (final lines):
     - `### 개선 사항`
   - High/Medium 이슈가 없으면 `LGTM` 문구를 반드시 포함
 - `PR_OVERALL_COMMENT_END`
+- `LINE_COMMENTS_BEGIN`
+- JSON array of line comment objects, one per line. Each object:
+    - `path`: relative file path
+    - `line`: line number in the diff
+    - `side`: `"RIGHT"`
+    - `body`: Korean comment text including `<!-- cursor-pr-review:v1 -->` marker
+- If no issues found, output an empty array `[]`.
+- `LINE_COMMENTS_END`
 - `요약: High=<number>, Medium=<number>, Comments=<number>`
 - `완료: cursor-pr-review:v1`
 

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -92,6 +92,7 @@ jobs:
           persist-credentials: false
 
       - name: Guard draft PRs for issue_comment trigger
+        id: draft_guard
         if: ${{ github.event_name == 'issue_comment' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -100,10 +101,11 @@ jobs:
           is_draft="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.draft')"
           if [ "${is_draft}" = "true" ]; then
             echo "::notice::Skipping review: PR #${PR_NUMBER} is a draft."
-            exit 1
+            echo "skip_review=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Cursor CLI
+        if: ${{ steps.draft_guard.outputs.skip_review != 'true' }}
         continue-on-error: true
         run: |
           curl https://cursor.com/install -fsS | bash
@@ -115,11 +117,13 @@ jobs:
           fi
 
       - name: Confirm GitHub CLI
+        if: ${{ steps.draft_guard.outputs.skip_review != 'true' }}
         continue-on-error: true
         run: gh --version
 
       - name: Run Cursor PR review (non-blocking)
         id: cursor_review
+        if: ${{ steps.draft_guard.outputs.skip_review != 'true' }}
         continue-on-error: true
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
@@ -232,7 +236,7 @@ jobs:
           exit "${cursor_exit_code}"
 
       - name: Write review summary
-        if: always()
+        if: ${{ always() && steps.draft_guard.outputs.skip_review != 'true' }}
         env:
           CURSOR_OUTCOME: ${{ steps.cursor_review.outcome }}
           CURSOR_EXIT_CODE: ${{ steps.cursor_review.outputs.cursor_exit_code }}
@@ -283,7 +287,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish PR summary comment
-        if: always()
+        if: ${{ always() && steps.draft_guard.outputs.skip_review != 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -330,15 +334,23 @@ jobs:
             fi
           fi
 
-          existing_comment_id="$(
+          existing_comment="$(
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" --paginate \
-              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | .id" \
-              | head -n 1
+              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | {id, body}" \
+              | jq -s 'first // empty'
           )"
 
-          if [ -n "${existing_comment_id:-}" ]; then
-            echo "Summary comment already exists (id=${existing_comment_id}). Skipping."
-            exit 0
+          if [ -n "${existing_comment:-}" ]; then
+            existing_comment_id="$(echo "${existing_comment}" | jq -r '.id')"
+            existing_body="$(echo "${existing_comment}" | jq -r '.body')"
+
+            if echo "${existing_body}" | grep -q "⚠️"; then
+              echo "Previous summary was a failure (id=${existing_comment_id}). Deleting for re-post."
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" >/dev/null
+            else
+              echo "Summary comment already exists (id=${existing_comment_id}). Skipping."
+              exit 0
+            fi
           fi
 
           if [ "${CURSOR_OUTCOME}" = "success" ] && [ "${CURSOR_EXIT_CODE}" = "0" ]; then

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -141,6 +141,24 @@ jobs:
           SELECTED_MODEL="${CURSOR_MODEL:-auto}"
           echo "selected_model=${SELECTED_MODEL}" >> "$GITHUB_OUTPUT"
 
+          # Resolve PR metadata early so downstream steps can still publish
+          # failure summaries even when this step exits early.
+          if [ -n "${PR_NUMBER:-}" ]; then
+            pr_meta_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || true)"
+            if [ -n "${pr_meta_json:-}" ]; then
+              PR_URL="$(echo "$pr_meta_json" | jq -r '.html_url')"
+              PR_HEAD_SHA="$(echo "$pr_meta_json" | jq -r '.head.sha')"
+              PR_BASE_REF="$(echo "$pr_meta_json" | jq -r '.base.ref')"
+              PR_HEAD_REF="$(echo "$pr_meta_json" | jq -r '.head.ref')"
+              PR_TITLE="$(echo "$pr_meta_json" | jq -r '.title // ""')"
+              PR_BODY="$(echo "$pr_meta_json" | jq -r '.body // ""')"
+            fi
+          fi
+
+          if [ -n "${PR_HEAD_SHA:-}" ]; then
+            echo "pr_head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
           if [ -z "${CURSOR_API_KEY:-}" ]; then
             echo "ERROR: CURSOR_API_KEY secret is missing." | tee cursor-review-output.txt
             echo "cursor_exit_code=97" >> "$GITHUB_OUTPUT"
@@ -309,17 +327,30 @@ jobs:
 
           SUMMARY_MARKER="<!-- cursor-pr-review-summary:v1 -->"
 
-          sanitized_output=""
-          if [ -f cursor-review-output.txt ]; then
-            sanitized_output="$(sed -e 's/\x1b\[[0-9;]*m//g' cursor-review-output.txt)"
+          if [ -z "${PR_HEAD_SHA:-}" ]; then
+            PR_HEAD_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)"
+            if [ -n "${PR_HEAD_SHA:-}" ]; then
+              echo "Resolved PR_HEAD_SHA via API fallback: ${PR_HEAD_SHA}"
+            else
+              echo "Warning: PR_HEAD_SHA is empty. Posting review without commit_id."
+            fi
           fi
 
-          summary_line="$(printf '%s\n' "${sanitized_output}" | grep -E '^요약:[[:space:]]*High=[0-9]+,[[:space:]]*Medium=[0-9]+,[[:space:]]*Comments=[0-9]+' | tail -n 1)"
-          overall_comment="$(printf '%s\n' "${sanitized_output}" | sed -n '/^PR_OVERALL_COMMENT_BEGIN$/,/^PR_OVERALL_COMMENT_END$/p' | sed '1d;$d')"
+          sanitized_output=""
+          if [ -f cursor-review-output.txt ]; then
+            sanitized_output="$(sed -e 's/\x1b\[[0-9;]*m//g' cursor-review-output.txt | tr -d '\r')"
+          fi
+
+          summary_line="$(printf '%s\n' "${sanitized_output}" | grep -E '요약:[[:space:]]*High=[0-9]+,[[:space:]]*Medium=[0-9]+,[[:space:]]*Comments=[0-9]+' | tail -n 1)"
+          overall_comment="$(printf '%s\n' "${sanitized_output}" | sed -n '/^[[:space:]]*PR_OVERALL_COMMENT_BEGIN[[:space:]]*$/,/^[[:space:]]*PR_OVERALL_COMMENT_END[[:space:]]*$/p' | sed '1d;$d')"
 
           # Parse line comments JSON (B3)
           line_comments_json="$(printf '%s\n' "${sanitized_output}" \
-            | sed -n '/^LINE_COMMENTS_BEGIN$/,/^LINE_COMMENTS_END$/p' | sed '1d;$d')"
+            | sed -n '/^[[:space:]]*LINE_COMMENTS_BEGIN[[:space:]]*$/,/^[[:space:]]*LINE_COMMENTS_END[[:space:]]*$/p' | sed '1d;$d')"
+
+          if [ -z "$(printf '%s' "${line_comments_json:-}" | tr -d '[:space:]')" ]; then
+            line_comments_json="[]"
+          fi
 
           # Validate JSON array, fallback to empty array
           if ! echo "${line_comments_json:-[]}" | jq -e 'type == "array"' >/dev/null 2>&1; then
@@ -349,18 +380,25 @@ jobs:
           # Check for existing PR review (B4)
           existing_review="$(
             gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
-              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | {id, body}" \
+              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | {id, body, commit_id}" \
               | jq -s 'last // empty'
           )"
 
           if [ -n "${existing_review:-}" ]; then
             existing_body="$(echo "${existing_review}" | jq -r '.body')"
             existing_id="$(echo "${existing_review}" | jq -r '.id')"
+            existing_commit_id="$(echo "${existing_review}" | jq -r '.commit_id // ""')"
 
             if echo "${existing_body}" | grep -q "Status: ⚠️"; then
               echo "Previous review was a failure (id=${existing_id}). Posting new review."
+            elif [ "${GITHUB_EVENT_NAME}" = "issue_comment" ]; then
+              echo "Manual /review trigger detected. Posting a fresh review."
+            elif [ -z "${existing_commit_id:-}" ] || [ -z "${PR_HEAD_SHA:-}" ]; then
+              echo "Unable to compare review commits reliably. Posting a fresh review."
+            elif [ "${existing_commit_id}" != "${PR_HEAD_SHA}" ]; then
+              echo "Existing successful review is for an older commit (${existing_commit_id}). Posting new review for ${PR_HEAD_SHA}."
             else
-              echo "Successful review already exists (id=${existing_id}). Skipping."
+              echo "Successful review already exists for current commit (id=${existing_id}). Skipping."
               exit 0
             fi
           fi
@@ -389,13 +427,22 @@ jobs:
             "${SUMMARY_MARKER}")"
 
           # Submit as single PR review with line comments (B5)
-          jq -n \
-            --arg commit_id "${PR_HEAD_SHA}" \
-            --arg body "${review_body}" \
-            --arg event "COMMENT" \
-            --argjson comments "${line_comments_json:-[]}" \
-            '{commit_id: $commit_id, body: $body, event: $event, comments: $comments}' \
-            > pr-review-payload.json
+          if [ -n "${PR_HEAD_SHA:-}" ]; then
+            jq -n \
+              --arg commit_id "${PR_HEAD_SHA}" \
+              --arg body "${review_body}" \
+              --arg event "COMMENT" \
+              --argjson comments "${line_comments_json:-[]}" \
+              '{commit_id: $commit_id, body: $body, event: $event, comments: $comments}' \
+              > pr-review-payload.json
+          else
+            jq -n \
+              --arg body "${review_body}" \
+              --arg event "COMMENT" \
+              --argjson comments "${line_comments_json:-[]}" \
+              '{body: $body, event: $event, comments: $comments}' \
+              > pr-review-payload.json
+          fi
 
           if ! gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
             --method POST --input pr-review-payload.json >/dev/null; then
@@ -404,12 +451,20 @@ jobs:
             line_count="$(echo "${line_comments_json:-[]}" | jq 'length')"
             if [ "${line_count}" -gt 0 ]; then
               echo "Warning: PR review with line comments failed. Retrying summary-only."
-              jq -n \
-                --arg commit_id "${PR_HEAD_SHA}" \
-                --arg body "${review_body}" \
-                --arg event "COMMENT" \
-                '{commit_id: $commit_id, body: $body, event: $event, comments: []}' \
-                > pr-review-payload.json
+              if [ -n "${PR_HEAD_SHA:-}" ]; then
+                jq -n \
+                  --arg commit_id "${PR_HEAD_SHA}" \
+                  --arg body "${review_body}" \
+                  --arg event "COMMENT" \
+                  '{commit_id: $commit_id, body: $body, event: $event, comments: []}' \
+                  > pr-review-payload.json
+              else
+                jq -n \
+                  --arg body "${review_body}" \
+                  --arg event "COMMENT" \
+                  '{body: $body, event: $event, comments: []}' \
+                  > pr-review-payload.json
+              fi
 
               gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
                 --method POST --input pr-review-payload.json >/dev/null

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -233,6 +233,7 @@ jobs:
 
           cursor_exit_code=${PIPESTATUS[0]}
           echo "cursor_exit_code=${cursor_exit_code}" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           exit "${cursor_exit_code}"
 
       - name: Write review summary
@@ -286,13 +287,14 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Publish PR summary comment
+      - name: Publish PR review
         if: ${{ always() && steps.draft_guard.outputs.skip_review != 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.cursor_review.outputs.pr_head_sha }}
           CURSOR_OUTCOME: ${{ steps.cursor_review.outcome }}
           CURSOR_EXIT_CODE: ${{ steps.cursor_review.outputs.cursor_exit_code }}
           CURSOR_MODEL: ${{ steps.cursor_review.outputs.selected_model }}
@@ -301,7 +303,7 @@ jobs:
           set +e
 
           if [ -z "${PR_NUMBER:-}" ]; then
-            echo "Skip PR summary comment: PR_NUMBER is empty."
+            echo "Skip PR review: PR_NUMBER is empty."
             exit 0
           fi
 
@@ -314,6 +316,16 @@ jobs:
 
           summary_line="$(printf '%s\n' "${sanitized_output}" | grep -E '^요약:[[:space:]]*High=[0-9]+,[[:space:]]*Medium=[0-9]+,[[:space:]]*Comments=[0-9]+' | tail -n 1)"
           overall_comment="$(printf '%s\n' "${sanitized_output}" | sed -n '/^PR_OVERALL_COMMENT_BEGIN$/,/^PR_OVERALL_COMMENT_END$/p' | sed '1d;$d')"
+
+          # Parse line comments JSON (B3)
+          line_comments_json="$(printf '%s\n' "${sanitized_output}" \
+            | sed -n '/^LINE_COMMENTS_BEGIN$/,/^LINE_COMMENTS_END$/p' | sed '1d;$d')"
+
+          # Validate JSON array, fallback to empty array
+          if ! echo "${line_comments_json:-[]}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "Warning: LINE_COMMENTS JSON is invalid, falling back to empty array."
+            line_comments_json="[]"
+          fi
 
           high_count="N/A"
           medium_count="N/A"
@@ -334,21 +346,21 @@ jobs:
             fi
           fi
 
-          existing_comment="$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" --paginate \
+          # Check for existing PR review (B4)
+          existing_review="$(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
               | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | {id, body}" \
               | jq -s 'first // empty'
           )"
 
-          if [ -n "${existing_comment:-}" ]; then
-            existing_comment_id="$(echo "${existing_comment}" | jq -r '.id')"
-            existing_body="$(echo "${existing_comment}" | jq -r '.body')"
+          if [ -n "${existing_review:-}" ]; then
+            existing_body="$(echo "${existing_review}" | jq -r '.body')"
+            existing_id="$(echo "${existing_review}" | jq -r '.id')"
 
-            if echo "${existing_body}" | grep -q "⚠️"; then
-              echo "Previous summary was a failure (id=${existing_comment_id}). Deleting for re-post."
-              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" >/dev/null
+            if echo "${existing_body}" | grep -q "Status: ⚠️"; then
+              echo "Previous review was a failure (id=${existing_id}). Posting new review."
             else
-              echo "Summary comment already exists (id=${existing_comment_id}). Skipping."
+              echo "Successful review already exists (id=${existing_id}). Skipping."
               exit 0
             fi
           fi
@@ -359,26 +371,46 @@ jobs:
             status_line="⚠️ failed or incomplete (non-blocking)"
           fi
 
+          # Build review body (B5)
+          review_body="$(printf '%s' "## PR Overall Review
+
+${overall_comment}
+
+---
+- Status: ${status_line}
+- Model: \`${CURSOR_MODEL:-auto}\`
+- Related issues detected: \`${RELATED_ISSUE_COUNT:-0}\`
+- High: \`${high_count}\`
+- Medium: \`${medium_count}\`
+- Line comments posted: \`${comment_count}\`
+- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+${SUMMARY_MARKER}")"
+
+          # Submit as single PR review with line comments (B5)
           jq -n \
-            --arg status "${status_line}" \
-            --arg model "${CURSOR_MODEL:-auto}" \
-            --arg issues "${RELATED_ISSUE_COUNT:-0}" \
-            --arg high "${high_count}" \
-            --arg medium "${medium_count}" \
-            --arg comments "${comment_count}" \
-            --arg overall "${overall_comment}" \
-            --arg repo "${GITHUB_REPOSITORY}" \
-            --arg run_id "${GITHUB_RUN_ID}" \
-            --arg marker "${SUMMARY_MARKER}" \
-            '{ body: ("## PR Overall Review\n\n"
-              + $overall + "\n\n---\n"
-              + "- Status: " + $status + "\n"
-              + "- Model: `" + $model + "`\n"
-              + "- Related issues detected: `" + $issues + "`\n"
-              + "- High: `" + $high + "`\n"
-              + "- Medium: `" + $medium + "`\n"
-              + "- Line comments posted: `" + $comments + "`\n"
-              + "- Workflow run: https://github.com/" + $repo + "/actions/runs/" + $run_id + "\n"
-              + "라인별 상세 내용은 PR의 파일/라인 코멘트를 확인해주세요.\n\n"
-              + $marker) }' > pr-summary-comment.json
-          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --method POST --input pr-summary-comment.json >/dev/null
+            --arg commit_id "${PR_HEAD_SHA}" \
+            --arg body "${review_body}" \
+            --arg event "COMMENT" \
+            --argjson comments "${line_comments_json:-[]}" \
+            '{commit_id: $commit_id, body: $body, event: $event, comments: $comments}' \
+            > pr-review-payload.json
+
+          if ! gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            --method POST --input pr-review-payload.json >/dev/null; then
+
+            # Fallback: retry without line comments if they caused the failure (B6)
+            line_count="$(echo "${line_comments_json:-[]}" | jq 'length')"
+            if [ "${line_count}" -gt 0 ]; then
+              echo "Warning: PR review with line comments failed. Retrying summary-only."
+              jq -n \
+                --arg commit_id "${PR_HEAD_SHA}" \
+                --arg body "${review_body}" \
+                --arg event "COMMENT" \
+                '{commit_id: $commit_id, body: $body, event: $event, comments: []}' \
+                > pr-review-payload.json
+
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+                --method POST --input pr-review-payload.json >/dev/null
+            fi
+          fi

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -3,7 +3,7 @@ name: Cursor PR Review
 on:
   pull_request_target:
     branches: [ main ]
-    types: [ opened, reopened, synchronize, ready_for_review, labeled ]
+    types: [ opened, reopened, ready_for_review, labeled ]
     paths:
       - "**/*.ts"
       - "**/*.tsx"
@@ -16,6 +16,8 @@ on:
       - "**/*.yaml"
       - "!package-lock.json"
       - "!**/*.md"
+  issue_comment:
+    types: [ created ]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -31,18 +33,47 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 concurrency:
-  group: cursor-pr-review-${{ github.event.pull_request.number || github.run_id }}
+  group: cursor-pr-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   cursor-pr-review:
     name: Cursor PR Review
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ai-review')) }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        || (
+          github.event_name == 'pull_request_target'
+          && !github.event.pull_request.draft
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && contains(github.event.pull_request.labels.*.name, 'ai-review')
+        )
+        || (
+          github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && github.event.comment.body == '/review'
+          && contains(github.event.issue.labels.*.name, 'ai-review')
+          && (
+            github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'COLLABORATOR'
+          )
+        )
+      }}
 
     steps:
+      - name: React to /review comment
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST -f content='eyes' >/dev/null
+
       - name: Checkout trusted base repository
         uses: actions/checkout@v4
         with:
@@ -59,6 +90,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
           persist-credentials: false
+
+      - name: Guard draft PRs for issue_comment trigger
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          is_draft="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.draft')"
+          if [ "${is_draft}" = "true" ]; then
+            echo "::notice::Skipping review: PR #${PR_NUMBER} is a draft."
+            exit 1
+          fi
 
       - name: Install Cursor CLI
         continue-on-error: true
@@ -83,7 +126,7 @@ jobs:
           CURSOR_MODEL: ${{ inputs.model || vars.CURSOR_REVIEW_MODEL }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -245,7 +288,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           CURSOR_OUTCOME: ${{ steps.cursor_review.outcome }}
           CURSOR_EXIT_CODE: ${{ steps.cursor_review.outputs.cursor_exit_code }}
           CURSOR_MODEL: ${{ steps.cursor_review.outputs.selected_model }}
@@ -287,16 +330,15 @@ jobs:
             fi
           fi
 
-          old_comment_ids="$(
+          existing_comment_id="$(
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" --paginate \
-              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | .id"
+              | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | .id" \
+              | head -n 1
           )"
 
-          if [ -n "${old_comment_ids:-}" ]; then
-            while IFS= read -r comment_id; do
-              [ -z "${comment_id}" ] && continue
-              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" >/dev/null
-            done <<< "${old_comment_ids}"
+          if [ -n "${existing_comment_id:-}" ]; then
+            echo "Summary comment already exists (id=${existing_comment_id}). Skipping."
+            exit 0
           fi
 
           if [ "${CURSOR_OUTCOME}" = "success" ] && [ "${CURSOR_EXIT_CODE}" = "0" ]; then

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -350,7 +350,7 @@ jobs:
           existing_review="$(
             gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
               | jq -r ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${SUMMARY_MARKER}\"))) | {id, body}" \
-              | jq -s 'first // empty'
+              | jq -s 'last // empty'
           )"
 
           if [ -n "${existing_review:-}" ]; then
@@ -372,20 +372,21 @@ jobs:
           fi
 
           # Build review body (B5)
-          review_body="$(printf '%s' "## PR Overall Review
-
-${overall_comment}
-
----
-- Status: ${status_line}
-- Model: \`${CURSOR_MODEL:-auto}\`
-- Related issues detected: \`${RELATED_ISSUE_COUNT:-0}\`
-- High: \`${high_count}\`
-- Medium: \`${medium_count}\`
-- Line comments posted: \`${comment_count}\`
-- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-
-${SUMMARY_MARKER}")"
+          review_body="$(printf '%s\n' \
+            "## PR Overall Review" \
+            "" \
+            "${overall_comment}" \
+            "" \
+            "---" \
+            "- Status: ${status_line}" \
+            "- Model: \`${CURSOR_MODEL:-auto}\`" \
+            "- Related issues detected: \`${RELATED_ISSUE_COUNT:-0}\`" \
+            "- High: \`${high_count}\`" \
+            "- Medium: \`${medium_count}\`" \
+            "- Line comments posted: \`${comment_count}\`" \
+            "- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "" \
+            "${SUMMARY_MARKER}")"
 
           # Submit as single PR review with line comments (B5)
           jq -n \


### PR DESCRIPTION
## 개요

- PR 리뷰 워크플로우 트리거 정책 변경: `synchronize` 제거, `/review` 코멘트 트리거 추가
- 요약 코멘트 정책 변경: 매번 삭제 후 재작성 → 최초 1회만 게시
- 라인 코멘트 삭제 로직 제거 (누적 방식으로 변경)

### 변경 사항

- `synchronize` 이벤트 제거 → 커밋 push마다 리뷰 재실행 방지
- `issue_comment` 트리거 추가 → PR에 `/review` 코멘트로 수동 리뷰 요청 가능
  - 정확히 `/review`만 매칭 (OWNER/MEMBER/COLLABORATOR만 허용)
  - `ai-review` 라벨 필수
  - Draft PR 가드 포함
  - 코멘트에 👀 reaction 추가
- 요약 코멘트: 이미 존재하면 스킵, 없을 때만 게시
- `cursor-pr-review.md`: 이전 코멘트 삭제 지시 섹션 제거

## 이슈

X