### PR TITLE
feat(#123): mysql pk generate

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -112,8 +112,7 @@ public final class MySqlDdlUtils {
 
     String normalized = action.toUpperCase().trim();
     if (!VALID_REFERENTIAL_ACTIONS.contains(normalized)) {
-      throw new IllegalArgumentException(
-          "Invalid referential action: " + action);
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
     return Optional.of(normalized);
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MySqlDdlUtils {
 
+  private static final Set<String> VALID_REFERENTIAL_ACTIONS = Set.of(
+      "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION");
+
   private static final Set<String> VALID_SORT_DIRECTIONS = Set.of("ASC", "DESC");
 
   private static final Set<String> VALID_INDEX_TYPES = Set.of(
@@ -99,6 +102,18 @@ public final class MySqlDdlUtils {
     String normalized = sortDir.toUpperCase().trim();
     if (!VALID_SORT_DIRECTIONS.contains(normalized)) {
       throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+    return Optional.of(normalized);
+  }
+
+  public static Optional<String> sanitizeReferentialAction(String action) {
+    if (action == null || action.isEmpty())
+      return Optional.empty();
+
+    String normalized = action.toUpperCase().trim();
+    if (!VALID_REFERENTIAL_ACTIONS.contains(normalized)) {
+      throw new IllegalArgumentException(
+          "Invalid referential action: " + action);
     }
     return Optional.of(normalized);
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtils.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public final class MySqlDdlUtils {
 
   private static final Set<String> VALID_REFERENTIAL_ACTIONS = Set.of(
-      "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION");
+      "CASCADE", "SET NULL", "RESTRICT", "NO ACTION");
 
   private static final Set<String> VALID_SORT_DIRECTIONS = Set.of("ASC", "DESC");
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.schemafy.core.common.exception.BusinessException;
+import com.schemafy.core.common.exception.ErrorCode;
 import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintSnapshotResponse;
 import com.schemafy.core.erd.controller.dto.response.TableSnapshotResponse;
@@ -35,7 +37,7 @@ public class MySqlPrimaryKeyGenerator {
       Map<String, String> columnIdToName) {
     List<ConstraintColumnResponse> cols = getColumns(pk);
     if (cols.isEmpty()) {
-      throw new IllegalArgumentException("Primary key must have at least one column");
+      throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     String columns = cols.stream()

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -1,0 +1,61 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.ConstraintSnapshotResponse;
+import com.schemafy.core.erd.controller.dto.response.TableSnapshotResponse;
+import com.schemafy.domain.erd.constraint.domain.type.ConstraintKind;
+
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.escapeIdentifier;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.quoteColumn;
+import static com.schemafy.core.erd.service.util.mysql.MySqlDdlUtils.requireNonBlank;
+
+@Component
+public class MySqlPrimaryKeyGenerator {
+
+  public Optional<String> generate(TableSnapshotResponse table,
+      Map<String, String> columnIdToName) {
+    requireNonBlank(table.table().name(), "Table name");
+
+    return getConstraints(table).stream()
+        .filter(c -> ConstraintKind.PRIMARY_KEY == c.constraint().kind())
+        .findFirst()
+        .map(pk -> generateAlter(table.table().name(), pk, columnIdToName));
+  }
+
+  private String generateAlter(String tableName, ConstraintSnapshotResponse pk,
+      Map<String, String> columnIdToName) {
+    List<ConstraintColumnResponse> cols = getColumns(pk);
+    if (cols.isEmpty()) {
+      throw new IllegalArgumentException("Primary key must have at least one column");
+    }
+
+    String columns = cols.stream()
+        .sorted(Comparator.comparing(ConstraintColumnResponse::seqNo,
+            Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(cc -> quoteColumn(columnIdToName, cc.columnId()))
+        .collect(Collectors.joining(", "));
+
+    return String.format("ALTER TABLE `%s` ADD PRIMARY KEY (%s);",
+        escapeIdentifier(tableName), columns);
+  }
+
+  public static List<ConstraintSnapshotResponse> getConstraints(TableSnapshotResponse table) {
+    return table.constraints() != null
+        ? table.constraints()
+        : Collections.emptyList();
+  }
+
+  public static List<ConstraintColumnResponse> getColumns(ConstraintSnapshotResponse c) {
+    return c.columns() != null ? c.columns() : Collections.emptyList();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGenerator.java
@@ -50,13 +50,13 @@ public class MySqlPrimaryKeyGenerator {
         escapeIdentifier(tableName), columns);
   }
 
-  public static List<ConstraintSnapshotResponse> getConstraints(TableSnapshotResponse table) {
+  private List<ConstraintSnapshotResponse> getConstraints(TableSnapshotResponse table) {
     return table.constraints() != null
         ? table.constraints()
         : Collections.emptyList();
   }
 
-  public static List<ConstraintColumnResponse> getColumns(ConstraintSnapshotResponse c) {
+  private List<ConstraintColumnResponse> getColumns(ConstraintSnapshotResponse c) {
     return c.columns() != null ? c.columns() : Collections.emptyList();
   }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
@@ -126,6 +126,18 @@ class MySqlDdlUtilsTest {
         () -> MySqlDdlUtils.sanitizeSortDirection("INVALID"));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = { "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION" })
+  void sanitizeReferentialAction_withValidActions_returnsOptional(String action) {
+    assertEquals(Optional.of(action), MySqlDdlUtils.sanitizeReferentialAction(action.toLowerCase()));
+  }
+
+  @Test
+  void sanitizeReferentialAction_withInvalidAction_throwsException() {
+    assertThrows(IllegalArgumentException.class,
+        () -> MySqlDdlUtils.sanitizeReferentialAction("INVALID"));
+  }
+
   @Test
   void quoteColumn_withValidColumnId_returnsQuotedName() {
     Map<String, String> columnMap = Map.of("col1", "user_name");

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
@@ -134,7 +134,7 @@ class MySqlDdlUtilsTest {
 
   @Test
   void sanitizeReferentialAction_withInvalidAction_throwsException() {
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BusinessException.class,
         () -> MySqlDdlUtils.sanitizeReferentialAction("INVALID"));
   }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlDdlUtilsTest.java
@@ -127,7 +127,7 @@ class MySqlDdlUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION" })
+  @ValueSource(strings = { "CASCADE", "SET NULL", "RESTRICT", "NO ACTION" })
   void sanitizeReferentialAction_withValidActions_returnsOptional(String action) {
     assertEquals(Optional.of(action), MySqlDdlUtils.sanitizeReferentialAction(action.toLowerCase()));
   }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
@@ -123,7 +123,7 @@ class MySqlPrimaryKeyGeneratorTest {
         new TableResponse("t1", null, "users", null, null, null),
         null, List.of(pk), null, null);
 
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BusinessException.class,
         () -> generator.generate(table, Collections.emptyMap()));
   }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
@@ -1,5 +1,13 @@
 package com.schemafy.core.erd.service.util.mysql;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.schemafy.core.common.exception.BusinessException;
 import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
@@ -7,13 +15,6 @@ import com.schemafy.core.erd.controller.dto.response.ConstraintSnapshotResponse;
 import com.schemafy.core.erd.controller.dto.response.TableResponse;
 import com.schemafy.core.erd.controller.dto.response.TableSnapshotResponse;
 import com.schemafy.domain.erd.constraint.domain.type.ConstraintKind;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/service/util/mysql/MySqlPrimaryKeyGeneratorTest.java
@@ -1,0 +1,166 @@
+package com.schemafy.core.erd.service.util.mysql;
+
+import com.schemafy.core.common.exception.BusinessException;
+import com.schemafy.core.erd.controller.dto.response.ConstraintColumnResponse;
+import com.schemafy.core.erd.controller.dto.response.ConstraintResponse;
+import com.schemafy.core.erd.controller.dto.response.ConstraintSnapshotResponse;
+import com.schemafy.core.erd.controller.dto.response.TableResponse;
+import com.schemafy.core.erd.controller.dto.response.TableSnapshotResponse;
+import com.schemafy.domain.erd.constraint.domain.type.ConstraintKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MySqlPrimaryKeyGeneratorTest {
+
+  private MySqlPrimaryKeyGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new MySqlPrimaryKeyGenerator();
+  }
+
+  @Test
+  void generate_withPrimaryKey_returnsAlterStatement() {
+    ConstraintColumnResponse column = new ConstraintColumnResponse("cc1", "pk1", "col1", 1);
+
+    ConstraintSnapshotResponse pk = new ConstraintSnapshotResponse(
+        new ConstraintResponse("pk1", "t1", "PRIMARY", ConstraintKind.PRIMARY_KEY, null, null),
+        List.of(column));
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "users", null, null, null),
+        null, List.of(pk), null, null);
+
+    Map<String, String> columnIdToName = Map.of("col1", "id");
+
+    Optional<String> result = generator.generate(table, columnIdToName);
+
+    assertTrue(result.isPresent());
+    assertEquals("ALTER TABLE `users` ADD PRIMARY KEY (`id`);", result.get());
+  }
+
+  @Test
+  void generate_withMultipleColumns_ordersCorrectly() {
+    ConstraintColumnResponse col1 = new ConstraintColumnResponse("cc1", "pk1", "col1", 2);
+    ConstraintColumnResponse col2 = new ConstraintColumnResponse("cc2", "pk1", "col2", 1);
+
+    ConstraintSnapshotResponse pk = new ConstraintSnapshotResponse(
+        new ConstraintResponse("pk1", "t1", "PRIMARY", ConstraintKind.PRIMARY_KEY, null, null),
+        List.of(col1, col2));
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "orders", null, null, null),
+        null, List.of(pk), null, null);
+
+    Map<String, String> columnIdToName = Map.of("col1", "order_id", "col2", "user_id");
+
+    Optional<String> result = generator.generate(table, columnIdToName);
+
+    assertTrue(result.isPresent());
+    assertEquals("ALTER TABLE `orders` ADD PRIMARY KEY (`user_id`, `order_id`);", result.get());
+  }
+
+  @Test
+  void generate_withNoPrimaryKey_returnsEmpty() {
+    ConstraintSnapshotResponse unique = new ConstraintSnapshotResponse(
+        new ConstraintResponse("uk1", "t1", "uk_email", ConstraintKind.UNIQUE, null, null),
+        Collections.emptyList());
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "users", null, null, null),
+        null, List.of(unique), null, null);
+
+    Optional<String> result = generator.generate(table, Collections.emptyMap());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void generate_withNullConstraints_returnsEmpty() {
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "users", null, null, null),
+        null, null, null, null);
+
+    Optional<String> result = generator.generate(table, Collections.emptyMap());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void generate_withBlankTableName_throwsException() {
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "", null, null, null),
+        null, null, null, null);
+
+    assertThrows(BusinessException.class,
+        () -> generator.generate(table, Collections.emptyMap()));
+  }
+
+  @Test
+  void generate_withNullTableName_throwsException() {
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, null, null, null, null),
+        null, null, null, null);
+
+    assertThrows(BusinessException.class,
+        () -> generator.generate(table, Collections.emptyMap()));
+  }
+
+  @Test
+  void generate_withEmptyColumns_throwsException() {
+    ConstraintSnapshotResponse pk = new ConstraintSnapshotResponse(
+        new ConstraintResponse("pk1", "t1", "PRIMARY", ConstraintKind.PRIMARY_KEY, null, null),
+        Collections.emptyList());
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "users", null, null, null),
+        null, List.of(pk), null, null);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> generator.generate(table, Collections.emptyMap()));
+  }
+
+  @Test
+  void generate_withUnknownColumnId_throwsException() {
+    ConstraintColumnResponse column = new ConstraintColumnResponse("cc1", "pk1", "unknown_col", 1);
+
+    ConstraintSnapshotResponse pk = new ConstraintSnapshotResponse(
+        new ConstraintResponse("pk1", "t1", "PRIMARY", ConstraintKind.PRIMARY_KEY, null, null),
+        List.of(column));
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "users", null, null, null),
+        null, List.of(pk), null, null);
+
+    assertThrows(BusinessException.class,
+        () -> generator.generate(table, Map.of("col1", "id")));
+  }
+
+  @Test
+  void generate_withSpecialCharactersInTableName_escapesCorrectly() {
+    ConstraintColumnResponse column = new ConstraintColumnResponse("cc1", "pk1", "col1", 1);
+
+    ConstraintSnapshotResponse pk = new ConstraintSnapshotResponse(
+        new ConstraintResponse("pk1", "t1", "PRIMARY", ConstraintKind.PRIMARY_KEY, null, null),
+        List.of(column));
+
+    TableSnapshotResponse table = new TableSnapshotResponse(
+        new TableResponse("t1", null, "user`table", null, null, null),
+        null, List.of(pk), null, null);
+
+    Map<String, String> columnIdToName = Map.of("col1", "id");
+
+    Optional<String> result = generator.generate(table, columnIdToName);
+
+    assertTrue(result.isPresent());
+    assertEquals("ALTER TABLE `user``table` ADD PRIMARY KEY (`id`);", result.get());
+  }
+
+}


### PR DESCRIPTION
## 개요
- `MySqlPrimaryKeyGenerator` 추가: 테이블의 PK constraint로부터 `ALTER TABLE ... ADD PRIMARY KEY` DDL 생성
  - 복합 PK 지원 (여러 컬럼을 seqNo 기준 정렬)
  - 테이블명/컬럼명 backtick escape 처리
  - PK가 없는 테이블은 `Optional.empty()` 반환

## New tests (vs main)
| 테스트 메서드 | 설명 |
|---|---|
| `MySqlPrimaryKeyGeneratorTest` | `generate_withPrimaryKey_returnsAlterStatement` | PK 단일 컬럼 ALTER 생성 |
| `generate_withMultipleColumns_ordersCorrectly` | 복수 컬럼 seqNo 순서 정렬 |
| `generate_withNoPrimaryKey_returnsEmpty` | PK 없으면 empty 반환 |
| `generate_withNullConstraints_returnsEmpty` | constraints null이면 empty 반환 |
| `generate_withBlankTableName_throwsException` | 테이블명 blank → BusinessException |
| `generate_withNullTableName_throwsException` | 테이블명 null → BusinessException |
| `generate_withEmptyColumns_throwsException` | PK 컬럼 비어있으면 → IllegalArgumentException |
| `generate_withUnknownColumnId_throwsException` | 존재하지 않는 columnId → BusinessException |
| `generate_withSpecialCharactersInTableName_escapesCorrectly` | 테이블명 백틱 escape 처리 |

## 이슈
#123 