### PR TITLE
fix(#249): remove ApiResponse type and move error message conversion from BFF to frontend

### DIFF
--- a/apps/bff/src/auth/auth.service.ts
+++ b/apps/bff/src/auth/auth.service.ts
@@ -1,24 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from 'src/common/backend-client/backend-client.service';
 import { AuthResponse } from './auth.types';
-import { ApiResponse } from 'src/common/types/api-response.types';
 
 @Injectable()
 export class AuthService {
   constructor(private readonly backendClient: BackendClientService) {}
 
-  async getMyInfo(authHeader: string): Promise<ApiResponse<AuthResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<AuthResponse>
-    >('/api/v1.0/users', this.backendClient.getAuthConfig(authHeader));
+  async getMyInfo(authHeader: string): Promise<AuthResponse> {
+    const response = await this.backendClient.client.get<AuthResponse>(
+      '/api/v1.0/users',
+      this.backendClient.getAuthConfig(authHeader),
+    );
 
     return response.data;
   }
 
   async logout(
     authHeader: string,
-  ): Promise<{ data: ApiResponse<null>; setCookies: string[] }> {
-    const response = await this.backendClient.client.post<ApiResponse<null>>(
+  ): Promise<{ data: null; setCookies: string[] }> {
+    const response = await this.backendClient.client.post(
       '/api/v1.0/users/logout',
       {},
       this.backendClient.getAuthConfig(authHeader),

--- a/apps/bff/src/common/constants/error-messages.ts
+++ b/apps/bff/src/common/constants/error-messages.ts
@@ -4,66 +4,53 @@ import {
 } from '../types/api-response.types.js';
 
 type ErrorInfo = {
-  message: string;
   category: ErrorCategoryType;
 };
 
 const SESSION_EXPIRED: ErrorInfo = {
-  message: 'Your session has expired. Please sign in again.',
   category: ErrorCategory.AUTO_HANDLE,
 };
 
 const SOMETHING_WENT_WRONG: ErrorInfo = {
-  message: 'Something went wrong. Please try again later.',
   category: ErrorCategory.USER_FEEDBACK,
 };
 
 const CHECK_INPUT: ErrorInfo = {
-  message: 'Please check your input and try again.',
   category: ErrorCategory.USER_FEEDBACK,
 };
 
 const SETTINGS_TOO_LARGE: ErrorInfo = {
-  message: 'Settings are too large. Please reduce the size and try again.',
   category: ErrorCategory.USER_FEEDBACK,
 };
 
-const notFound = (item: string): ErrorInfo => ({
-  message: `${item} not found. Please check and try again.`,
+const notFound = (): ErrorInfo => ({
   category: ErrorCategory.USER_FEEDBACK,
 });
 
-export const ErrorMessages: Record<string, ErrorInfo> = {
+const ErrorMessages: Record<string, ErrorInfo> = {
   COMMON_SYSTEM_ERROR: SOMETHING_WENT_WRONG,
   COMMON_INVALID_PARAMETER: {
-    message: 'Invalid parameter.',
     category: ErrorCategory.SILENT,
   },
   COMMON_API_VERSION_MISSING: {
-    message: 'API version is missing.',
     category: ErrorCategory.SILENT,
   },
   COMMON_API_VERSION_INVALID: {
-    message: 'Invalid API version format. (e.g., v1.0, v2.1)',
     category: ErrorCategory.SILENT,
   },
   COMMON_INVALID_INPUT_VALUE: CHECK_INPUT,
   COMMON_NOT_FOUND: {
-    message: "The requested item doesn't exist or may have been moved.",
     category: ErrorCategory.USER_FEEDBACK,
   },
   COMMON_INTERNAL_SERVER_ERROR: SOMETHING_WENT_WRONG,
   COMMON_ALREADY_DELETED: {
-    message: 'This item has already been deleted.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 
   AUTH_AUTHENTICATION_REQUIRED: {
-    message: 'Please sign in to continue.',
     category: ErrorCategory.AUTO_HANDLE,
   },
   AUTH_ACCESS_DENIED: {
-    message: "You don't have permission to perform this action.",
     category: ErrorCategory.USER_FEEDBACK,
   },
   AUTH_INVALID_REFRESH_TOKEN: SESSION_EXPIRED,
@@ -76,194 +63,152 @@ export const ErrorMessages: Record<string, ErrorInfo> = {
   AUTH_TOKEN_VALIDATION_ERROR: SESSION_EXPIRED,
 
   HMAC_SIGNATURE_MISSING: {
-    message: 'Security signature is missing.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   HMAC_SIGNATURE_INVALID: {
-    message: 'Invalid request signature.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   HMAC_TIMESTAMP_EXPIRED: {
-    message: 'Request has expired. Please try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   HMAC_NONCE_DUPLICATE: {
-    message: 'Duplicate request detected. Please retry.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 
   USER_NOT_FOUND: {
-    message: 'User not found. Please check and try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   USER_ALREADY_EXISTS: {
-    message: 'This email is already registered.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   USER_LOGIN_FAILED: {
-    message: 'Invalid email or password. Please try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 
   VALIDATION_FAILED: CHECK_INPUT,
   VALIDATION_SERVICE_UNAVAILABLE: {
-    message: 'Service is temporarily unavailable. Please try again later.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   VALIDATION_TIMEOUT: {
-    message: 'Request timed out. Please try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   VALIDATION_ERROR: SOMETHING_WENT_WRONG,
 
-  SCHEMA_NOT_FOUND: notFound('Schema'),
-  TABLE_NOT_FOUND: notFound('Table'),
-  COLUMN_NOT_FOUND: notFound('Column'),
-  CONSTRAINT_NOT_FOUND: notFound('Constraint'),
-  INDEX_NOT_FOUND: notFound('Index'),
-  RELATIONSHIP_NOT_FOUND: notFound('Relationship'),
-  CONSTRAINT_COLUMN_NOT_FOUND: notFound('Constraint column'),
-  INDEX_COLUMN_NOT_FOUND: notFound('Index column'),
-  RELATIONSHIP_COLUMN_NOT_FOUND: notFound('Relationship column'),
+  SCHEMA_NOT_FOUND: notFound(),
+  TABLE_NOT_FOUND: notFound(),
+  COLUMN_NOT_FOUND: notFound(),
+  CONSTRAINT_NOT_FOUND: notFound(),
+  INDEX_NOT_FOUND: notFound(),
+  RELATIONSHIP_NOT_FOUND: notFound(),
+  CONSTRAINT_COLUMN_NOT_FOUND: notFound(),
+  INDEX_COLUMN_NOT_FOUND: notFound(),
+  RELATIONSHIP_COLUMN_NOT_FOUND: notFound(),
   VENDOR_NOT_FOUND: {
-    message: 'Unsupported database type.',
     category: ErrorCategory.USER_FEEDBACK,
   },
-  MEMO_NOT_FOUND: notFound('Memo'),
-  MEMO_COMMENT_NOT_FOUND: notFound('Comment'),
+  MEMO_NOT_FOUND: notFound(),
+  MEMO_COMMENT_NOT_FOUND: notFound(),
 
-  WORKSPACE_NOT_FOUND: notFound('Workspace'),
+  WORKSPACE_NOT_FOUND: notFound(),
   WORKSPACE_ACCESS_DENIED: {
-    message: "You don't have access to this workspace.",
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_SETTINGS_INVALID: {
-    message: 'Failed to save settings. Please check the format and try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_SETTINGS_TOO_LARGE: SETTINGS_TOO_LARGE,
   WORKSPACE_ALREADY_DELETED: {
-    message: 'This workspace has been deleted.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_ADMIN_REQUIRED: {
-    message: 'Only admins can perform this action.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_MEMBER_ALREADY_EXISTS: {
-    message: 'This user is already a member of this workspace.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_MEMBER_NOT_FOUND: {
-    message: 'Member not found in this workspace.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_MEMBER_LIMIT_EXCEEDED: {
-    message: 'Workspace has reached the member limit (max 30).',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_LAST_ADMIN_CANNOT_LEAVE: {
-    message:
-      'You are the last admin. Please assign another admin before leaving.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   WORKSPACE_LAST_ADMIN_CANNOT_CHANGE_ROLE: {
-    message:
-      "Cannot change the last admin's role. Please assign another admin first.",
     category: ErrorCategory.USER_FEEDBACK,
   },
 
-  PROJECT_NOT_FOUND: notFound('Project'),
+  PROJECT_NOT_FOUND: notFound(),
   PROJECT_ACCESS_DENIED: {
-    message: "You don't have access to this project.",
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_OWNER_ONLY: {
-    message: 'Only the project owner can perform this action.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_ADMIN_REQUIRED: {
-    message: 'Only project admins can perform this action.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_WORKSPACE_MISMATCH: {
-    message: 'This project is not part of the current workspace.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_SETTINGS_TOO_LARGE: SETTINGS_TOO_LARGE,
   PROJECT_ALREADY_DELETED: {
-    message: 'This project has been deleted.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_CANNOT_ASSIGN_HIGHER_ROLE: {
-    message: 'You cannot assign a role higher than your own.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_CANNOT_MODIFY_HIGHER_ROLE_MEMBER: {
-    message: 'You cannot modify members with higher roles than yours.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 
   PROJECT_CANNOT_CHANGE_OWN_ROLE: {
-    message: 'You cannot change your own role.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_LAST_OWNER_CANNOT_BE_REMOVED: {
-    message: 'Cannot remove the last owner. Please assign another owner first.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_WORKSPACE_MEMBERSHIP_REQUIRED: {
-    message: 'You must be a workspace member to access this project.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_MEMBER_LIMIT_EXCEEDED: {
-    message: 'Project has reached the member limit (max 30).',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_MEMBER_NOT_FOUND: {
-    message: 'Member not found in this project.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   PROJECT_MEMBER_ALREADY_EXISTS: {
-    message: 'This user is already a member of this project.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 
-  SHARE_LINK_NOT_FOUND: notFound('Share link'),
+  SHARE_LINK_NOT_FOUND: notFound(),
   SHARE_LINK_EXPIRED: {
-    message: 'This share link has expired. Please request a new one.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   SHARE_LINK_REVOKED: {
-    message: 'This share link has been deactivated.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   SHARE_LINK_INVALID: {
-    message: 'Invalid share link. Please check and try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
   SHARE_LINK_INVALID_PROJECT_ID: {
-    message: 'Invalid project ID.',
     category: ErrorCategory.SILENT,
   },
   SHARE_LINK_INVALID_TOKEN_HASH: {
-    message: 'Invalid token hash.',
     category: ErrorCategory.SILENT,
   },
   SHARE_LINK_INVALID_ROLE: {
-    message: 'Invalid role.',
     category: ErrorCategory.SILENT,
   },
   SHARE_LINK_INVALID_EXPIRATION: {
-    message: 'Expiration date must be in the future.',
     category: ErrorCategory.USER_FEEDBACK,
   },
 };
 
-export function getErrorInfo(code: string, fallbackMessage: string): ErrorInfo {
+export function getErrorInfo(code: string): ErrorInfo {
   return (
     ErrorMessages[code] ?? {
-      message: fallbackMessage,
       category: ErrorCategory.SILENT,
     }
   );

--- a/apps/bff/src/common/constants/http-status-maps.ts
+++ b/apps/bff/src/common/constants/http-status-maps.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import { ErrorCode, ErrorCodeType } from '../types/api-response.types.js';
 
-export const STATUS_CODE_MAP: Record<number, ErrorCodeType> = {
+const STATUS_CODE_MAP: Record<number, ErrorCodeType> = {
   [HttpStatus.BAD_REQUEST]: ErrorCode.BAD_REQUEST,
   [HttpStatus.UNAUTHORIZED]: ErrorCode.UNAUTHORIZED,
   [HttpStatus.FORBIDDEN]: ErrorCode.FORBIDDEN,
@@ -12,28 +12,6 @@ export const STATUS_CODE_MAP: Record<number, ErrorCodeType> = {
   [HttpStatus.GATEWAY_TIMEOUT]: ErrorCode.GATEWAY_TIMEOUT,
 };
 
-export const STATUS_MESSAGE_MAP: Record<number, string> = {
-  [HttpStatus.BAD_REQUEST]: 'Please check your input and try again.',
-  [HttpStatus.UNAUTHORIZED]: 'Please sign in to continue.',
-  [HttpStatus.FORBIDDEN]: "You don't have permission to perform this action.",
-  [HttpStatus.NOT_FOUND]:
-    "The requested item doesn't exist or may have been moved.",
-  [HttpStatus.CONFLICT]:
-    'This action conflicts with existing data. Please refresh and try again.',
-  [HttpStatus.INTERNAL_SERVER_ERROR]:
-    'Something went wrong. Please try again later.',
-  [HttpStatus.SERVICE_UNAVAILABLE]:
-    'Service is temporarily unavailable. Please try again later.',
-  [HttpStatus.GATEWAY_TIMEOUT]: 'Request timed out. Please try again.',
-};
-
 export function getErrorCodeFromStatus(status: number): ErrorCodeType {
   return STATUS_CODE_MAP[status] ?? ErrorCode.INTERNAL_SERVER_ERROR;
-}
-
-export function getMessageFromStatus(status: number): string {
-  return (
-    STATUS_MESSAGE_MAP[status] ??
-    'Something went wrong. Please try again later.'
-  );
 }

--- a/apps/bff/src/common/filters/http-exception.filter.ts
+++ b/apps/bff/src/common/filters/http-exception.filter.ts
@@ -184,7 +184,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
     }
 
     const problem = data as Record<string, unknown>;
-    return 'reason' in problem || ('title' in problem && 'status' in problem);
+    return (
+      'reason' in problem ||
+      'type' in problem ||
+      ('title' in problem && 'status' in problem)
+    );
   }
 
   private extractProblemDetails(

--- a/apps/bff/src/common/filters/http-exception.filter.ts
+++ b/apps/bff/src/common/filters/http-exception.filter.ts
@@ -17,10 +17,7 @@ import {
   ErrorCategoryType,
 } from '../types/api-response.types.js';
 import { getErrorInfo } from '../constants/error-messages.js';
-import {
-  getErrorCodeFromStatus,
-  getMessageFromStatus,
-} from '../constants/http-status-maps.js';
+import { getErrorCodeFromStatus } from '../constants/http-status-maps.js';
 
 type BackendProblemDetails = {
   type?: string;
@@ -81,51 +78,20 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (this.isProblemDetailsResponse(rawData)) {
       const reason =
         typeof rawData.reason === 'string' ? rawData.reason : undefined;
-      const detail =
-        typeof rawData.detail === 'string' ? rawData.detail : undefined;
-      const title =
-        typeof rawData.title === 'string' ? rawData.title : undefined;
       const errorCode = reason ?? getErrorCodeFromStatus(status);
-      const fallbackMessage = detail ?? title ?? getMessageFromStatus(status);
-      const errorInfo = getErrorInfo(errorCode, fallbackMessage);
+      const errorInfo = getErrorInfo(errorCode);
 
       return {
         status,
         errorResponse: this.createErrorResponse(
           errorCode,
-          errorInfo.message,
           errorInfo.category,
           this.extractProblemDetails(rawData),
         ),
       };
     }
 
-    if (this.isValidBackendResponse(rawData)) {
-      const { code, message, details } = rawData.error;
-      const errorCode = code ?? getErrorCodeFromStatus(status);
-      const errorInfo = getErrorInfo(
-        errorCode,
-        message ?? getMessageFromStatus(status),
-      );
-
-      const mergedDetails = this.mergeDetails(details, message);
-
-      return {
-        status,
-        errorResponse: this.createErrorResponse(
-          errorCode,
-          errorInfo.message,
-          errorInfo.category,
-          mergedDetails,
-        ),
-      };
-    }
-
-    return this.buildErrorResult(
-      status,
-      getErrorCodeFromStatus(status),
-      getMessageFromStatus(status),
-    );
+    return this.buildErrorResult(status, getErrorCodeFromStatus(status));
   }
 
   private handleNetworkError(error: AxiosError, context: string) {
@@ -134,7 +100,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return this.buildErrorResult(
         HttpStatus.SERVICE_UNAVAILABLE,
         ErrorCode.BACKEND_UNREACHABLE,
-        'Service is temporarily unavailable. Please try again later.',
         ErrorCategory.USER_FEEDBACK,
       );
     }
@@ -144,7 +109,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return this.buildErrorResult(
         HttpStatus.GATEWAY_TIMEOUT,
         ErrorCode.BACKEND_TIMEOUT,
-        'Request timed out. Please try again.',
         ErrorCategory.USER_FEEDBACK,
       );
     }
@@ -153,7 +117,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
     return this.buildErrorResult(
       HttpStatus.INTERNAL_SERVER_ERROR,
       ErrorCode.INTERNAL_SERVER_ERROR,
-      'Something went wrong. Please try again later.',
       ErrorCategory.USER_FEEDBACK,
     );
   }
@@ -165,18 +128,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
       `${context} - HttpException: ${status} - ${exception.message}`,
     );
 
-    const { message, details } = this.extractValidationInfo(
-      exception.message,
-      exception.getResponse(),
-    );
-
     return {
       status,
       errorResponse: this.createErrorResponse(
         getErrorCodeFromStatus(status),
-        message,
         ErrorCategory.USER_FEEDBACK,
-        details,
       ),
     };
   }
@@ -193,9 +149,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
     return this.buildErrorResult(
       HttpStatus.INTERNAL_SERVER_ERROR,
       ErrorCode.INTERNAL_SERVER_ERROR,
-      this.isProduction
-        ? 'Something went wrong. Please try again later.'
-        : errorMessage,
       ErrorCategory.USER_FEEDBACK,
     );
   }
@@ -203,42 +156,24 @@ export class HttpExceptionFilter implements ExceptionFilter {
   private buildErrorResult(
     status: number,
     code: string,
-    message: string,
     category: ErrorCategoryType = ErrorCategory.SILENT,
   ) {
     return {
       status,
-      errorResponse: this.createErrorResponse(code, message, category),
+      errorResponse: this.createErrorResponse(code, category),
     };
   }
 
   private createErrorResponse(
     code: string,
-    message: string,
     category: ErrorCategoryType,
     details?: Record<string, unknown>,
   ) {
-    const error: ApiError = { code, message, category };
+    const error: ApiError = { code, category };
     if (!this.isProduction && details) {
       error.details = details;
     }
     return error;
-  }
-
-  private isValidBackendResponse(data: unknown): data is {
-    error: {
-      code?: string;
-      message?: string;
-      details?: Record<string, unknown>;
-    };
-  } {
-    return (
-      typeof data === 'object' &&
-      data !== null &&
-      'error' in data &&
-      typeof (data as { error: unknown }).error === 'object' &&
-      (data as { error: unknown }).error !== null
-    );
   }
 
   private isProblemDetailsResponse(
@@ -249,48 +184,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     }
 
     const problem = data as Record<string, unknown>;
-    return (
-      'type' in problem ||
-      'title' in problem ||
-      'status' in problem ||
-      'detail' in problem ||
-      'instance' in problem
-    );
-  }
-
-  private extractValidationInfo(defaultMessage: string, response: unknown) {
-    if (
-      typeof response !== 'object' ||
-      response === null ||
-      !('message' in response)
-    ) {
-      return { message: defaultMessage };
-    }
-
-    const responseMessage = (response as { message: unknown }).message;
-
-    if (Array.isArray(responseMessage)) {
-      return {
-        message: responseMessage.join(', '),
-        details: { validationErrors: responseMessage },
-      };
-    }
-
-    return { message: String(responseMessage) };
-  }
-
-  private mergeDetails(
-    details?: Record<string, unknown>,
-    originalMessage?: string,
-  ): Record<string, unknown> | undefined {
-    if (!originalMessage && !details) {
-      return undefined;
-    }
-
-    return {
-      ...details,
-      ...(originalMessage && { originalMessage }),
-    };
+    return 'reason' in problem || ('title' in problem && 'status' in problem);
   }
 
   private extractProblemDetails(

--- a/apps/bff/src/common/filters/http-exception.filter.ts
+++ b/apps/bff/src/common/filters/http-exception.filter.ts
@@ -222,7 +222,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (!this.isProduction && details) {
       error.details = details;
     }
-    return { success: false, result: null, error };
+    return error;
   }
 
   private isValidBackendResponse(data: unknown): data is {

--- a/apps/bff/src/common/types/api-response.types.ts
+++ b/apps/bff/src/common/types/api-response.types.ts
@@ -14,12 +14,6 @@ export type ApiError = {
   details?: Record<string, unknown>;
 };
 
-export type ApiResponse<T = unknown> = {
-  success: boolean;
-  result: T | null;
-  error: ApiError | null;
-};
-
 export const ErrorCode = {
   BAD_REQUEST: 'BAD_REQUEST',
   UNAUTHORIZED: 'UNAUTHORIZED',

--- a/apps/bff/src/common/types/api-response.types.ts
+++ b/apps/bff/src/common/types/api-response.types.ts
@@ -9,7 +9,6 @@ export type ErrorCategoryType =
 
 export type ApiError = {
   code: string;
-  message: string;
   category: ErrorCategoryType;
   details?: Record<string, unknown>;
 };

--- a/apps/bff/src/erd/column.service.ts
+++ b/apps/bff/src/erd/column.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   ChangeColumnMetaRequest,
   ChangeColumnNameRequest,
@@ -18,9 +17,9 @@ export class ColumnService {
   async createColumn(
     data: CreateColumnRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<ColumnResponse>>> {
+  ): Promise<MutationResponse<ColumnResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<ColumnResponse>>
+      MutationResponse<ColumnResponse>
     >('/api/v1.0/columns', data, this.backendClient.getAuthConfig(authHeader));
     return response.data;
   }
@@ -28,10 +27,8 @@ export class ColumnService {
   async getColumn(
     columnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ColumnResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<ColumnResponse>
-    >(
+  ): Promise<ColumnResponse> {
+    const response = await this.backendClient.client.get<ColumnResponse>(
       `/api/v1.0/columns/${columnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -41,10 +38,8 @@ export class ColumnService {
   async getColumnsByTableId(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ColumnResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<ColumnResponse[]>
-    >(
+  ): Promise<ColumnResponse[]> {
+    const response = await this.backendClient.client.get<ColumnResponse[]>(
       `/api/v1.0/tables/${tableId}/columns`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -55,10 +50,8 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -70,10 +63,8 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnTypeRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/type`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -85,10 +76,8 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnMetaRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/meta`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -100,10 +89,8 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnPositionRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/position`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -114,10 +101,8 @@ export class ColumnService {
   async deleteColumn(
     columnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/columns/${columnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );

--- a/apps/bff/src/erd/constraint.service.ts
+++ b/apps/bff/src/erd/constraint.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   AddConstraintColumnRequest,
   AddConstraintColumnResponse,
@@ -21,9 +20,9 @@ export class ConstraintService {
   async createConstraint(
     data: CreateConstraintRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<ConstraintResponse>>> {
+  ): Promise<MutationResponse<ConstraintResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<ConstraintResponse>>
+      MutationResponse<ConstraintResponse>
     >(
       '/api/v1.0/constraints',
       data,
@@ -35,10 +34,8 @@ export class ConstraintService {
   async getConstraint(
     constraintId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ConstraintResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<ConstraintResponse>
-    >(
+  ): Promise<ConstraintResponse> {
+    const response = await this.backendClient.client.get<ConstraintResponse>(
       `/api/v1.0/constraints/${constraintId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -48,10 +45,8 @@ export class ConstraintService {
   async getConstraintsByTableId(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ConstraintResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<ConstraintResponse[]>
-    >(
+  ): Promise<ConstraintResponse[]> {
+    const response = await this.backendClient.client.get<ConstraintResponse[]>(
       `/api/v1.0/tables/${tableId}/constraints`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -62,10 +57,8 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -77,10 +70,8 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintCheckExprRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/check-expr`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -92,10 +83,8 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintDefaultExprRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/default-expr`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -106,10 +95,8 @@ export class ConstraintService {
   async deleteConstraint(
     constraintId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -119,9 +106,9 @@ export class ConstraintService {
   async getConstraintColumns(
     constraintId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ConstraintColumnResponse[]>> {
+  ): Promise<ConstraintColumnResponse[]> {
     const response = await this.backendClient.client.get<
-      ApiResponse<ConstraintColumnResponse[]>
+      ConstraintColumnResponse[]
     >(
       `/api/v1.0/constraints/${constraintId}/columns`,
       this.backendClient.getAuthConfig(authHeader),
@@ -133,9 +120,9 @@ export class ConstraintService {
     constraintId: string,
     data: AddConstraintColumnRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<AddConstraintColumnResponse>>> {
+  ): Promise<MutationResponse<AddConstraintColumnResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<AddConstraintColumnResponse>>
+      MutationResponse<AddConstraintColumnResponse>
     >(
       `/api/v1.0/constraints/${constraintId}/columns`,
       data,
@@ -147,10 +134,8 @@ export class ConstraintService {
   async removeConstraintColumn(
     constraintColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/constraint-columns/${constraintColumnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -160,13 +145,12 @@ export class ConstraintService {
   async getConstraintColumn(
     constraintColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<ConstraintColumnResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<ConstraintColumnResponse>
-    >(
-      `/api/v1.0/constraint-columns/${constraintColumnId}`,
-      this.backendClient.getAuthConfig(authHeader),
-    );
+  ): Promise<ConstraintColumnResponse> {
+    const response =
+      await this.backendClient.client.get<ConstraintColumnResponse>(
+        `/api/v1.0/constraint-columns/${constraintColumnId}`,
+        this.backendClient.getAuthConfig(authHeader),
+      );
     return response.data;
   }
 
@@ -174,10 +158,8 @@ export class ConstraintService {
     constraintColumnId: string,
     data: ChangeConstraintColumnPositionRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraint-columns/${constraintColumnId}/position`,
       data,
       this.backendClient.getAuthConfig(authHeader),

--- a/apps/bff/src/erd/index.service.ts
+++ b/apps/bff/src/erd/index.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   AddIndexColumnRequest,
   AddIndexColumnResponse,
@@ -21,20 +20,15 @@ export class IndexService {
   async createIndex(
     data: CreateIndexRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<IndexResponse>>> {
+  ): Promise<MutationResponse<IndexResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<IndexResponse>>
+      MutationResponse<IndexResponse>
     >('/api/v1.0/indexes', data, this.backendClient.getAuthConfig(authHeader));
     return response.data;
   }
 
-  async getIndex(
-    indexId: string,
-    authHeader: string,
-  ): Promise<ApiResponse<IndexResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<IndexResponse>
-    >(
+  async getIndex(indexId: string, authHeader: string): Promise<IndexResponse> {
+    const response = await this.backendClient.client.get<IndexResponse>(
       `/api/v1.0/indexes/${indexId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -44,10 +38,8 @@ export class IndexService {
   async getIndexesByTableId(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<IndexResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<IndexResponse[]>
-    >(
+  ): Promise<IndexResponse[]> {
+    const response = await this.backendClient.client.get<IndexResponse[]>(
       `/api/v1.0/tables/${tableId}/indexes`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -58,10 +50,8 @@ export class IndexService {
     indexId: string,
     data: ChangeIndexNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/indexes/${indexId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -73,10 +63,8 @@ export class IndexService {
     indexId: string,
     data: ChangeIndexTypeRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/indexes/${indexId}/type`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -87,10 +75,8 @@ export class IndexService {
   async deleteIndex(
     indexId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/indexes/${indexId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -100,10 +86,8 @@ export class IndexService {
   async getIndexColumns(
     indexId: string,
     authHeader: string,
-  ): Promise<ApiResponse<IndexColumnResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<IndexColumnResponse[]>
-    >(
+  ): Promise<IndexColumnResponse[]> {
+    const response = await this.backendClient.client.get<IndexColumnResponse[]>(
       `/api/v1.0/indexes/${indexId}/columns`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -114,9 +98,9 @@ export class IndexService {
     indexId: string,
     data: AddIndexColumnRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<AddIndexColumnResponse>>> {
+  ): Promise<MutationResponse<AddIndexColumnResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<AddIndexColumnResponse>>
+      MutationResponse<AddIndexColumnResponse>
     >(
       `/api/v1.0/indexes/${indexId}/columns`,
       data,
@@ -128,10 +112,8 @@ export class IndexService {
   async removeIndexColumn(
     indexColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -141,10 +123,8 @@ export class IndexService {
   async getIndexColumn(
     indexColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<IndexColumnResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<IndexColumnResponse>
-    >(
+  ): Promise<IndexColumnResponse> {
+    const response = await this.backendClient.client.get<IndexColumnResponse>(
       `/api/v1.0/index-columns/${indexColumnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -155,10 +135,8 @@ export class IndexService {
     indexColumnId: string,
     data: ChangeIndexColumnPositionRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}/position`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -170,10 +148,8 @@ export class IndexService {
     indexColumnId: string,
     data: ChangeIndexColumnSortDirectionRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}/sort-direction`,
       data,
       this.backendClient.getAuthConfig(authHeader),

--- a/apps/bff/src/erd/relationship.service.ts
+++ b/apps/bff/src/erd/relationship.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   AddRelationshipColumnRequest,
   AddRelationshipColumnResponse,
@@ -22,9 +21,9 @@ export class RelationshipService {
   async createRelationship(
     data: CreateRelationshipRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<RelationshipResponse>>> {
+  ): Promise<MutationResponse<RelationshipResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<RelationshipResponse>>
+      MutationResponse<RelationshipResponse>
     >(
       '/api/v1.0/relationships',
       data,
@@ -36,10 +35,8 @@ export class RelationshipService {
   async getRelationship(
     relationshipId: string,
     authHeader: string,
-  ): Promise<ApiResponse<RelationshipResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<RelationshipResponse>
-    >(
+  ): Promise<RelationshipResponse> {
+    const response = await this.backendClient.client.get<RelationshipResponse>(
       `/api/v1.0/relationships/${relationshipId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -49,9 +46,9 @@ export class RelationshipService {
   async getRelationshipsByTableId(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<RelationshipResponse[]>> {
+  ): Promise<RelationshipResponse[]> {
     const response = await this.backendClient.client.get<
-      ApiResponse<RelationshipResponse[]>
+      RelationshipResponse[]
     >(
       `/api/v1.0/tables/${tableId}/relationships`,
       this.backendClient.getAuthConfig(authHeader),
@@ -63,10 +60,8 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -78,10 +73,8 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipKindRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/kind`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -93,10 +86,8 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipCardinalityRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/cardinality`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -108,10 +99,8 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipExtraRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/extra`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -122,10 +111,8 @@ export class RelationshipService {
   async deleteRelationship(
     relationshipId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -135,9 +122,9 @@ export class RelationshipService {
   async getRelationshipColumns(
     relationshipId: string,
     authHeader: string,
-  ): Promise<ApiResponse<RelationshipColumnResponse[]>> {
+  ): Promise<RelationshipColumnResponse[]> {
     const response = await this.backendClient.client.get<
-      ApiResponse<RelationshipColumnResponse[]>
+      RelationshipColumnResponse[]
     >(
       `/api/v1.0/relationships/${relationshipId}/columns`,
       this.backendClient.getAuthConfig(authHeader),
@@ -149,9 +136,9 @@ export class RelationshipService {
     relationshipId: string,
     data: AddRelationshipColumnRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<AddRelationshipColumnResponse>>> {
+  ): Promise<MutationResponse<AddRelationshipColumnResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<AddRelationshipColumnResponse>>
+      MutationResponse<AddRelationshipColumnResponse>
     >(
       `/api/v1.0/relationships/${relationshipId}/columns`,
       data,
@@ -163,10 +150,8 @@ export class RelationshipService {
   async removeRelationshipColumn(
     relationshipColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/relationship-columns/${relationshipColumnId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -176,13 +161,12 @@ export class RelationshipService {
   async getRelationshipColumn(
     relationshipColumnId: string,
     authHeader: string,
-  ): Promise<ApiResponse<RelationshipColumnResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<RelationshipColumnResponse>
-    >(
-      `/api/v1.0/relationship-columns/${relationshipColumnId}`,
-      this.backendClient.getAuthConfig(authHeader),
-    );
+  ): Promise<RelationshipColumnResponse> {
+    const response =
+      await this.backendClient.client.get<RelationshipColumnResponse>(
+        `/api/v1.0/relationship-columns/${relationshipColumnId}`,
+        this.backendClient.getAuthConfig(authHeader),
+      );
     return response.data;
   }
 
@@ -190,10 +174,8 @@ export class RelationshipService {
     relationshipColumnId: string,
     data: ChangeRelationshipColumnPositionRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationship-columns/${relationshipColumnId}/position`,
       data,
       this.backendClient.getAuthConfig(authHeader),

--- a/apps/bff/src/erd/schema.service.ts
+++ b/apps/bff/src/erd/schema.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   ChangeSchemaNameRequest,
   CreateSchemaRequest,
@@ -15,9 +14,9 @@ export class SchemaService {
   async createSchema(
     data: CreateSchemaRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<SchemaResponse>>> {
+  ): Promise<MutationResponse<SchemaResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<SchemaResponse>>
+      MutationResponse<SchemaResponse>
     >('/api/v1.0/schemas', data, this.backendClient.getAuthConfig(authHeader));
     return response.data;
   }
@@ -25,10 +24,8 @@ export class SchemaService {
   async getSchemasByProjectId(
     projectId: string,
     authHeader: string,
-  ): Promise<ApiResponse<SchemaResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<SchemaResponse[]>
-    >(
+  ): Promise<SchemaResponse[]> {
+    const response = await this.backendClient.client.get<SchemaResponse[]>(
       `/api/v1.0/projects/${projectId}/schemas`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -38,10 +35,8 @@ export class SchemaService {
   async getSchema(
     schemaId: string,
     authHeader: string,
-  ): Promise<ApiResponse<SchemaResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<SchemaResponse>
-    >(
+  ): Promise<SchemaResponse> {
+    const response = await this.backendClient.client.get<SchemaResponse>(
       `/api/v1.0/schemas/${schemaId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -52,10 +47,8 @@ export class SchemaService {
     schemaId: string,
     data: ChangeSchemaNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/schemas/${schemaId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -66,10 +59,8 @@ export class SchemaService {
   async deleteSchema(
     schemaId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/schemas/${schemaId}`,
       this.backendClient.getAuthConfig(authHeader),
     );

--- a/apps/bff/src/erd/table.service.ts
+++ b/apps/bff/src/erd/table.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import type {
   ChangeTableExtraRequest,
   ChangeTableMetaRequest,
@@ -18,20 +17,15 @@ export class TableService {
   async createTable(
     data: CreateTableRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse<TableResponse>>> {
+  ): Promise<MutationResponse<TableResponse>> {
     const response = await this.backendClient.client.post<
-      ApiResponse<MutationResponse<TableResponse>>
+      MutationResponse<TableResponse>
     >('/api/v1.0/tables', data, this.backendClient.getAuthConfig(authHeader));
     return response.data;
   }
 
-  async getTable(
-    tableId: string,
-    authHeader: string,
-  ): Promise<ApiResponse<TableResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<TableResponse>
-    >(
+  async getTable(tableId: string, authHeader: string): Promise<TableResponse> {
+    const response = await this.backendClient.client.get<TableResponse>(
       `/api/v1.0/tables/${tableId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -41,10 +35,8 @@ export class TableService {
   async getTablesBySchemaId(
     schemaId: string,
     authHeader: string,
-  ): Promise<ApiResponse<TableResponse[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<TableResponse[]>
-    >(
+  ): Promise<TableResponse[]> {
+    const response = await this.backendClient.client.get<TableResponse[]>(
       `/api/v1.0/schemas/${schemaId}/tables`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -54,10 +46,8 @@ export class TableService {
   async getTableSnapshot(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<TableSnapshotResponse>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<TableSnapshotResponse>
-    >(
+  ): Promise<TableSnapshotResponse> {
+    const response = await this.backendClient.client.get<TableSnapshotResponse>(
       `/api/v1.0/tables/${tableId}/snapshot`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -67,9 +57,9 @@ export class TableService {
   async getTableSnapshots(
     tableIds: string[],
     authHeader: string,
-  ): Promise<ApiResponse<Record<string, TableSnapshotResponse>>> {
+  ): Promise<Record<string, TableSnapshotResponse>> {
     const response = await this.backendClient.client.get<
-      ApiResponse<Record<string, TableSnapshotResponse>>
+      Record<string, TableSnapshotResponse>
     >('/api/v1.0/tables/snapshots', {
       ...this.backendClient.getAuthConfig(authHeader),
       params: { tableIds },
@@ -81,10 +71,8 @@ export class TableService {
     tableId: string,
     data: ChangeTableNameRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/name`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -96,10 +84,8 @@ export class TableService {
     tableId: string,
     data: ChangeTableMetaRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/meta`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -111,10 +97,8 @@ export class TableService {
     tableId: string,
     data: ChangeTableExtraRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.patch<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/extra`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -125,10 +109,8 @@ export class TableService {
   async deleteTable(
     tableId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MutationResponse>> {
-    const response = await this.backendClient.client.delete<
-      ApiResponse<MutationResponse>
-    >(
+  ): Promise<MutationResponse> {
+    const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/tables/${tableId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -138,22 +120,12 @@ export class TableService {
   async getSchemaWithSnapshots(
     schemaId: string,
     authHeader: string,
-  ): Promise<ApiResponse<Record<string, TableSnapshotResponse>>> {
-    const tablesRes = await this.getTablesBySchemaId(schemaId, authHeader);
-
-    if (!tablesRes.success || !tablesRes.result) {
-      return {
-        success: tablesRes.success,
-        result: null,
-        error: tablesRes.error,
-      };
-    }
-
-    const tableIds = tablesRes.result.map((t) => t.id);
+  ): Promise<Record<string, TableSnapshotResponse>> {
+    const tables = await this.getTablesBySchemaId(schemaId, authHeader);
+    const tableIds = tables.map((t) => t.id);
     if (tableIds.length === 0) {
-      return { success: true, result: {}, error: null };
+      return {};
     }
-
     return this.getTableSnapshots(tableIds, authHeader);
   }
 }

--- a/apps/bff/src/memo/memo.service.ts
+++ b/apps/bff/src/memo/memo.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { BackendClientService } from '../common/backend-client/backend-client.service';
-import { ApiResponse } from '../common/types/api-response.types';
 import {
   CreateMemoCommentRequest,
   CreateMemoRequest,
@@ -14,11 +13,8 @@ import {
 export class MemoService {
   constructor(private readonly backendClient: BackendClientService) {}
 
-  async createMemo(
-    data: CreateMemoRequest,
-    authHeader: string,
-  ): Promise<ApiResponse<Memo>> {
-    const response = await this.backendClient.client.post<ApiResponse<Memo>>(
+  async createMemo(data: CreateMemoRequest, authHeader: string): Promise<Memo> {
+    const response = await this.backendClient.client.post<Memo>(
       '/api/v1.0/memos',
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -26,22 +22,16 @@ export class MemoService {
     return response.data;
   }
 
-  async getMemo(
-    memoId: string,
-    authHeader: string,
-  ): Promise<ApiResponse<Memo>> {
-    const response = await this.backendClient.client.get<ApiResponse<Memo>>(
+  async getMemo(memoId: string, authHeader: string): Promise<Memo> {
+    const response = await this.backendClient.client.get<Memo>(
       `/api/v1.0/memos/${memoId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
     return response.data;
   }
 
-  async getSchemaMemos(
-    schemaId: string,
-    authHeader: string,
-  ): Promise<ApiResponse<Memo[]>> {
-    const response = await this.backendClient.client.get<ApiResponse<Memo[]>>(
+  async getSchemaMemos(schemaId: string, authHeader: string): Promise<Memo[]> {
+    const response = await this.backendClient.client.get<Memo[]>(
       `/api/v1.0/schemas/${schemaId}/memos`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -51,23 +41,17 @@ export class MemoService {
   async getSchemaMemosWithComments(
     schemaId: string,
     authHeader: string,
-  ): Promise<ApiResponse<Memo[]>> {
-    const memosResponse = await this.backendClient.client.get<
-      ApiResponse<Memo[]>
-    >(
+  ): Promise<Memo[]> {
+    const memosResponse = await this.backendClient.client.get<Memo[]>(
       `/api/v1.0/schemas/${schemaId}/memos`,
       this.backendClient.getAuthConfig(authHeader),
     );
 
-    if (!memosResponse.data.success || !memosResponse.data.result) {
-      return memosResponse.data;
-    }
-
-    const memos = memosResponse.data.result;
+    const memos = memosResponse.data;
 
     const commentsResults = await Promise.allSettled(
       memos.map((memo) =>
-        this.backendClient.client.get<ApiResponse<MemoComment[]>>(
+        this.backendClient.client.get<MemoComment[]>(
           `/api/v1.0/memos/${memo.id}/comments`,
           this.backendClient.getAuthConfig(authHeader),
         ),
@@ -76,28 +60,19 @@ export class MemoService {
 
     const memosWithComments = memos.map((memo, index) => {
       const result = commentsResults[index];
-      const comments =
-        result.status === 'fulfilled' &&
-        result.value.data.success &&
-        result.value.data.result
-          ? result.value.data.result
-          : [];
+      const comments = result.status === 'fulfilled' ? result.value.data : [];
       return { ...memo, comments };
     });
 
-    return {
-      success: true,
-      result: memosWithComments,
-      error: null,
-    };
+    return memosWithComments;
   }
 
   async updateMemo(
     memoId: string,
     data: UpdateMemoRequest,
     authHeader: string,
-  ): Promise<ApiResponse<Memo>> {
-    const response = await this.backendClient.client.put<ApiResponse<Memo>>(
+  ): Promise<Memo> {
+    const response = await this.backendClient.client.put<Memo>(
       `/api/v1.0/memos/${memoId}`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -105,11 +80,8 @@ export class MemoService {
     return response.data;
   }
 
-  async deleteMemo(
-    memoId: string,
-    authHeader: string,
-  ): Promise<ApiResponse<null>> {
-    const response = await this.backendClient.client.delete<ApiResponse<null>>(
+  async deleteMemo(memoId: string, authHeader: string): Promise<null> {
+    const response = await this.backendClient.client.delete<null>(
       `/api/v1.0/memos/${memoId}`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -120,10 +92,8 @@ export class MemoService {
     memoId: string,
     data: CreateMemoCommentRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MemoComment>> {
-    const response = await this.backendClient.client.post<
-      ApiResponse<MemoComment>
-    >(
+  ): Promise<MemoComment> {
+    const response = await this.backendClient.client.post<MemoComment>(
       `/api/v1.0/memos/${memoId}/comments`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -134,10 +104,8 @@ export class MemoService {
   async getMemoComments(
     memoId: string,
     authHeader: string,
-  ): Promise<ApiResponse<MemoComment[]>> {
-    const response = await this.backendClient.client.get<
-      ApiResponse<MemoComment[]>
-    >(
+  ): Promise<MemoComment[]> {
+    const response = await this.backendClient.client.get<MemoComment[]>(
       `/api/v1.0/memos/${memoId}/comments`,
       this.backendClient.getAuthConfig(authHeader),
     );
@@ -149,10 +117,8 @@ export class MemoService {
     commentId: string,
     data: UpdateMemoCommentRequest,
     authHeader: string,
-  ): Promise<ApiResponse<MemoComment>> {
-    const response = await this.backendClient.client.put<
-      ApiResponse<MemoComment>
-    >(
+  ): Promise<MemoComment> {
+    const response = await this.backendClient.client.put<MemoComment>(
       `/api/v1.0/memos/${memoId}/comments/${commentId}`,
       data,
       this.backendClient.getAuthConfig(authHeader),
@@ -164,8 +130,8 @@ export class MemoService {
     memoId: string,
     commentId: string,
     authHeader: string,
-  ): Promise<ApiResponse<null>> {
-    const response = await this.backendClient.client.delete<ApiResponse<null>>(
+  ): Promise<null> {
+    const response = await this.backendClient.client.delete<null>(
       `/api/v1.0/memos/${memoId}/comments/${commentId}`,
       this.backendClient.getAuthConfig(authHeader),
     );

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -32,6 +32,7 @@ export default tseslint.config([
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      'no-empty': ['error', { allowEmptyCatch: true }],
     },
   },
 ])

--- a/apps/frontend/src/components/Header/DashboardHeader.tsx
+++ b/apps/frontend/src/components/Header/DashboardHeader.tsx
@@ -6,11 +6,11 @@ import { logout } from '@/features/auth/api';
 
 export const DashboardHeader = () => {
   const handleLogout = async () => {
-    const response = await logout();
-    if (response.success) {
+    try {
+      await logout();
       authStore.clearAuth();
-    } else {
-      console.error(response.error?.message || 'Failed to sign out');
+    } catch (error) {
+      console.error('Failed to sign out', error);
     }
   };
 

--- a/apps/frontend/src/features/auth/api/api.ts
+++ b/apps/frontend/src/features/auth/api/api.ts
@@ -1,5 +1,6 @@
 import type { AxiosResponse } from 'axios';
 import { apiClient, publicClient } from '@/lib/api/client';
+import { handleApiError } from '@/lib/api/error-handler';
 import type { SignInRequest, SignUpRequest, AuthResponse } from './types';
 
 import { authStore } from '@/store/auth.store';
@@ -18,19 +19,33 @@ const handleTokenResponse = (response: AxiosResponse): string => {
 };
 
 export const signUp = async (data: SignUpRequest): Promise<AuthResponse> => {
-  const response = await publicClient.post<AuthResponse>('/users/signup', data);
+  try {
+    const response = await publicClient.post<AuthResponse>(
+      '/users/signup',
+      data,
+    );
 
-  handleTokenResponse(response);
+    handleTokenResponse(response);
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
 };
 
 export const signIn = async (data: SignInRequest): Promise<AuthResponse> => {
-  const response = await publicClient.post<AuthResponse>('/users/login', data);
+  try {
+    const response = await publicClient.post<AuthResponse>(
+      '/users/login',
+      data,
+    );
 
-  handleTokenResponse(response);
+    handleTokenResponse(response);
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
 };
 
 export const refreshToken = async (): Promise<string> => {

--- a/apps/frontend/src/features/auth/api/api.ts
+++ b/apps/frontend/src/features/auth/api/api.ts
@@ -1,15 +1,12 @@
 import type { AxiosResponse } from 'axios';
 import { apiClient, publicClient } from '@/lib/api/client';
-import type { ApiResponse } from '@/lib/api';
 import type { SignInRequest, SignUpRequest, AuthResponse } from './types';
 
 import { authStore } from '@/store/auth.store';
 
 let refreshPromise: Promise<string> | null = null;
 
-const handleTokenResponse = (
-  response: AxiosResponse<ApiResponse<unknown>>,
-): string => {
+const handleTokenResponse = (response: AxiosResponse): string => {
   const accessToken = response.headers['authorization'];
   if (accessToken && accessToken.startsWith('Bearer ')) {
     const token = accessToken.replace('Bearer ', '');
@@ -20,26 +17,16 @@ const handleTokenResponse = (
   }
 };
 
-export const signUp = async (
-  data: SignUpRequest,
-): Promise<ApiResponse<AuthResponse>> => {
-  const response = await publicClient.post<ApiResponse<AuthResponse>>(
-    '/users/signup',
-    data,
-  );
+export const signUp = async (data: SignUpRequest): Promise<AuthResponse> => {
+  const response = await publicClient.post<AuthResponse>('/users/signup', data);
 
   handleTokenResponse(response);
 
   return response.data;
 };
 
-export const signIn = async (
-  data: SignInRequest,
-): Promise<ApiResponse<AuthResponse>> => {
-  const response = await publicClient.post<ApiResponse<AuthResponse>>(
-    '/users/login',
-    data,
-  );
+export const signIn = async (data: SignInRequest): Promise<AuthResponse> => {
+  const response = await publicClient.post<AuthResponse>('/users/login', data);
 
   handleTokenResponse(response);
 
@@ -50,8 +37,7 @@ export const refreshToken = async (): Promise<string> => {
   if (!refreshPromise) {
     refreshPromise = (async () => {
       try {
-        const response =
-          await publicClient.post<ApiResponse<null>>('/users/refresh');
+        const response = await publicClient.post('/users/refresh');
         return handleTokenResponse(response);
       } catch (error) {
         authStore.clearAuth();
@@ -64,18 +50,12 @@ export const refreshToken = async (): Promise<string> => {
   return refreshPromise;
 };
 
-export const getMyInfo = async (): Promise<ApiResponse<AuthResponse>> => {
-  const response = await apiClient.get<ApiResponse<AuthResponse>>(`/users`);
-
-  if (!response.data.success) {
-    throw new Error('Failed to get my info');
-  }
+export const getMyInfo = async (): Promise<AuthResponse> => {
+  const response = await apiClient.get<AuthResponse>(`/users`);
 
   return response.data;
 };
 
-export const logout = async (): Promise<ApiResponse<null>> => {
-  const response = await apiClient.post<ApiResponse<null>>('/users/logout');
-
-  return response.data;
+export const logout = async (): Promise<void> => {
+  await apiClient.post('/users/logout');
 };

--- a/apps/frontend/src/features/auth/components/SignInForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignInForm.tsx
@@ -77,7 +77,6 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
       resetForm();
       navigate('/');
     } catch {
-      // 에러 토스트는 signIn 내부에서 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/components/SignInForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignInForm.tsx
@@ -52,7 +52,6 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
     validationRules,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string>('');
   const navigate = useNavigate();
 
   const handleGithubLogin = () => {
@@ -61,7 +60,6 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setSubmitError('');
     const hasErrors = Object.keys(errors).length > 0;
     if (hasErrors) {
       return;
@@ -70,24 +68,16 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
     setIsSubmitting(true);
 
     try {
-      const response = await signIn({
+      const user = await signIn({
         email: form.email,
         password: form.password,
       });
 
-      if (response.success) {
-        if (response.result) {
-          authStore.setUser(response.result);
-        }
-        resetForm();
-        navigate('/');
-      } else {
-        setSubmitError(response.error?.message || '로그인에 실패했습니다.');
-      }
-    } catch (error) {
-      setSubmitError(
-        error instanceof Error ? error.message : '로그인에 실패했습니다.',
-      );
+      authStore.setUser(user);
+      resetForm();
+      navigate('/');
+    } catch {
+      // publicClient interceptor
     } finally {
       setIsSubmitting(false);
     }
@@ -124,9 +114,6 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
         <Button type="submit" disabled={isSubmitting} round fullWidth>
           {isSubmitting ? 'Sign In...' : 'Sign In'}
         </Button>
-        {submitError && (
-          <p className="text-red-600 text-sm mt-2 mb-2">{submitError}</p>
-        )}
         {oauthError && (
           <p className="text-red-600 text-sm mt-2 mb-2">{oauthError}</p>
         )}

--- a/apps/frontend/src/features/auth/components/SignInForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignInForm.tsx
@@ -77,7 +77,7 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
       resetForm();
       navigate('/');
     } catch {
-      // 에러 토스트는 인터셉터가 처리
+      // 에러 토스트는 signIn 내부에서 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/components/SignInForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignInForm.tsx
@@ -77,7 +77,7 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
       resetForm();
       navigate('/');
     } catch {
-      // publicClient interceptor
+      // 에러 토스트는 인터셉터가 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -93,7 +93,6 @@ export const SignUpForm = () => {
       resetForm();
       navigate('/');
     } catch {
-      // 에러 토스트는 signUp 내부에서 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -93,7 +93,7 @@ export const SignUpForm = () => {
       resetForm();
       navigate('/');
     } catch {
-      // 에러 토스트는 인터셉터가 처리
+      // 에러 토스트는 signUp 내부에서 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -71,12 +71,10 @@ export const SignUpForm = () => {
     validationRules,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string>('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setSubmitError('');
 
     const hasErrors = Object.keys(errors).length > 0;
     if (hasErrors) {
@@ -86,22 +84,16 @@ export const SignUpForm = () => {
     setIsSubmitting(true);
 
     try {
-      const response = await signUp({
+      await signUp({
         email: form.email,
         name: form.name,
         password: form.password,
       });
 
-      if (response.success) {
-        resetForm();
-        navigate('/');
-      } else {
-        setSubmitError(response.error?.message || '회원가입에 실패했습니다.');
-      }
-    } catch (error) {
-      setSubmitError(
-        error instanceof Error ? error.message : '회원가입에 실패했습니다.',
-      );
+      resetForm();
+      navigate('/');
+    } catch {
+      // publicClient interceptor
     } finally {
       setIsSubmitting(false);
     }
@@ -127,9 +119,6 @@ export const SignUpForm = () => {
           onBlur={handleBlur}
         />
       ))}
-      {submitError && (
-        <p className="text-red-600 text-sm mt-2 mb-2">{submitError}</p>
-      )}
       <Button type="submit" disabled={isSubmitting} className="my-4" round>
         {isSubmitting ? 'Creating...' : 'Create Account'}
       </Button>

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -93,7 +93,7 @@ export const SignUpForm = () => {
       resetForm();
       navigate('/');
     } catch {
-      // publicClient interceptor
+      // 에러 토스트는 인터셉터가 처리
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/apps/frontend/src/features/auth/hooks/useAuthBootstrap.ts
@@ -9,12 +9,8 @@ export const useAuthBootstrap = () => {
         authStore.setAuthLoading(true);
         await refreshToken();
 
-        const res = await getMyInfo();
-        if (res.success && res.result) {
-          authStore.setUser(res.result);
-        } else {
-          authStore.clearAuth();
-        }
+        const user = await getMyInfo();
+        authStore.setUser(user);
       } catch {
         authStore.clearAuth();
       } finally {

--- a/apps/frontend/src/features/drawing/api/column.api.ts
+++ b/apps/frontend/src/features/drawing/api/column.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   ColumnResponse,
@@ -12,101 +12,76 @@ import type {
 export const createColumn = async (
   data: CreateColumnRequest,
 ): Promise<MutationResponse<ColumnResponse>> => {
-  const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<ColumnResponse>>
-  >('/columns', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  const { data: res } = await apiClient.post<MutationResponse<ColumnResponse>>(
+    '/columns',
+    data,
+  );
+  return res;
 };
 
 export const getColumn = async (columnId: string): Promise<ColumnResponse> => {
-  const { data } = await apiClient.get<ApiResponse<ColumnResponse>>(
-    `/columns/${columnId}`,
-  );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<ColumnResponse>(`/columns/${columnId}`);
+  return data;
 };
 
 export const getColumnsByTableId = async (
   tableId: string,
 ): Promise<ColumnResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<ColumnResponse[]>>(
+  const { data } = await apiClient.get<ColumnResponse[]>(
     `/tables/${tableId}/columns`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeColumnName = async (
   columnId: string,
   data: ChangeColumnNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeColumnType = async (
   columnId: string,
   data: ChangeColumnTypeRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/type`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeColumnMeta = async (
   columnId: string,
   data: ChangeColumnMetaRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/meta`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeColumnPosition = async (
   columnId: string,
   data: ChangeColumnPositionRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/position`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteColumn = async (
   columnId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/columns/${columnId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };

--- a/apps/frontend/src/features/drawing/api/constraint.api.ts
+++ b/apps/frontend/src/features/drawing/api/constraint.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   ConstraintResponse,
@@ -16,102 +16,78 @@ export const createConstraint = async (
   data: CreateConstraintRequest,
 ): Promise<MutationResponse<ConstraintResponse>> => {
   const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<ConstraintResponse>>
+    MutationResponse<ConstraintResponse>
   >('/constraints', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getConstraint = async (
   constraintId: string,
 ): Promise<ConstraintResponse> => {
-  const { data } = await apiClient.get<ApiResponse<ConstraintResponse>>(
+  const { data } = await apiClient.get<ConstraintResponse>(
     `/constraints/${constraintId}`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const getConstraintsByTableId = async (
   tableId: string,
 ): Promise<ConstraintResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<ConstraintResponse[]>>(
+  const { data } = await apiClient.get<ConstraintResponse[]>(
     `/tables/${tableId}/constraints`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeConstraintName = async (
   constraintId: string,
   data: ChangeConstraintNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeConstraintCheckExpr = async (
   constraintId: string,
   data: ChangeConstraintCheckExprRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/check-expr`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeConstraintDefaultExpr = async (
   constraintId: string,
   data: ChangeConstraintDefaultExprRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/default-expr`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteConstraint = async (
   constraintId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/constraints/${constraintId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getConstraintColumns = async (
   constraintId: string,
 ): Promise<ConstraintColumnResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<ConstraintColumnResponse[]>>(
+  const { data } = await apiClient.get<ConstraintColumnResponse[]>(
     `/constraints/${constraintId}/columns`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const addConstraintColumn = async (
@@ -119,48 +95,36 @@ export const addConstraintColumn = async (
   data: AddConstraintColumnRequest,
 ): Promise<MutationResponse<AddConstraintColumnResponse>> => {
   const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<AddConstraintColumnResponse>>
+    MutationResponse<AddConstraintColumnResponse>
   >(`/constraints/${constraintId}/columns`, data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const removeConstraintColumn = async (
   constraintColumnId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/constraint-columns/${constraintColumnId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getConstraintColumn = async (
   constraintColumnId: string,
 ): Promise<ConstraintColumnResponse> => {
-  const { data } = await apiClient.get<ApiResponse<ConstraintColumnResponse>>(
+  const { data } = await apiClient.get<ConstraintColumnResponse>(
     `/constraint-columns/${constraintColumnId}`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeConstraintColumnPosition = async (
   constraintColumnId: string,
   data: ChangeConstraintColumnPositionRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraint-columns/${constraintColumnId}/position`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };

--- a/apps/frontend/src/features/drawing/api/index-entity.api.ts
+++ b/apps/frontend/src/features/drawing/api/index-entity.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   IndexResponse,
@@ -15,87 +15,65 @@ import type {
 export const createIndex = async (
   data: CreateIndexRequest,
 ): Promise<MutationResponse<IndexResponse>> => {
-  const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<IndexResponse>>
-  >('/indexes', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  const { data: res } = await apiClient.post<MutationResponse<IndexResponse>>(
+    '/indexes',
+    data,
+  );
+  return res;
 };
 
 export const getIndex = async (indexId: string): Promise<IndexResponse> => {
-  const { data } = await apiClient.get<ApiResponse<IndexResponse>>(
-    `/indexes/${indexId}`,
-  );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<IndexResponse>(`/indexes/${indexId}`);
+  return data;
 };
 
 export const getIndexesByTableId = async (
   tableId: string,
 ): Promise<IndexResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<IndexResponse[]>>(
+  const { data } = await apiClient.get<IndexResponse[]>(
     `/tables/${tableId}/indexes`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeIndexName = async (
   indexId: string,
   data: ChangeIndexNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/indexes/${indexId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeIndexType = async (
   indexId: string,
   data: ChangeIndexTypeRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/indexes/${indexId}/type`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteIndex = async (
   indexId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/indexes/${indexId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getIndexColumns = async (
   indexId: string,
 ): Promise<IndexColumnResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<IndexColumnResponse[]>>(
+  const { data } = await apiClient.get<IndexColumnResponse[]>(
     `/indexes/${indexId}/columns`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const addIndexColumn = async (
@@ -103,62 +81,47 @@ export const addIndexColumn = async (
   data: AddIndexColumnRequest,
 ): Promise<MutationResponse<AddIndexColumnResponse>> => {
   const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<AddIndexColumnResponse>>
+    MutationResponse<AddIndexColumnResponse>
   >(`/indexes/${indexId}/columns`, data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const removeIndexColumn = async (
   indexColumnId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/index-columns/${indexColumnId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getIndexColumn = async (
   indexColumnId: string,
 ): Promise<IndexColumnResponse> => {
-  const { data } = await apiClient.get<ApiResponse<IndexColumnResponse>>(
+  const { data } = await apiClient.get<IndexColumnResponse>(
     `/index-columns/${indexColumnId}`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeIndexColumnPosition = async (
   indexColumnId: string,
   data: ChangeIndexColumnPositionRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/index-columns/${indexColumnId}/position`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeIndexColumnSortDirection = async (
   indexColumnId: string,
   data: ChangeIndexColumnSortDirectionRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/index-columns/${indexColumnId}/sort-direction`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };

--- a/apps/frontend/src/features/drawing/api/relationship.api.ts
+++ b/apps/frontend/src/features/drawing/api/relationship.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   RelationshipResponse,
@@ -17,116 +17,89 @@ export const createRelationship = async (
   data: CreateRelationshipRequest,
 ): Promise<MutationResponse<RelationshipResponse>> => {
   const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<RelationshipResponse>>
+    MutationResponse<RelationshipResponse>
   >('/relationships', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getRelationship = async (
   relationshipId: string,
 ): Promise<RelationshipResponse> => {
-  const { data } = await apiClient.get<ApiResponse<RelationshipResponse>>(
+  const { data } = await apiClient.get<RelationshipResponse>(
     `/relationships/${relationshipId}`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const getRelationshipsByTableId = async (
   tableId: string,
 ): Promise<RelationshipResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<RelationshipResponse[]>>(
+  const { data } = await apiClient.get<RelationshipResponse[]>(
     `/tables/${tableId}/relationships`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeRelationshipName = async (
   relationshipId: string,
   data: ChangeRelationshipNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeRelationshipKind = async (
   relationshipId: string,
   data: ChangeRelationshipKindRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/kind`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeRelationshipCardinality = async (
   relationshipId: string,
   data: ChangeRelationshipCardinalityRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/cardinality`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeRelationshipExtra = async (
   relationshipId: string,
   data: ChangeRelationshipExtraRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/extra`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteRelationship = async (
   relationshipId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/relationships/${relationshipId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getRelationshipColumns = async (
   relationshipId: string,
 ): Promise<RelationshipColumnResponse[]> => {
-  const { data } = await apiClient.get<
-    ApiResponse<RelationshipColumnResponse[]>
-  >(`/relationships/${relationshipId}/columns`);
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<RelationshipColumnResponse[]>(
+    `/relationships/${relationshipId}/columns`,
+  );
+  return data;
 };
 
 export const addRelationshipColumn = async (
@@ -134,48 +107,36 @@ export const addRelationshipColumn = async (
   data: AddRelationshipColumnRequest,
 ): Promise<MutationResponse<AddRelationshipColumnResponse>> => {
   const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<AddRelationshipColumnResponse>>
+    MutationResponse<AddRelationshipColumnResponse>
   >(`/relationships/${relationshipId}/columns`, data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const removeRelationshipColumn = async (
   relationshipColumnId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/relationship-columns/${relationshipColumnId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getRelationshipColumn = async (
   relationshipColumnId: string,
 ): Promise<RelationshipColumnResponse> => {
-  const { data } = await apiClient.get<ApiResponse<RelationshipColumnResponse>>(
+  const { data } = await apiClient.get<RelationshipColumnResponse>(
     `/relationship-columns/${relationshipColumnId}`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const changeRelationshipColumnPosition = async (
   relationshipColumnId: string,
   data: ChangeRelationshipColumnPositionRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationship-columns/${relationshipColumnId}/position`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };

--- a/apps/frontend/src/features/drawing/api/schema.api.ts
+++ b/apps/frontend/src/features/drawing/api/schema.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   SchemaResponse,
@@ -9,59 +9,43 @@ import type {
 export const createSchema = async (
   data: CreateSchemaRequest,
 ): Promise<MutationResponse<SchemaResponse>> => {
-  const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<SchemaResponse>>
-  >('/schemas', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  const { data: res } = await apiClient.post<MutationResponse<SchemaResponse>>(
+    '/schemas',
+    data,
+  );
+  return res;
 };
 
 export const getSchemasByProjectId = async (
   projectId: string,
 ): Promise<SchemaResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<SchemaResponse[]>>(
+  const { data } = await apiClient.get<SchemaResponse[]>(
     `/projects/${projectId}/schemas`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const getSchema = async (schemaId: string): Promise<SchemaResponse> => {
-  const { data } = await apiClient.get<ApiResponse<SchemaResponse>>(
-    `/schemas/${schemaId}`,
-  );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<SchemaResponse>(`/schemas/${schemaId}`);
+  return data;
 };
 
 export const changeSchemaName = async (
   schemaId: string,
   data: ChangeSchemaNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/schemas/${schemaId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteSchema = async (
   schemaId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/schemas/${schemaId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };

--- a/apps/frontend/src/features/drawing/api/table.api.ts
+++ b/apps/frontend/src/features/drawing/api/table.api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   MutationResponse,
   TableResponse,
@@ -12,123 +12,93 @@ import type {
 export const createTable = async (
   data: CreateTableRequest,
 ): Promise<MutationResponse<TableResponse>> => {
-  const { data: res } = await apiClient.post<
-    ApiResponse<MutationResponse<TableResponse>>
-  >('/tables', data);
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  const { data: res } = await apiClient.post<MutationResponse<TableResponse>>(
+    '/tables',
+    data,
+  );
+  return res;
 };
 
 export const getTable = async (tableId: string): Promise<TableResponse> => {
-  const { data } = await apiClient.get<ApiResponse<TableResponse>>(
-    `/tables/${tableId}`,
-  );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<TableResponse>(`/tables/${tableId}`);
+  return data;
 };
 
 export const getTablesBySchemaId = async (
   schemaId: string,
 ): Promise<TableResponse[]> => {
-  const { data } = await apiClient.get<ApiResponse<TableResponse[]>>(
+  const { data } = await apiClient.get<TableResponse[]>(
     `/schemas/${schemaId}/tables`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const getTableSnapshot = async (
   tableId: string,
 ): Promise<TableSnapshotResponse> => {
-  const { data } = await apiClient.get<ApiResponse<TableSnapshotResponse>>(
+  const { data } = await apiClient.get<TableSnapshotResponse>(
     `/tables/${tableId}/snapshot`,
   );
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  return data;
 };
 
 export const getTableSnapshots = async (
   tableIds: string[],
 ): Promise<Record<string, TableSnapshotResponse>> => {
-  const { data } = await apiClient.get<
-    ApiResponse<Record<string, TableSnapshotResponse>>
-  >('/tables/snapshots', { params: { tableIds } });
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<Record<string, TableSnapshotResponse>>(
+    '/tables/snapshots',
+    { params: { tableIds } },
+  );
+  return data;
 };
 
 export const changeTableName = async (
   tableId: string,
   data: ChangeTableNameRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/name`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeTableMeta = async (
   tableId: string,
   data: ChangeTableMetaRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/meta`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const changeTableExtra = async (
   tableId: string,
   data: ChangeTableExtraRequest,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.patch<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/extra`,
     data,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const deleteTable = async (
   tableId: string,
 ): Promise<MutationResponse> => {
-  const { data: res } = await apiClient.delete<ApiResponse<MutationResponse>>(
+  const { data: res } = await apiClient.delete<MutationResponse>(
     `/tables/${tableId}`,
   );
-  if (!res.success || !res.result) {
-    throw res.error ?? new Error('Unknown API error');
-  }
-  return res.result;
+  return res;
 };
 
 export const getSchemaWithSnapshots = async (
   schemaId: string,
 ): Promise<Record<string, TableSnapshotResponse>> => {
-  const { data } = await apiClient.get<
-    ApiResponse<Record<string, TableSnapshotResponse>>
-  >(`/schemas/${schemaId}/snapshots`);
-  if (!data.success || !data.result) {
-    throw data.error ?? new Error('Unknown API error');
-  }
-  return data.result;
+  const { data } = await apiClient.get<Record<string, TableSnapshotResponse>>(
+    `/schemas/${schemaId}/snapshots`,
+  );
+  return data;
 };

--- a/apps/frontend/src/features/memo/api/api.ts
+++ b/apps/frontend/src/features/memo/api/api.ts
@@ -1,4 +1,4 @@
-import { type ApiResponse, apiClient } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import type {
   Memo,
   MemoComment,
@@ -8,31 +8,25 @@ import type {
   UpdateMemoCommentRequest,
 } from './types';
 
-export const createMemo = async (
-  data: CreateMemoRequest,
-): Promise<ApiResponse<Memo>> => {
-  const response = await apiClient.post<ApiResponse<Memo>>('/memos', data);
+export const createMemo = async (data: CreateMemoRequest): Promise<Memo> => {
+  const response = await apiClient.post<Memo>('/memos', data);
   return response.data;
 };
 
-export const getMemo = async (memoId: string): Promise<ApiResponse<Memo>> => {
-  const response = await apiClient.get<ApiResponse<Memo>>(`/memos/${memoId}`);
+export const getMemo = async (memoId: string): Promise<Memo> => {
+  const response = await apiClient.get<Memo>(`/memos/${memoId}`);
   return response.data;
 };
 
-export const getSchemaMemos = async (
-  schemaId: string,
-): Promise<ApiResponse<Memo[]>> => {
-  const response = await apiClient.get<ApiResponse<Memo[]>>(
-    `/schemas/${schemaId}/memos`,
-  );
+export const getSchemaMemos = async (schemaId: string): Promise<Memo[]> => {
+  const response = await apiClient.get<Memo[]>(`/schemas/${schemaId}/memos`);
   return response.data;
 };
 
 export const getSchemaMemosWithComments = async (
   schemaId: string,
-): Promise<ApiResponse<Memo[]>> => {
-  const response = await apiClient.get<ApiResponse<Memo[]>>(
+): Promise<Memo[]> => {
+  const response = await apiClient.get<Memo[]>(
     `/schemas/${schemaId}/memos-with-comments`,
   );
   return response.data;
@@ -41,28 +35,21 @@ export const getSchemaMemosWithComments = async (
 export const updateMemo = async (
   memoId: string,
   data: UpdateMemoRequest,
-): Promise<ApiResponse<Memo>> => {
-  const response = await apiClient.put<ApiResponse<Memo>>(
-    `/memos/${memoId}`,
-    data,
-  );
+): Promise<Memo> => {
+  const response = await apiClient.put<Memo>(`/memos/${memoId}`, data);
   return response.data;
 };
 
-export const deleteMemo = async (
-  memoId: string,
-): Promise<ApiResponse<null>> => {
-  const response = await apiClient.delete<ApiResponse<null>>(
-    `/memos/${memoId}`,
-  );
+export const deleteMemo = async (memoId: string): Promise<null> => {
+  const response = await apiClient.delete<null>(`/memos/${memoId}`);
   return response.data;
 };
 
 export const createMemoComment = async (
   memoId: string,
   data: CreateMemoCommentRequest,
-): Promise<ApiResponse<MemoComment>> => {
-  const response = await apiClient.post<ApiResponse<MemoComment>>(
+): Promise<MemoComment> => {
+  const response = await apiClient.post<MemoComment>(
     `/memos/${memoId}/comments`,
     data,
   );
@@ -71,8 +58,8 @@ export const createMemoComment = async (
 
 export const getMemoComments = async (
   memoId: string,
-): Promise<ApiResponse<MemoComment[]>> => {
-  const response = await apiClient.get<ApiResponse<MemoComment[]>>(
+): Promise<MemoComment[]> => {
+  const response = await apiClient.get<MemoComment[]>(
     `/memos/${memoId}/comments`,
   );
   return response.data;
@@ -82,8 +69,8 @@ export const updateMemoComment = async (
   memoId: string,
   commentId: string,
   data: UpdateMemoCommentRequest,
-): Promise<ApiResponse<MemoComment>> => {
-  const response = await apiClient.put<ApiResponse<MemoComment>>(
+): Promise<MemoComment> => {
+  const response = await apiClient.put<MemoComment>(
     `/memos/${memoId}/comments/${commentId}`,
     data,
   );
@@ -93,8 +80,8 @@ export const updateMemoComment = async (
 export const deleteMemoComment = async (
   memoId: string,
   commentId: string,
-): Promise<ApiResponse<null>> => {
-  const response = await apiClient.delete<ApiResponse<null>>(
+): Promise<null> => {
+  const response = await apiClient.delete<null>(
     `/memos/${memoId}/comments/${commentId}`,
   );
   return response.data;

--- a/apps/frontend/src/features/memo/hooks/useMemoStore.ts
+++ b/apps/frontend/src/features/memo/hooks/useMemoStore.ts
@@ -7,7 +7,7 @@ import {
 } from 'react';
 import { type Node, type NodeChange, applyNodeChanges } from '@xyflow/react';
 import * as memoApi from '../api/api';
-import type { Memo, MemoComment } from '../api/types';
+import type { Memo } from '../api/types';
 import {
   stringifyPosition,
   transformApiMemoToNode,
@@ -29,9 +29,8 @@ export const useMemoStore = () => {
 
     memoApi
       .getSchemaMemosWithComments(SCHEMA_ID)
-      .then((res) => {
-        if (!res.success) return;
-        setStoredMemos(res.result as Memo[]);
+      .then((memos) => {
+        setStoredMemos(memos);
       })
       .catch((error) => {
         console.error('Failed to fetch memos:', error);
@@ -42,33 +41,24 @@ export const useMemoStore = () => {
     position: { x: number; y: number },
     content: string,
   ) => {
-    const res = await memoApi.createMemo({
+    const memo = await memoApi.createMemo({
       schemaId: SCHEMA_ID,
       positions: stringifyPosition(position),
       body: content,
     });
-    if (res.success) {
-      setStoredMemos((prev) => [res.result as Memo, ...prev]);
-    }
+    setStoredMemos((prev) => [memo, ...prev]);
   };
 
   const updateMemo = useCallback(async (id: string, positions: string) => {
-    const res = await memoApi.updateMemo(id, { positions });
-    if (res.success) {
-      const updated = res.result as Memo;
-      setStoredMemos((prev) =>
-        prev.map((m) =>
-          m.id === id ? { ...updated, comments: m.comments } : m,
-        ),
-      );
-    }
+    const updated = await memoApi.updateMemo(id, { positions });
+    setStoredMemos((prev) =>
+      prev.map((m) => (m.id === id ? { ...updated, comments: m.comments } : m)),
+    );
   }, []);
 
   const deleteMemo = useCallback(async (id: string) => {
-    const res = await memoApi.deleteMemo(id);
-    if (res.success) {
-      setStoredMemos((prev) => prev.filter((m) => m.id !== id));
-    }
+    await memoApi.deleteMemo(id);
+    setStoredMemos((prev) => prev.filter((m) => m.id !== id));
   }, []);
 
   const onMemosChange = useCallback(
@@ -91,15 +81,12 @@ export const useMemoStore = () => {
   );
 
   const createComment = async (memoId: string, body: string) => {
-    const res = await memoApi.createMemoComment(memoId, { body });
-    if (res.success) {
-      const comment = res.result as MemoComment;
-      setStoredMemos((prev) =>
-        prev.map((m) =>
-          m.id === memoId ? { ...m, comments: [...m.comments, comment] } : m,
-        ),
-      );
-    }
+    const comment = await memoApi.createMemoComment(memoId, { body });
+    setStoredMemos((prev) =>
+      prev.map((m) =>
+        m.id === memoId ? { ...m, comments: [...m.comments, comment] } : m,
+      ),
+    );
   };
 
   const updateComment = async (
@@ -107,36 +94,33 @@ export const useMemoStore = () => {
     commentId: string,
     body: string,
   ) => {
-    const res = await memoApi.updateMemoComment(memoId, commentId, { body });
-    if (res.success) {
-      const updated = res.result as MemoComment;
-      setStoredMemos((prev) =>
-        prev.map((m) =>
-          m.id === memoId
-            ? {
-                ...m,
-                comments: m.comments.map((c) =>
-                  c.id === commentId ? updated : c,
-                ),
-              }
-            : m,
-        ),
-      );
-    }
+    const updated = await memoApi.updateMemoComment(memoId, commentId, {
+      body,
+    });
+    setStoredMemos((prev) =>
+      prev.map((m) =>
+        m.id === memoId
+          ? {
+              ...m,
+              comments: m.comments.map((c) =>
+                c.id === commentId ? updated : c,
+              ),
+            }
+          : m,
+      ),
+    );
   };
 
   const deleteComment = async (memoId: string, commentId: string) => {
-    const res = await memoApi.deleteMemoComment(memoId, commentId);
-    if (res.success) {
-      setStoredMemos((prev) => {
-        const updated = prev.map((m) =>
-          m.id === memoId
-            ? { ...m, comments: m.comments.filter((c) => c.id !== commentId) }
-            : m,
-        );
-        return updated.filter((m) => m.id !== memoId || m.comments.length > 0);
-      });
-    }
+    await memoApi.deleteMemoComment(memoId, commentId);
+    setStoredMemos((prev) => {
+      const updated = prev.map((m) =>
+        m.id === memoId
+          ? { ...m, comments: m.comments.filter((c) => c.id !== commentId) }
+          : m,
+      );
+      return updated.filter((m) => m.id !== memoId || m.comments.length > 0);
+    });
   };
 
   return {

--- a/apps/frontend/src/features/memo/hooks/useMemoStore.ts
+++ b/apps/frontend/src/features/memo/hooks/useMemoStore.ts
@@ -41,24 +41,32 @@ export const useMemoStore = () => {
     position: { x: number; y: number },
     content: string,
   ) => {
-    const memo = await memoApi.createMemo({
-      schemaId: SCHEMA_ID,
-      positions: stringifyPosition(position),
-      body: content,
-    });
-    setStoredMemos((prev) => [memo, ...prev]);
+    try {
+      const memo = await memoApi.createMemo({
+        schemaId: SCHEMA_ID,
+        positions: stringifyPosition(position),
+        body: content,
+      });
+      setStoredMemos((prev) => [memo, ...prev]);
+    } catch {}
   };
 
   const updateMemo = useCallback(async (id: string, positions: string) => {
-    const updated = await memoApi.updateMemo(id, { positions });
-    setStoredMemos((prev) =>
-      prev.map((m) => (m.id === id ? { ...updated, comments: m.comments } : m)),
-    );
+    try {
+      const updated = await memoApi.updateMemo(id, { positions });
+      setStoredMemos((prev) =>
+        prev.map((m) =>
+          m.id === id ? { ...updated, comments: m.comments } : m,
+        ),
+      );
+    } catch {}
   }, []);
 
   const deleteMemo = useCallback(async (id: string) => {
-    await memoApi.deleteMemo(id);
-    setStoredMemos((prev) => prev.filter((m) => m.id !== id));
+    try {
+      await memoApi.deleteMemo(id);
+      setStoredMemos((prev) => prev.filter((m) => m.id !== id));
+    } catch {}
   }, []);
 
   const onMemosChange = useCallback(
@@ -81,12 +89,14 @@ export const useMemoStore = () => {
   );
 
   const createComment = async (memoId: string, body: string) => {
-    const comment = await memoApi.createMemoComment(memoId, { body });
-    setStoredMemos((prev) =>
-      prev.map((m) =>
-        m.id === memoId ? { ...m, comments: [...m.comments, comment] } : m,
-      ),
-    );
+    try {
+      const comment = await memoApi.createMemoComment(memoId, { body });
+      setStoredMemos((prev) =>
+        prev.map((m) =>
+          m.id === memoId ? { ...m, comments: [...m.comments, comment] } : m,
+        ),
+      );
+    } catch {}
   };
 
   const updateComment = async (
@@ -94,33 +104,37 @@ export const useMemoStore = () => {
     commentId: string,
     body: string,
   ) => {
-    const updated = await memoApi.updateMemoComment(memoId, commentId, {
-      body,
-    });
-    setStoredMemos((prev) =>
-      prev.map((m) =>
-        m.id === memoId
-          ? {
-              ...m,
-              comments: m.comments.map((c) =>
-                c.id === commentId ? updated : c,
-              ),
-            }
-          : m,
-      ),
-    );
+    try {
+      const updated = await memoApi.updateMemoComment(memoId, commentId, {
+        body,
+      });
+      setStoredMemos((prev) =>
+        prev.map((m) =>
+          m.id === memoId
+            ? {
+                ...m,
+                comments: m.comments.map((c) =>
+                  c.id === commentId ? updated : c,
+                ),
+              }
+            : m,
+        ),
+      );
+    } catch {}
   };
 
   const deleteComment = async (memoId: string, commentId: string) => {
-    await memoApi.deleteMemoComment(memoId, commentId);
-    setStoredMemos((prev) => {
-      const updated = prev.map((m) =>
-        m.id === memoId
-          ? { ...m, comments: m.comments.filter((c) => c.id !== commentId) }
-          : m,
-      );
-      return updated.filter((m) => m.id !== memoId || m.comments.length > 0);
-    });
+    try {
+      await memoApi.deleteMemoComment(memoId, commentId);
+      setStoredMemos((prev) => {
+        const updated = prev.map((m) =>
+          m.id === memoId
+            ? { ...m, comments: m.comments.filter((c) => c.id !== commentId) }
+            : m,
+        );
+        return updated.filter((m) => m.id !== memoId || m.comments.length > 0);
+      });
+    } catch {}
   };
 
   return {

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { authStore } from '../../store/auth.store';
 import { refreshToken } from '@/features/auth/api';
+import { handleApiError } from './error-handler';
 
 const API_BASE_URL: string =
   import.meta.env.VITE_BASE_URL || 'http://localhost:4000/api/v1.0';
@@ -84,3 +85,6 @@ apiClient.interceptors.response.use(
     return Promise.reject(error);
   },
 );
+
+apiClient.interceptors.response.use((response) => response, handleApiError);
+publicClient.interceptors.response.use((response) => response, handleApiError);

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -87,4 +87,3 @@ apiClient.interceptors.response.use(
 );
 
 apiClient.interceptors.response.use((response) => response, handleApiError);
-publicClient.interceptors.response.use((response) => response, handleApiError);

--- a/apps/frontend/src/lib/api/error-handler.ts
+++ b/apps/frontend/src/lib/api/error-handler.ts
@@ -1,0 +1,59 @@
+import { isAxiosError } from 'axios';
+import { toast } from 'sonner';
+import { ErrorCategory, type ApiError } from './types';
+import { getErrorMessage } from './error-messages';
+
+type ProblemDetails = {
+  detail?: string;
+  title?: string;
+  status?: number;
+  reason?: string;
+};
+
+type ErrorResponseData = ApiError | ProblemDetails;
+
+const extractCode = (data: ErrorResponseData): string | undefined => {
+  if ('code' in data && data.code) return data.code;
+  if ('reason' in data && data.reason) return data.reason;
+  return undefined;
+};
+
+export const handleApiError = (error: unknown): Promise<never> => {
+  if (!isAxiosError<ErrorResponseData>(error)) {
+    return Promise.reject(error);
+  }
+
+  const errorData = error.response?.data;
+
+  if (!errorData) {
+    toast.error('Network error. Please try again.');
+    return Promise.reject(error);
+  }
+
+  const code = extractCode(errorData);
+  const { message, category } = code
+    ? getErrorMessage(code)
+    : {
+        message: 'An unexpected error occurred. Please try again.',
+        category: ErrorCategory.USER_FEEDBACK,
+      };
+
+  switch (category) {
+    case ErrorCategory.SILENT:
+      console.error('[Silent Error]', errorData);
+      break;
+
+    case ErrorCategory.USER_FEEDBACK:
+      toast.error(message);
+      break;
+
+    case ErrorCategory.AUTO_HANDLE:
+      toast.info(message);
+      break;
+
+    default:
+      toast.error(message);
+  }
+
+  return Promise.reject(error);
+};

--- a/apps/frontend/src/lib/api/error-handler.ts
+++ b/apps/frontend/src/lib/api/error-handler.ts
@@ -1,21 +1,14 @@
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
-import { ErrorCategory, type ApiError } from './types';
+import { ErrorCategory, type ApiError, type ErrorResponseData } from './types';
 import { getErrorMessage } from './error-messages';
 
-type ProblemDetails = {
-  detail?: string;
-  title?: string;
-  status?: number;
-  reason?: string;
-};
-
-type ErrorResponseData = ApiError | ProblemDetails;
+const isApiError = (data: ErrorResponseData): data is ApiError =>
+  'category' in data && typeof data.category === 'string';
 
 const extractCode = (data: ErrorResponseData): string | undefined => {
-  if ('code' in data && data.code) return data.code;
-  if ('reason' in data && data.reason) return data.reason;
-  return undefined;
+  if (isApiError(data)) return data.code;
+  return data.reason;
 };
 
 export const handleApiError = (error: unknown): Promise<never> => {
@@ -26,17 +19,17 @@ export const handleApiError = (error: unknown): Promise<never> => {
   const errorData = error.response?.data;
 
   if (!errorData) {
-    toast.error('Network error. Please try again.');
+    const { message } = getErrorMessage('NETWORK_ERROR');
+    toast.error(message);
     return Promise.reject(error);
   }
 
   const code = extractCode(errorData);
-  const { message, category } = code
-    ? getErrorMessage(code)
-    : {
-        message: 'An unexpected error occurred. Please try again.',
-        category: ErrorCategory.USER_FEEDBACK,
-      };
+  const errorInfo = getErrorMessage(code ?? '');
+  const category = isApiError(errorData)
+    ? errorData.category
+    : errorInfo.category;
+  const message = errorInfo.message;
 
   switch (category) {
     case ErrorCategory.SILENT:

--- a/apps/frontend/src/lib/api/error-messages.ts
+++ b/apps/frontend/src/lib/api/error-messages.ts
@@ -1,0 +1,303 @@
+import { ErrorCategory, type ErrorCategoryType } from './types';
+
+type ErrorMessageInfo = {
+  message: string;
+  category: ErrorCategoryType;
+};
+
+const SESSION_EXPIRED: ErrorMessageInfo = {
+  message: 'Your session has expired. Please sign in again.',
+  category: ErrorCategory.AUTO_HANDLE,
+};
+
+const SOMETHING_WENT_WRONG: ErrorMessageInfo = {
+  message: 'Something went wrong. Please try again later.',
+  category: ErrorCategory.USER_FEEDBACK,
+};
+
+const CHECK_INPUT: ErrorMessageInfo = {
+  message: 'Please check your input and try again.',
+  category: ErrorCategory.USER_FEEDBACK,
+};
+
+const SETTINGS_TOO_LARGE: ErrorMessageInfo = {
+  message: 'Settings are too large. Please reduce the size and try again.',
+  category: ErrorCategory.USER_FEEDBACK,
+};
+
+const notFound = (item: string): ErrorMessageInfo => ({
+  message: `${item} not found. Please check and try again.`,
+  category: ErrorCategory.USER_FEEDBACK,
+});
+
+export const ERROR_MESSAGES: Record<string, ErrorMessageInfo> = {
+  COMMON_SYSTEM_ERROR: SOMETHING_WENT_WRONG,
+  COMMON_INVALID_PARAMETER: {
+    message: 'Invalid parameter.',
+    category: ErrorCategory.SILENT,
+  },
+  COMMON_API_VERSION_MISSING: {
+    message: 'API version is missing.',
+    category: ErrorCategory.SILENT,
+  },
+  COMMON_API_VERSION_INVALID: {
+    message: 'Invalid API version format. (e.g., v1.0, v2.1)',
+    category: ErrorCategory.SILENT,
+  },
+  COMMON_INVALID_INPUT_VALUE: CHECK_INPUT,
+  COMMON_NOT_FOUND: {
+    message: "The requested item doesn't exist or may have been moved.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  COMMON_INTERNAL_SERVER_ERROR: SOMETHING_WENT_WRONG,
+  COMMON_ALREADY_DELETED: {
+    message: 'This item has already been deleted.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  AUTH_AUTHENTICATION_REQUIRED: {
+    message: 'Please sign in to continue.',
+    category: ErrorCategory.AUTO_HANDLE,
+  },
+  AUTH_ACCESS_DENIED: {
+    message: "You don't have permission to perform this action.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  AUTH_INVALID_REFRESH_TOKEN: SESSION_EXPIRED,
+  AUTH_INVALID_TOKEN_TYPE: SESSION_EXPIRED,
+  AUTH_MISSING_REFRESH_TOKEN: SESSION_EXPIRED,
+  AUTH_EXPIRED_TOKEN: SESSION_EXPIRED,
+  AUTH_INVALID_TOKEN: SESSION_EXPIRED,
+  AUTH_INVALID_ACCESS_TOKEN_TYPE: SESSION_EXPIRED,
+  AUTH_MALFORMED_TOKEN: SESSION_EXPIRED,
+  AUTH_TOKEN_VALIDATION_ERROR: SESSION_EXPIRED,
+
+  HMAC_SIGNATURE_MISSING: {
+    message: 'Security signature is missing.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  HMAC_SIGNATURE_INVALID: {
+    message: 'Invalid request signature.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  HMAC_TIMESTAMP_EXPIRED: {
+    message: 'Request has expired. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  HMAC_NONCE_DUPLICATE: {
+    message: 'Duplicate request detected. Please retry.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  USER_NOT_FOUND: {
+    message: 'User not found. Please check and try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  USER_ALREADY_EXISTS: {
+    message: 'This email is already registered.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  USER_LOGIN_FAILED: {
+    message: 'Invalid email or password. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  VALIDATION_FAILED: CHECK_INPUT,
+  VALIDATION_SERVICE_UNAVAILABLE: {
+    message: 'Service is temporarily unavailable. Please try again later.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  VALIDATION_TIMEOUT: {
+    message: 'Request timed out. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  VALIDATION_ERROR: SOMETHING_WENT_WRONG,
+
+  SCHEMA_NOT_FOUND: notFound('Schema'),
+  TABLE_NOT_FOUND: notFound('Table'),
+  COLUMN_NOT_FOUND: notFound('Column'),
+  CONSTRAINT_NOT_FOUND: notFound('Constraint'),
+  INDEX_NOT_FOUND: notFound('Index'),
+  RELATIONSHIP_NOT_FOUND: notFound('Relationship'),
+  CONSTRAINT_COLUMN_NOT_FOUND: notFound('Constraint column'),
+  INDEX_COLUMN_NOT_FOUND: notFound('Index column'),
+  RELATIONSHIP_COLUMN_NOT_FOUND: notFound('Relationship column'),
+  VENDOR_NOT_FOUND: {
+    message: 'Unsupported database type.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  MEMO_NOT_FOUND: notFound('Memo'),
+  MEMO_COMMENT_NOT_FOUND: notFound('Comment'),
+
+  WORKSPACE_NOT_FOUND: notFound('Workspace'),
+  WORKSPACE_ACCESS_DENIED: {
+    message: "You don't have access to this workspace.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_SETTINGS_INVALID: {
+    message: 'Failed to save settings. Please check the format and try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_SETTINGS_TOO_LARGE: SETTINGS_TOO_LARGE,
+  WORKSPACE_ALREADY_DELETED: {
+    message: 'This workspace has been deleted.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_ADMIN_REQUIRED: {
+    message: 'Only admins can perform this action.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_MEMBER_ALREADY_EXISTS: {
+    message: 'This user is already a member of this workspace.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_MEMBER_NOT_FOUND: {
+    message: 'Member not found in this workspace.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_MEMBER_LIMIT_EXCEEDED: {
+    message: 'Workspace has reached the member limit (max 30).',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_LAST_ADMIN_CANNOT_LEAVE: {
+    message:
+      'You are the last admin. Please assign another admin before leaving.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  WORKSPACE_LAST_ADMIN_CANNOT_CHANGE_ROLE: {
+    message:
+      "Cannot change the last admin's role. Please assign another admin first.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  PROJECT_NOT_FOUND: notFound('Project'),
+  PROJECT_ACCESS_DENIED: {
+    message: "You don't have access to this project.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_OWNER_ONLY: {
+    message: 'Only the project owner can perform this action.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_ADMIN_REQUIRED: {
+    message: 'Only project admins can perform this action.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_WORKSPACE_MISMATCH: {
+    message: 'This project is not part of the current workspace.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_SETTINGS_TOO_LARGE: SETTINGS_TOO_LARGE,
+  PROJECT_ALREADY_DELETED: {
+    message: 'This project has been deleted.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_CANNOT_ASSIGN_HIGHER_ROLE: {
+    message: 'You cannot assign a role higher than your own.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_CANNOT_MODIFY_HIGHER_ROLE_MEMBER: {
+    message: 'You cannot modify members with higher roles than yours.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_CANNOT_CHANGE_OWN_ROLE: {
+    message: 'You cannot change your own role.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_LAST_OWNER_CANNOT_BE_REMOVED: {
+    message: 'Cannot remove the last owner. Please assign another owner first.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_WORKSPACE_MEMBERSHIP_REQUIRED: {
+    message: 'You must be a workspace member to access this project.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_MEMBER_LIMIT_EXCEEDED: {
+    message: 'Project has reached the member limit (max 30).',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_MEMBER_NOT_FOUND: {
+    message: 'Member not found in this project.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  PROJECT_MEMBER_ALREADY_EXISTS: {
+    message: 'This user is already a member of this project.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  SHARE_LINK_NOT_FOUND: notFound('Share link'),
+  SHARE_LINK_EXPIRED: {
+    message: 'This share link has expired. Please request a new one.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  SHARE_LINK_REVOKED: {
+    message: 'This share link has been deactivated.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  SHARE_LINK_INVALID: {
+    message: 'Invalid share link. Please check and try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  SHARE_LINK_INVALID_PROJECT_ID: {
+    message: 'Invalid project ID.',
+    category: ErrorCategory.SILENT,
+  },
+  SHARE_LINK_INVALID_TOKEN_HASH: {
+    message: 'Invalid token hash.',
+    category: ErrorCategory.SILENT,
+  },
+  SHARE_LINK_INVALID_ROLE: {
+    message: 'Invalid role.',
+    category: ErrorCategory.SILENT,
+  },
+  SHARE_LINK_INVALID_EXPIRATION: {
+    message: 'Expiration date must be in the future.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  BAD_REQUEST: CHECK_INPUT,
+  UNAUTHORIZED: {
+    message: 'Please sign in to continue.',
+    category: ErrorCategory.AUTO_HANDLE,
+  },
+  FORBIDDEN: {
+    message: "You don't have permission to perform this action.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  NOT_FOUND: {
+    message: "The requested item doesn't exist or may have been moved.",
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  CONFLICT: {
+    message:
+      'This action conflicts with existing data. Please refresh and try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  INTERNAL_SERVER_ERROR: SOMETHING_WENT_WRONG,
+  SERVICE_UNAVAILABLE: {
+    message: 'Service is temporarily unavailable. Please try again later.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  GATEWAY_TIMEOUT: {
+    message: 'Request timed out. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+
+  BACKEND_UNREACHABLE: {
+    message: 'Service is temporarily unavailable. Please try again later.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+  BACKEND_TIMEOUT: {
+    message: 'Request timed out. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
+};
+
+const DEFAULT_ERROR: ErrorMessageInfo = {
+  message: 'An unexpected error occurred. Please try again.',
+  category: ErrorCategory.USER_FEEDBACK,
+};
+
+export function getErrorMessage(code: string): ErrorMessageInfo {
+  return ERROR_MESSAGES[code] ?? DEFAULT_ERROR;
+}

--- a/apps/frontend/src/lib/api/error-messages.ts
+++ b/apps/frontend/src/lib/api/error-messages.ts
@@ -291,6 +291,11 @@ export const ERROR_MESSAGES: Record<string, ErrorMessageInfo> = {
     message: 'Request timed out. Please try again.',
     category: ErrorCategory.USER_FEEDBACK,
   },
+
+  NETWORK_ERROR: {
+    message: 'Network error. Please try again.',
+    category: ErrorCategory.USER_FEEDBACK,
+  },
 };
 
 const DEFAULT_ERROR: ErrorMessageInfo = {

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
 export * from './types';
+export * from './error-messages';

--- a/apps/frontend/src/lib/api/types.ts
+++ b/apps/frontend/src/lib/api/types.ts
@@ -8,8 +8,7 @@ export type ErrorCategoryType =
   (typeof ErrorCategory)[keyof typeof ErrorCategory];
 
 export type ApiError = {
-  code?: string;
-  message: string;
-  category?: ErrorCategoryType;
+  code: string;
+  category: ErrorCategoryType;
   details?: Record<string, unknown>;
 };

--- a/apps/frontend/src/lib/api/types.ts
+++ b/apps/frontend/src/lib/api/types.ts
@@ -12,3 +12,13 @@ export type ApiError = {
   category: ErrorCategoryType;
   details?: Record<string, unknown>;
 };
+
+type ProblemDetails = {
+  type?: string;
+  detail?: string;
+  title?: string;
+  status?: number;
+  reason?: string;
+};
+
+export type ErrorResponseData = ApiError | ProblemDetails;

--- a/apps/frontend/src/lib/api/types.ts
+++ b/apps/frontend/src/lib/api/types.ts
@@ -1,10 +1,3 @@
-// 기본 형식
-export type ApiResponse<T = unknown> = {
-  success: boolean;
-  result: T | null;
-  error: ApiError | null;
-};
-
 export const ErrorCategory = {
   USER_FEEDBACK: 'USER_FEEDBACK',
   SILENT: 'SILENT',

--- a/apps/frontend/src/lib/config/query-client.ts
+++ b/apps/frontend/src/lib/config/query-client.ts
@@ -1,10 +1,10 @@
 import { QueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { isAxiosError } from 'axios';
-import { ErrorCategory, type ApiResponse } from '../api/types';
+import { ErrorCategory, type ApiError } from '../api/types';
 
 const handleMutationError = (error: Error) => {
-  if (!isAxiosError<ApiResponse<unknown>>(error)) {
+  if (!isAxiosError<ApiError>(error)) {
     if (error && typeof error === 'object' && 'message' in error) {
       toast.error(error.message);
       return;
@@ -13,7 +13,7 @@ const handleMutationError = (error: Error) => {
     return;
   }
 
-  const apiError = error.response?.data?.error;
+  const apiError = error.response?.data;
 
   if (!apiError) {
     toast.error('Network error. Please try again.');

--- a/apps/frontend/src/lib/config/query-client.ts
+++ b/apps/frontend/src/lib/config/query-client.ts
@@ -1,44 +1,4 @@
 import { QueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { isAxiosError } from 'axios';
-import { ErrorCategory, type ApiError } from '../api/types';
-
-const handleMutationError = (error: Error) => {
-  if (!isAxiosError<ApiError>(error)) {
-    if (error && typeof error === 'object' && 'message' in error) {
-      toast.error(error.message);
-      return;
-    }
-    toast.error('An unexpected error occurred. Please try again.');
-    return;
-  }
-
-  const apiError = error.response?.data;
-
-  if (!apiError) {
-    toast.error('Network error. Please try again.');
-    return;
-  }
-
-  const { message, category = ErrorCategory.USER_FEEDBACK } = apiError;
-
-  switch (category) {
-    case ErrorCategory.SILENT:
-      console.error('[Silent Error]', apiError);
-      break;
-
-    case ErrorCategory.USER_FEEDBACK:
-      toast.error(message);
-      break;
-
-    case ErrorCategory.AUTO_HANDLE:
-      toast.info(message);
-      break;
-
-    default:
-      toast.error(message);
-  }
-};
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -46,9 +6,6 @@ export const queryClient = new QueryClient({
       staleTime: 1000 * 60,
       retry: 1,
       refetchOnWindowFocus: false,
-    },
-    mutations: {
-      onError: handleMutationError,
     },
   },
 });


### PR DESCRIPTION
## 개요
백엔드 응답 형식 변경에 따라 BFF, 프론트엔드 응답 형식 변경
- `ApiResponse` 타입 제거
- `.success`, `.result` 매핑 제거
- 에러 메시지 변환 작업을 프론트엔드로 옮김
   - BFF를 거치지 않는 login, signin, refresh 같은 작업도 일관적으로 관리하기 위해 프론트엔드에서 변환하는 것으로 변경
   - BFF는 코드와 카테고리만 프론트에 전해주고 프론트에서 유저 친화적인 메시지로 변환

## 이슈


- close #249