### PR TITLE
feat(#243): add extra field to table and relationship creation

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/RelationshipController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/RelationshipController.java
@@ -89,7 +89,8 @@ public class RelationshipController {
         request.fkTableId(),
         request.pkTableId(),
         request.kind(),
-        request.cardinality());
+        request.cardinality(),
+        request.extra());
     return createRelationshipUseCase.createRelationship(command)
         .flatMap(result -> broadcastMutation(result.affectedTableIds())
             .thenReturn(result))

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/TableController.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/TableController.java
@@ -109,7 +109,8 @@ public class TableController {
         request.schemaId(),
         request.name(),
         request.charset(),
-        request.collation());
+        request.collation(),
+        request.extra());
     return createTableUseCase.createTable(command)
         .flatMap(result -> broadcastMutation(result.affectedTableIds())
             .thenReturn(result))

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/request/CreateRelationshipRequest.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/request/CreateRelationshipRequest.java
@@ -3,6 +3,7 @@ package com.schemafy.core.erd.controller.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.schemafy.domain.erd.relationship.domain.type.Cardinality;
 import com.schemafy.domain.erd.relationship.domain.type.RelationshipKind;
 
@@ -10,5 +11,6 @@ public record CreateRelationshipRequest(
     @NotBlank(message = "fkTableId는 필수입니다.") String fkTableId,
     @NotBlank(message = "pkTableId는 필수입니다.") String pkTableId,
     @NotNull(message = "kind는 필수입니다.") RelationshipKind kind,
-    @NotNull(message = "cardinality는 필수입니다.") Cardinality cardinality) {
+    @NotNull(message = "cardinality는 필수입니다.") Cardinality cardinality,
+    @JsonDeserialize(using = JsonValueToStringDeserializer.class) String extra) {
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/request/CreateTableRequest.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/request/CreateTableRequest.java
@@ -2,9 +2,12 @@ package com.schemafy.core.erd.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 public record CreateTableRequest(
     @NotBlank(message = "schemaId는 필수입니다.") String schemaId,
     @NotBlank(message = "name은 필수입니다.") String name,
     String charset,
-    String collation) {
+    String collation,
+    @JsonDeserialize(using = JsonValueToStringDeserializer.class) String extra) {
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableResponse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/controller/dto/response/TableResponse.java
@@ -18,7 +18,7 @@ public record TableResponse(
         result.name(),
         result.charset(),
         result.collation(),
-        null);
+        result.extra());
   }
 
   public static TableResponse from(Table table) {

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/RelationshipControllerTest.java
@@ -134,7 +134,8 @@ class RelationshipControllerTest {
         fkTableId,
         pkTableId,
         RelationshipKind.NON_IDENTIFYING,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY,
+        null);
 
     CreateRelationshipResult result = new CreateRelationshipResult(
         relationshipId,

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/TableControllerTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/controller/TableControllerTest.java
@@ -142,13 +142,15 @@ class TableControllerTest {
         schemaId,
         "users",
         "utf8mb4",
-        "utf8mb4_general_ci");
+        "utf8mb4_general_ci",
+        null);
 
     CreateTableResult result = new CreateTableResult(
         tableId,
         "users",
         "utf8mb4",
-        "utf8mb4_general_ci");
+        "utf8mb4_general_ci",
+        null);
 
     given(createTableUseCase.createTable(any(CreateTableCommand.class)))
         .willReturn(Mono.just(MutationResult.of(result, tableId)));

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/docs/RelationshipApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/docs/RelationshipApiSnippets.java
@@ -68,7 +68,9 @@ public class RelationshipApiSnippets extends RestDocsSnippets {
         fieldWithPath("kind").type(JsonFieldType.STRING)
             .description("관계 종류 (IDENTIFYING, NON_IDENTIFYING)"),
         fieldWithPath("cardinality").type(JsonFieldType.STRING)
-            .description("카디널리티 (ONE_TO_ONE, ONE_TO_MANY)"));
+            .description("카디널리티 (ONE_TO_ONE, ONE_TO_MANY)"),
+        fieldWithPath("extra").type(JsonFieldType.VARIES)
+            .description("추가 정보 (JSON)").optional());
   }
 
   public static Snippet createRelationshipResponseHeaders() {

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/docs/TableApiSnippets.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/docs/TableApiSnippets.java
@@ -185,7 +185,9 @@ public class TableApiSnippets extends RestDocsSnippets {
         fieldWithPath("charset").type(JsonFieldType.STRING)
             .description("문자셋").optional(),
         fieldWithPath("collation").type(JsonFieldType.STRING)
-            .description("콜레이션").optional());
+            .description("콜레이션").optional(),
+        fieldWithPath("extra").type(JsonFieldType.VARIES)
+            .description("추가 정보 (JSON)").optional());
   }
 
   /** 테이블 생성 응답 헤더 */

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/port/in/CreateRelationshipCommand.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/port/in/CreateRelationshipCommand.java
@@ -7,5 +7,6 @@ public record CreateRelationshipCommand(
     String fkTableId,
     String pkTableId,
     RelationshipKind kind,
-    Cardinality cardinality) {
+    Cardinality cardinality,
+    String extra) {
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/CreateRelationshipService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/relationship/application/service/CreateRelationshipService.java
@@ -117,7 +117,7 @@ public class CreateRelationshipService implements CreateRelationshipUseCase {
                         normalizedName,
                         command.kind(),
                         command.cardinality(),
-                        null));
+                        command.extra()));
               }
 
               return persistAutoRelationship(
@@ -148,7 +148,7 @@ public class CreateRelationshipService implements CreateRelationshipUseCase {
               normalizedName,
               command.kind(),
               command.cardinality(),
-              null);
+              command.extra());
 
           return createRelationshipPort.createRelationship(relationship)
               .flatMap(savedRelationship -> createAutoRelationshipColumns(

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/port/in/CreateTableCommand.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/port/in/CreateTableCommand.java
@@ -4,5 +4,6 @@ public record CreateTableCommand(
     String schemaId,
     String name,
     String charset,
-    String collation) {
+    String collation,
+    String extra) {
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/port/in/CreateTableResult.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/port/in/CreateTableResult.java
@@ -4,6 +4,7 @@ public record CreateTableResult(
     String tableId,
     String name,
     String charset,
-    String collation) {
+    String collation,
+    String extra) {
 
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/CreateTableService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/CreateTableService.java
@@ -51,14 +51,16 @@ public class CreateTableService implements CreateTableUseCase {
                         command.schemaId(),
                         command.name(),
                         resolvedCharset,
-                        resolvedCollation);
+                        resolvedCollation,
+                        command.extra());
 
                     return createTablePort.createTable(table)
                         .map(savedTable -> new CreateTableResult(
                             savedTable.id(),
                             savedTable.name(),
                             savedTable.charset(),
-                            savedTable.collation()))
+                            savedTable.collation(),
+                            savedTable.extra()))
                         .map(result -> MutationResult.of(result, id));
                   }));
         });

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/column/integration/DeleteColumnCascadeIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/column/integration/DeleteColumnCascadeIntegrationTest.java
@@ -115,11 +115,11 @@ class DeleteColumnCascadeIntegrationTest {
         schemaId = schemaResult.id();
 
         var pkTableResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         pkTableId = pkTableResult.tableId();
 
         var fkTableResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         fkTableId = fkTableResult.tableId();
 
         var pkColumnResult = createColumnUseCase.createColumn(new CreateColumnCommand(
@@ -195,15 +195,15 @@ class DeleteColumnCascadeIntegrationTest {
         schemaId = schemaResult.id();
 
         var pkTableResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         pkTableId = pkTableResult.tableId();
 
         var fkTableResult1 = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "fk_table_1", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "fk_table_1", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         fkTableId1 = fkTableResult1.tableId();
 
         var fkTableResult2 = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "fk_table_2", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "fk_table_2", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         fkTableId2 = fkTableResult2.tableId();
 
         var pkColumnResult = createColumnUseCase.createColumn(new CreateColumnCommand(
@@ -269,15 +269,15 @@ class DeleteColumnCascadeIntegrationTest {
         schemaId = schemaResult.id();
 
         var tableAResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "table_a", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "table_a", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         tableAId = tableAResult.tableId();
 
         var tableBResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "table_b", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "table_b", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         tableBId = tableBResult.tableId();
 
         var tableCResult = createTableUseCase.createTable(new CreateTableCommand(
-            schemaId, "table_c", "utf8mb4", "utf8mb4_general_ci")).block().result();
+            schemaId, "table_c", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
         tableCId = tableCResult.tableId();
 
         var colAResult = createColumnUseCase.createColumn(new CreateColumnCommand(
@@ -352,11 +352,11 @@ class DeleteColumnCascadeIntegrationTest {
       schemaId = schemaResult.id();
 
       var pkTableResult = createTableUseCase.createTable(new CreateTableCommand(
-          schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci")).block().result();
+          schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
       pkTableId = pkTableResult.tableId();
 
       var fkTableResult = createTableUseCase.createTable(new CreateTableCommand(
-          schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci")).block().result();
+          schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci", null)).block().result();
       fkTableId = fkTableResult.tableId();
 
       var pkColumnResult = createColumnUseCase.createColumn(new CreateColumnCommand(
@@ -401,7 +401,7 @@ class DeleteColumnCascadeIntegrationTest {
     var createCommand = new CreateRelationshipCommand(fkTableId,
         pkTableId,
         kind,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
     var result = createRelationshipUseCase.createRelationship(createCommand).block().result();
     var columns = getRelationshipColumnsByRelationshipIdUseCase
         .getRelationshipColumnsByRelationshipId(

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintCascadeDeleteIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintCascadeDeleteIntegrationTest.java
@@ -96,7 +96,7 @@ class ConstraintCascadeDeleteIntegrationTest {
     schemaId = schemaResult.id();
 
     var createTableCommand = new CreateTableCommand(
-        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci", null);
     var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
     tableId = tableResult.tableId();
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintCreateIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintCreateIntegrationTest.java
@@ -101,7 +101,7 @@ class ConstraintCreateIntegrationTest {
     schemaId = schemaResult.id();
 
     var createTableCommand = new CreateTableCommand(
-        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci", null);
     var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
     tableId = tableResult.tableId();
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintRelationshipIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/constraint/integration/ConstraintRelationshipIntegrationTest.java
@@ -124,7 +124,7 @@ class ConstraintRelationshipIntegrationTest {
 
     // PK Table 생성 (복합키를 가질 테이블)
     var createPkTableCommand = new CreateTableCommand(
-        schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null);
     var pkTableResult = createTableUseCase.createTable(createPkTableCommand).block().result();
     pkTableId = pkTableResult.tableId();
 
@@ -150,13 +150,13 @@ class ConstraintRelationshipIntegrationTest {
 
     // FK Table 1 생성
     var createFkTable1Command = new CreateTableCommand(
-        schemaId, "fk_table_1", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "fk_table_1", "utf8mb4", "utf8mb4_general_ci", null);
     var fkTable1Result = createTableUseCase.createTable(createFkTable1Command).block().result();
     fkTableId1 = fkTable1Result.tableId();
 
     // FK Table 2 생성 (다중 Relationship 테스트용)
     var createFkTable2Command = new CreateTableCommand(
-        schemaId, "fk_table_2", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "fk_table_2", "utf8mb4", "utf8mb4_general_ci", null);
     var fkTable2Result = createTableUseCase.createTable(createFkTable2Command).block().result();
     fkTableId2 = fkTable2Result.tableId();
   }
@@ -172,7 +172,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -211,7 +211,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -257,7 +257,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -296,7 +296,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -335,14 +335,14 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand1 = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult1 = createRelationshipUseCase.createRelationship(createRelCommand1).block().result();
       String relationshipId1 = relResult1.relationshipId();
 
       var createRelCommand2 = new CreateRelationshipCommand(fkTableId2,
           pkTableId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_ONE);
+          Cardinality.ONE_TO_ONE, null);
       var relResult2 = createRelationshipUseCase.createRelationship(createRelCommand2).block().result();
       String relationshipId2 = relResult2.relationshipId();
 
@@ -397,7 +397,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -449,13 +449,13 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand1 = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createRelCommand1).block();
 
       var createRelCommand2 = new CreateRelationshipCommand(fkTableId2,
           pkTableId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_ONE);
+          Cardinality.ONE_TO_ONE, null);
       createRelationshipUseCase.createRelationship(createRelCommand2).block();
 
       // Given: PK 테이블에 새 컬럼 추가
@@ -507,7 +507,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String relationshipId = relResult.relationshipId();
 
@@ -549,7 +549,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String fkColumnId = getFkColumnId(relResult.relationshipId(), pkColumnId1);
 
@@ -579,14 +579,14 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand1 = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult1 = createRelationshipUseCase.createRelationship(createRelCommand1).block().result();
       String fkColumnId1 = getFkColumnId(relResult1.relationshipId(), pkColumnId1);
 
       var createRelCommand2 = new CreateRelationshipCommand(fkTableId2,
           pkTableId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_ONE);
+          Cardinality.ONE_TO_ONE, null);
       var relResult2 = createRelationshipUseCase.createRelationship(createRelCommand2).block().result();
       String fkColumnId2 = getFkColumnId(relResult2.relationshipId(), pkColumnId1);
 
@@ -643,7 +643,7 @@ class ConstraintRelationshipIntegrationTest {
       var createRelCommand = new CreateRelationshipCommand(fkTableId1,
           pkTableId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var relResult = createRelationshipUseCase.createRelationship(createRelCommand).block().result();
       String varcharFkColumnId = getFkColumnId(relResult.relationshipId(), varcharPkColumnId);
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/index/integration/IndexCascadeDeleteIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/index/integration/IndexCascadeDeleteIntegrationTest.java
@@ -97,7 +97,7 @@ class IndexCascadeDeleteIntegrationTest {
     schemaId = schemaResult.id();
 
     var createTableCommand = new CreateTableCommand(
-        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci", null);
     var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
     tableId = tableResult.tableId();
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/index/integration/IndexCreateIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/index/integration/IndexCreateIntegrationTest.java
@@ -111,7 +111,7 @@ class IndexCreateIntegrationTest {
     schemaId = schemaResult.id();
 
     var createTableCommand = new CreateTableCommand(
-        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci", null);
     var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
     tableId = tableResult.tableId();
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/application/service/CreateRelationshipServiceTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/application/service/CreateRelationshipServiceTest.java
@@ -115,7 +115,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, SCHEMA_ID, "pk_table");
       var pkColumn = ColumnFixture.columnWithId(PK_COLUMN_ID);
@@ -178,7 +178,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, SCHEMA_ID, "pk_table");
       var pkColumn = ColumnFixture.columnWithId(PK_COLUMN_ID);
@@ -236,7 +236,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, SCHEMA_ID, "pk_table");
       var pkColumn = ColumnFixture.columnWithId(PK_COLUMN_ID);
@@ -291,7 +291,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, SCHEMA_ID, "pk_table");
 
@@ -319,7 +319,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, OTHER_SCHEMA_ID, "pk_table");
 
@@ -339,7 +339,7 @@ class CreateRelationshipServiceTest {
       var command = new CreateRelationshipCommand(FK_TABLE_ID,
           PK_TABLE_ID,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var fkTable = createTable(FK_TABLE_ID, SCHEMA_ID, "fk_table");
       var pkTable = createTable(PK_TABLE_ID, SCHEMA_ID, "pk_table");
       var pkColumn = ColumnFixture.columnWithId(PK_COLUMN_ID);

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/fixture/RelationshipFixture.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/fixture/RelationshipFixture.java
@@ -216,7 +216,7 @@ public class RelationshipFixture {
         DEFAULT_FK_TABLE_ID,
         DEFAULT_PK_TABLE_ID,
         DEFAULT_KIND,
-        DEFAULT_CARDINALITY);
+        DEFAULT_CARDINALITY, null);
   }
 
   public static CreateRelationshipCommand createCommandWithTables(
@@ -225,7 +225,7 @@ public class RelationshipFixture {
         fkTableId,
         pkTableId,
         DEFAULT_KIND,
-        DEFAULT_CARDINALITY);
+        DEFAULT_CARDINALITY, null);
   }
 
   public static CreateRelationshipCommand createIdentifyingCommand() {
@@ -233,7 +233,7 @@ public class RelationshipFixture {
         DEFAULT_FK_TABLE_ID,
         DEFAULT_PK_TABLE_ID,
         RelationshipKind.IDENTIFYING,
-        DEFAULT_CARDINALITY);
+        DEFAULT_CARDINALITY, null);
   }
 
   public static CreateRelationshipCommand createIdentifyingCommandWithTables(
@@ -242,7 +242,7 @@ public class RelationshipFixture {
         fkTableId,
         pkTableId,
         RelationshipKind.IDENTIFYING,
-        DEFAULT_CARDINALITY);
+        DEFAULT_CARDINALITY, null);
   }
 
   public static CreateRelationshipCommand createCommandWithKind(RelationshipKind kind) {
@@ -250,7 +250,7 @@ public class RelationshipFixture {
         DEFAULT_FK_TABLE_ID,
         DEFAULT_PK_TABLE_ID,
         kind,
-        DEFAULT_CARDINALITY);
+        DEFAULT_CARDINALITY, null);
   }
 
   public static ChangeRelationshipNameCommand changeNameCommand(String newName) {

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipAutoCreateIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipAutoCreateIntegrationTest.java
@@ -85,7 +85,7 @@ class RelationshipAutoCreateIntegrationTest {
     var createCommand = new CreateRelationshipCommand(fkTableId,
         pkTableId,
         RelationshipKind.NON_IDENTIFYING,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
     var result = createRelationshipUseCase.createRelationship(createCommand).block().result();
 
     assertThat(result.name()).isEqualTo("rel_fk_table_to_pk_table");
@@ -129,13 +129,13 @@ class RelationshipAutoCreateIntegrationTest {
     var childToGrandchild = new CreateRelationshipCommand(grandchildTableId,
         childTableId,
         RelationshipKind.NON_IDENTIFYING,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
     var childRelationship = createRelationshipUseCase.createRelationship(childToGrandchild).block().result();
 
     var parentToChild = new CreateRelationshipCommand(childTableId,
         parentTableId,
         RelationshipKind.IDENTIFYING,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
     createRelationshipUseCase.createRelationship(parentToChild).block();
 
     StepVerifier.create(getColumnsByTableIdUseCase.getColumnsByTableId(
@@ -169,7 +169,7 @@ class RelationshipAutoCreateIntegrationTest {
     var createCommand = new CreateRelationshipCommand(fkTableId,
         pkTableId,
         RelationshipKind.NON_IDENTIFYING,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
 
     StepVerifier.create(createRelationshipUseCase.createRelationship(createCommand))
         .expectError(InvalidValueException.class)
@@ -187,7 +187,7 @@ class RelationshipAutoCreateIntegrationTest {
 
   private String createTable(String schemaId, String name) {
     var createTableCommand = new CreateTableCommand(
-        schemaId, name, "utf8mb4", "utf8mb4_general_ci");
+        schemaId, name, "utf8mb4", "utf8mb4_general_ci", null);
     var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
     return tableResult.tableId();
   }

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipCascadeDeleteIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipCascadeDeleteIntegrationTest.java
@@ -105,12 +105,12 @@ class RelationshipCascadeDeleteIntegrationTest {
     schemaId = schemaResult.id();
 
     var createPkTableCommand = new CreateTableCommand(
-        schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null);
     var pkTableResult = createTableUseCase.createTable(createPkTableCommand).block().result();
     pkTableId = pkTableResult.tableId();
 
     var createFkTableCommand = new CreateTableCommand(
-        schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci", null);
     var fkTableResult = createTableUseCase.createTable(createFkTableCommand).block().result();
     fkTableId = fkTableResult.tableId();
 
@@ -315,7 +315,7 @@ class RelationshipCascadeDeleteIntegrationTest {
     var createCommand = new CreateRelationshipCommand(fkTableId,
         pkTableId,
         kind,
-        Cardinality.ONE_TO_MANY);
+        Cardinality.ONE_TO_MANY, null);
     var result = createRelationshipUseCase.createRelationship(createCommand).block().result();
     var columns = getRelationshipColumnsByRelationshipIdUseCase
         .getRelationshipColumnsByRelationshipId(

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipCyclicReferenceIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/relationship/integration/RelationshipCyclicReferenceIntegrationTest.java
@@ -78,17 +78,17 @@ class RelationshipCyclicReferenceIntegrationTest {
     schemaId = schemaResult.id();
 
     var createTableACommand = new CreateTableCommand(
-        schemaId, "table_a", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "table_a", "utf8mb4", "utf8mb4_general_ci", null);
     var tableAResult = createTableUseCase.createTable(createTableACommand).block().result();
     tableAId = tableAResult.tableId();
 
     var createTableBCommand = new CreateTableCommand(
-        schemaId, "table_b", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "table_b", "utf8mb4", "utf8mb4_general_ci", null);
     var tableBResult = createTableUseCase.createTable(createTableBCommand).block().result();
     tableBId = tableBResult.tableId();
 
     var createTableCCommand = new CreateTableCommand(
-        schemaId, "table_c", "utf8mb4", "utf8mb4_general_ci");
+        schemaId, "table_c", "utf8mb4", "utf8mb4_general_ci", null);
     var tableCResult = createTableUseCase.createTable(createTableCCommand).block().result();
     tableCId = tableCResult.tableId();
 
@@ -122,14 +122,14 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createABCommand).block();
 
       // B -> A (IDENTIFYING) - 순환 참조!
       var createBACommand = new CreateRelationshipCommand(tableBId,
           tableAId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
 
       StepVerifier.create(createRelationshipUseCase.createRelationship(createBACommand))
           .expectError(RelationshipCyclicReferenceException.class)
@@ -143,21 +143,21 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createABCommand).block();
 
       // B -> C (IDENTIFYING)
       var createBCCommand = new CreateRelationshipCommand(tableBId,
           tableCId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createBCCommand).block();
 
       // C -> A (IDENTIFYING) - 간접 순환 참조!
       var createCACommand = new CreateRelationshipCommand(tableCId,
           tableAId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
 
       StepVerifier.create(createRelationshipUseCase.createRelationship(createCACommand))
           .expectError(RelationshipCyclicReferenceException.class)
@@ -171,14 +171,14 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createABCommand).block();
 
       // B -> A (NON_IDENTIFYING) - 허용됨
       var createBACommand = new CreateRelationshipCommand(tableBId,
           tableAId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
 
       StepVerifier.create(createRelationshipUseCase.createRelationship(createBACommand))
           .expectNextCount(1)
@@ -192,14 +192,14 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createABCommand).block();
 
       // B -> A (IDENTIFYING) - NON_IDENTIFYING은 그래프에 없으므로 허용됨
       var createBACommand = new CreateRelationshipCommand(tableBId,
           tableAId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
 
       StepVerifier.create(createRelationshipUseCase.createRelationship(createBACommand))
           .expectNextCount(1)
@@ -219,14 +219,14 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var abResult = createRelationshipUseCase.createRelationship(createABCommand).block().result();
 
       // B -> A (IDENTIFYING)
       var createBACommand = new CreateRelationshipCommand(tableBId,
           tableAId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createBACommand).block();
 
       // A -> B를 IDENTIFYING로 변경 - 순환 참조!
@@ -245,7 +245,7 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var abResult = createRelationshipUseCase.createRelationship(createABCommand).block().result();
 
       // A -> B를 NON_IDENTIFYING로 변경
@@ -264,21 +264,21 @@ class RelationshipCyclicReferenceIntegrationTest {
       var createABCommand = new CreateRelationshipCommand(tableAId,
           tableBId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createABCommand).block();
 
       // B -> C (IDENTIFYING)
       var createBCCommand = new CreateRelationshipCommand(tableBId,
           tableCId,
           RelationshipKind.IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       createRelationshipUseCase.createRelationship(createBCCommand).block();
 
       // C -> A (NON_IDENTIFYING)
       var createCACommand = new CreateRelationshipCommand(tableCId,
           tableAId,
           RelationshipKind.NON_IDENTIFYING,
-          Cardinality.ONE_TO_MANY);
+          Cardinality.ONE_TO_MANY, null);
       var caResult = createRelationshipUseCase.createRelationship(createCACommand).block().result();
 
       // C -> A를 IDENTIFYING로 변경 - 간접 순환 참조!

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/schema/integration/DeleteSchemaIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/schema/integration/DeleteSchemaIntegrationTest.java
@@ -67,7 +67,7 @@ class DeleteSchemaIntegrationTest {
         schemaId = schemaResult.id();
 
         var createTableCommand = new CreateTableCommand(
-            schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci");
+            schemaId, "test_table", "utf8mb4", "utf8mb4_general_ci", null);
         createTableUseCase.createTable(createTableCommand).block();
       }
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/fixture/TableFixture.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/fixture/TableFixture.java
@@ -60,7 +60,8 @@ public class TableFixture {
         DEFAULT_SCHEMA_ID,
         DEFAULT_NAME,
         DEFAULT_CHARSET,
-        DEFAULT_COLLATION);
+        DEFAULT_COLLATION,
+        null);
   }
 
   public static CreateTableCommand createCommandWithName(String name) {
@@ -68,7 +69,8 @@ public class TableFixture {
         DEFAULT_SCHEMA_ID,
         name,
         DEFAULT_CHARSET,
-        DEFAULT_COLLATION);
+        DEFAULT_COLLATION,
+        null);
   }
 
   public static CreateTableCommand createCommandWithMeta(String charset, String collation) {
@@ -76,7 +78,8 @@ public class TableFixture {
         DEFAULT_SCHEMA_ID,
         DEFAULT_NAME,
         charset,
-        collation);
+        collation,
+        null);
   }
 
   public static CreateTableCommand createCommandWithoutMeta() {
@@ -88,7 +91,8 @@ public class TableFixture {
         DEFAULT_ID,
         DEFAULT_NAME,
         DEFAULT_CHARSET,
-        DEFAULT_COLLATION);
+        DEFAULT_COLLATION,
+        null);
   }
 
   public static CreateTableResult createResultFrom(Table table) {
@@ -96,7 +100,8 @@ public class TableFixture {
         table.id(),
         table.name(),
         table.charset(),
-        table.collation());
+        table.collation(),
+        table.extra());
   }
 
   public static ChangeTableNameCommand changeNameCommand(String newName) {

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/integration/DeleteTableIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/integration/DeleteTableIntegrationTest.java
@@ -114,12 +114,12 @@ class DeleteTableIntegrationTest {
         schemaId = schemaResult.id();
 
         var createPkTableCommand = new CreateTableCommand(
-            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci");
+            schemaId, "pk_table", "utf8mb4", "utf8mb4_general_ci", null);
         var pkTableResult = createTableUseCase.createTable(createPkTableCommand).block().result();
         pkTableId = pkTableResult.tableId();
 
         var createFkTableCommand = new CreateTableCommand(
-            schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci");
+            schemaId, "fk_table", "utf8mb4", "utf8mb4_general_ci", null);
         var fkTableResult = createTableUseCase.createTable(createFkTableCommand).block().result();
         fkTableId = fkTableResult.tableId();
 
@@ -151,7 +151,7 @@ class DeleteTableIntegrationTest {
         var createRelationshipCommand = new CreateRelationshipCommand(fkTableId,
             pkTableId,
             RelationshipKind.NON_IDENTIFYING,
-            Cardinality.ONE_TO_MANY);
+            Cardinality.ONE_TO_MANY, null);
         createRelationshipUseCase.createRelationship(createRelationshipCommand).block();
       }
 


### PR DESCRIPTION
## 개요

- 테이블, 관계 생성 API에서 optional `extra` 필드를 받을 수 있도록 생성 플로우 수정
- 생성 시점에 초기 `extra` 정보를 설정할 수 있어 별도 업데이트 API 호출이 불필요

## 이슈

- close #243 
