### PR TITLE
fix(#238): replace deleted ERD response DTOs in DdlGenerator

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/DdlGenerator.java
@@ -2,12 +2,12 @@ package com.schemafy.core.erd.service.util;
 
 import java.util.List;
 
-import com.schemafy.core.erd.controller.dto.response.SchemaDetailResponse;
-import com.schemafy.core.erd.controller.dto.response.TableDetailResponse;
+import com.schemafy.core.erd.controller.dto.response.SchemaResponse;
+import com.schemafy.core.erd.controller.dto.response.TableSnapshotResponse;
 
 public interface DdlGenerator {
 
-  String generateSchemaDdl(SchemaDetailResponse schema,
-      List<TableDetailResponse> tables);
+  String generateSchemaDdl(SchemaResponse schema,
+      List<TableSnapshotResponse> tables);
 
 }


### PR DESCRIPTION
## 개요

- `DdlGenerator` 인터페이스가 리팩토링(#186)으로 삭제된 `SchemaDetailResponse`, `TableDetailResponse`를 참조하여 컴파일 오류 발생
- 현재 존재하는 `SchemaResponse`, `TableSnapshotResponse`로 교체

## 변경
- `SchemaDetailResponse` → `SchemaResponse`
- `TableDetailResponse` → `TableSnapshotResponse`

## 이슈
close #238 