### PR TITLE
fix(#234): use lazy evaluation for affectedTableIds in MutationResult

### DIFF
--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/ChangeColumnMetaService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/ChangeColumnMetaService.java
@@ -56,7 +56,7 @@ public class ChangeColumnMetaService implements ChangeColumnMetaUseCase {
               .defaultIfEmpty(List.of())
               .flatMap(columns -> applyChange(column, columns, command, affectedTableIds));
         })
-        .thenReturn(MutationResult.<Void>of(null, affectedTableIds))
+        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/ChangeColumnTypeService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/ChangeColumnTypeService.java
@@ -68,7 +68,7 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
                   lengthScale,
                   affectedTableIds));
         })
-        .thenReturn(MutationResult.<Void>of(null, affectedTableIds))
+        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/DeleteColumnService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/column/application/service/DeleteColumnService.java
@@ -79,7 +79,7 @@ public class DeleteColumnService implements DeleteColumnUseCase {
             command.columnId(),
             ConcurrentHashMap.newKeySet(),
             affectedTableIds)))
-        .thenReturn(MutationResult.<Void>of(null, affectedTableIds))
+        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/constraint/application/service/DeleteConstraintService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/constraint/application/service/DeleteConstraintService.java
@@ -48,11 +48,11 @@ public class DeleteConstraintService implements DeleteConstraintUseCase {
                 affectedTableIds)
                 .then(deleteConstraintColumnsPort.deleteByConstraintId(constraintId))
                 .then(deleteConstraintPort.deleteConstraint(constraintId))
-                .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
           }
           return deleteConstraintColumnsPort.deleteByConstraintId(constraintId)
               .then(deleteConstraintPort.deleteConstraint(constraintId))
-              .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+              .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
         })
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/constraint/application/service/RemoveConstraintColumnService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/constraint/application/service/RemoveConstraintColumnService.java
@@ -58,7 +58,7 @@ public class RemoveConstraintColumnService implements RemoveConstraintColumnUseC
                       constraintColumn.columnId(),
                       affectedTableIds))
                   .then(reorderOrDeleteConstraint(constraint.id()))
-                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                  .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
             }))
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/ChangeRelationshipKindService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/ChangeRelationshipKindService.java
@@ -60,7 +60,7 @@ public class ChangeRelationshipKindService implements ChangeRelationshipKindUseC
                 oldKind,
                 newKind,
                 affectedTableIds)
-                .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
           }
           return getTableByIdPort.findTableById(relationship.fkTableId())
               .switchIfEmpty(Mono.error(new RelationshipTargetTableNotExistException(
@@ -74,7 +74,7 @@ public class ChangeRelationshipKindService implements ChangeRelationshipKindUseC
                       oldKind,
                       newKind,
                       affectedTableIds))
-                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds)));
+                  .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))));
         })
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/DeleteRelationshipService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/DeleteRelationshipService.java
@@ -60,7 +60,7 @@ public class DeleteRelationshipService implements DeleteRelationshipUseCase {
                         .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                         .then())
                     .then()
-                    .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                    .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
               });
         })
         .as(transactionalOperator::transactional);

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/RemoveRelationshipColumnService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/RemoveRelationshipColumnService.java
@@ -58,7 +58,7 @@ public class RemoveRelationshipColumnService implements RemoveRelationshipColumn
                   .then(handleRemainingColumns(relationship.id()))
                   .then(deleteColumnUseCase.deleteColumn(new DeleteColumnCommand(fkColumnId)))
                   .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
-                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                  .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
             }))
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/schema/application/service/DeleteSchemaService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/schema/application/service/DeleteSchemaService.java
@@ -48,7 +48,7 @@ public class DeleteSchemaService implements DeleteSchemaUseCase {
               .then();
         })
         .then(Mono.defer(() -> deleteSchemaPort.deleteSchema(schemaId)))
-        .thenReturn(MutationResult.<Void>of(null, affectedTableIds))
+        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
@@ -59,7 +59,7 @@ public class DeleteTableService implements DeleteTableUseCase {
                 .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                 .then())
             .then(Mono.defer(() -> deleteTablePort.deleteTable(tableId)))
-            .thenReturn(MutationResult.<Void>of(null, affectedTableIds)))
+            .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
         .as(transactionalOperator::transactional);
   }
 


### PR DESCRIPTION
## 개요

- `MutationResult.of()`의 compact constructor가 `Set.copyOf()`로 방어적 복사를 수행하는데, `thenReturn()`은 체인 조립 시점에 인자를 즉시 평가하므로 비동기 작업이 set을 채우기 전에 빈 set이 복사되는 버그 수정
- 10개 서비스에서 `.thenReturn(MutationResult.of(...))` -> `.then(Mono.fromCallable(() -> MutationResult.of(...)))` 로 변경하여 lazy evaluation 적용
- 동기적으로 완성된 set을 사용하는 서비스(ChangeTableNameService, ChangeColumnNameService 등)는 영향 없으므로 수정하지 않음

## 이슈

- close #234 