### PR TITLE
fix(#232): add indexes and table extra to table snapshot API

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/TableController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/TableController.java
@@ -29,6 +29,9 @@ import com.schemafy.core.erd.controller.dto.response.ColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintSnapshotResponse;
+import com.schemafy.core.erd.controller.dto.response.IndexColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.IndexResponse;
+import com.schemafy.core.erd.controller.dto.response.IndexSnapshotResponse;
 import com.schemafy.core.erd.controller.dto.response.RelationshipColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.RelationshipResponse;
 import com.schemafy.core.erd.controller.dto.response.RelationshipSnapshotResponse;
@@ -42,6 +45,11 @@ import com.schemafy.domain.erd.constraint.application.port.in.GetConstraintColum
 import com.schemafy.domain.erd.constraint.application.port.in.GetConstraintsByTableIdQuery;
 import com.schemafy.domain.erd.constraint.application.port.in.GetConstraintsByTableIdUseCase;
 import com.schemafy.domain.erd.constraint.domain.ConstraintColumn;
+import com.schemafy.domain.erd.index.application.port.in.GetIndexColumnsByIndexIdQuery;
+import com.schemafy.domain.erd.index.application.port.in.GetIndexColumnsByIndexIdUseCase;
+import com.schemafy.domain.erd.index.application.port.in.GetIndexesByTableIdQuery;
+import com.schemafy.domain.erd.index.application.port.in.GetIndexesByTableIdUseCase;
+import com.schemafy.domain.erd.index.domain.IndexColumn;
 import com.schemafy.domain.erd.relationship.application.port.in.GetRelationshipColumnsByRelationshipIdQuery;
 import com.schemafy.domain.erd.relationship.application.port.in.GetRelationshipColumnsByRelationshipIdUseCase;
 import com.schemafy.domain.erd.relationship.application.port.in.GetRelationshipsByTableIdQuery;
@@ -81,6 +89,8 @@ public class TableController {
   private final GetConstraintColumnsByConstraintIdUseCase getConstraintColumnsByConstraintIdUseCase;
   private final GetRelationshipsByTableIdUseCase getRelationshipsByTableIdUseCase;
   private final GetRelationshipColumnsByRelationshipIdUseCase getRelationshipColumnsByRelationshipIdUseCase;
+  private final GetIndexesByTableIdUseCase getIndexesByTableIdUseCase;
+  private final GetIndexColumnsByIndexIdUseCase getIndexColumnsByIndexIdUseCase;
   private final ChangeTableNameUseCase changeTableNameUseCase;
   private final ChangeTableMetaUseCase changeTableMetaUseCase;
   private final ChangeTableExtraUseCase changeTableExtraUseCase;
@@ -178,12 +188,29 @@ public class TableController {
                     columns)))
             .collectList());
 
-    return Mono.zip(tableMono, columnsMono, constraintsMono, relationshipsMono)
+    Mono<List<IndexSnapshotResponse>> indexesMono = getIndexesByTableIdUseCase
+        .getIndexesByTableId(new GetIndexesByTableIdQuery(tableId))
+        .defaultIfEmpty(List.of())
+        .flatMap(indexes -> Flux.fromIterable(indexes)
+            .flatMap(index -> getIndexColumnsByIndexIdUseCase
+                .getIndexColumnsByIndexId(new GetIndexColumnsByIndexIdQuery(index.id()))
+                .defaultIfEmpty(List.of())
+                .map(columns -> columns.stream()
+                    .sorted(Comparator.comparingInt(IndexColumn::seqNo))
+                    .map(IndexColumnResponse::from)
+                    .toList())
+                .map(columns -> new IndexSnapshotResponse(
+                    IndexResponse.from(index),
+                    columns)))
+            .collectList());
+
+    return Mono.zip(tableMono, columnsMono, constraintsMono, relationshipsMono, indexesMono)
         .map(tuple -> new TableSnapshotResponse(
             tuple.getT1(),
             tuple.getT2(),
             tuple.getT3(),
-            tuple.getT4()));
+            tuple.getT4(),
+            tuple.getT5()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableResponse.java
@@ -8,7 +8,8 @@ public record TableResponse(
     String schemaId,
     String name,
     String charset,
-    String collation) {
+    String collation,
+    String extra) {
 
   public static TableResponse from(CreateTableResult result, String schemaId) {
     return new TableResponse(
@@ -16,7 +17,8 @@ public record TableResponse(
         schemaId,
         result.name(),
         result.charset(),
-        result.collation());
+        result.collation(),
+        null);
   }
 
   public static TableResponse from(Table table) {
@@ -25,7 +27,8 @@ public record TableResponse(
         table.schemaId(),
         table.name(),
         table.charset(),
-        table.collation());
+        table.collation(),
+        table.extra());
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableSnapshotResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableSnapshotResponse.java
@@ -6,5 +6,6 @@ public record TableSnapshotResponse(
     TableResponse table,
     List<ColumnResponse> columns,
     List<ConstraintSnapshotResponse> constraints,
-    List<RelationshipSnapshotResponse> relationships) {
+    List<RelationshipSnapshotResponse> relationships,
+    List<IndexSnapshotResponse> indexes) {
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/adapter/out/persistence/TableEntity.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/adapter/out/persistence/TableEntity.java
@@ -47,12 +47,13 @@ public class TableEntity implements Persistable<String> {
 
   @Builder
   private TableEntity(String id, String schemaId, String name,
-      String charset, String collation) {
+      String charset, String collation, String extra) {
     this.id = id;
     this.schemaId = schemaId;
     this.name = name;
     this.charset = charset;
     this.collation = collation;
+    this.extra = extra;
   }
 
   @Override

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/adapter/out/persistence/TableMapper.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/adapter/out/persistence/TableMapper.java
@@ -14,6 +14,7 @@ class TableMapper {
         .name(table.name())
         .charset(table.charset())
         .collation(table.collation())
+        .extra(table.extra())
         .build();
   }
 
@@ -23,7 +24,8 @@ class TableMapper {
         entity.getSchemaId(),
         entity.getName(),
         entity.getCharset(),
-        entity.getCollation());
+        entity.getCollation(),
+        entity.getExtra());
   }
 
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/domain/Table.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/domain/Table.java
@@ -5,5 +5,16 @@ public record Table(
     String schemaId,
     String name,
     String charset,
-    String collation) {
+    String collation,
+    String extra) {
+
+  public Table(
+      String id,
+      String schemaId,
+      String name,
+      String charset,
+      String collation) {
+    this(id, schemaId, name, charset, collation, null);
+  }
+
 }


### PR DESCRIPTION
## 개요

- 테이블 스냅샷 응답에 `indexes` 정보를 추가
- `TableResponse`에 `extra 스냅샷의 `table.extra` 반환

## 이슈

- close #232
- refs #216
