### PR TITLE
fix(#265): stabilize table deletion

### DIFF
--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
@@ -15,6 +15,7 @@ import com.schemafy.domain.erd.column.application.port.out.GetColumnsByTableIdPo
 import com.schemafy.domain.erd.relationship.application.port.in.DeleteRelationshipCommand;
 import com.schemafy.domain.erd.relationship.application.port.in.DeleteRelationshipUseCase;
 import com.schemafy.domain.erd.relationship.application.port.out.GetRelationshipsByTableIdPort;
+import com.schemafy.domain.erd.relationship.domain.exception.RelationshipErrorCode;
 import com.schemafy.domain.erd.table.application.port.in.DeleteTableCommand;
 import com.schemafy.domain.erd.table.application.port.in.DeleteTableUseCase;
 import com.schemafy.domain.erd.table.application.port.out.DeleteTablePort;
@@ -49,10 +50,8 @@ public class DeleteTableService implements DeleteTableUseCase {
         .then(getRelationshipsByTableIdPort.findRelationshipsByTableId(tableId)
             .defaultIfEmpty(List.of())
             .flatMapMany(Flux::fromIterable)
-            .concatMap(relationship -> deleteRelationshipUseCase.deleteRelationship(
-                new DeleteRelationshipCommand(relationship.id()))
-                .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
-                .then())
+            // Identifying cascade can remove later relationships from the initial snapshot.
+            .concatMap(relationship -> deleteRelationshipIgnoringAlreadyDeleted(relationship.id(), affectedTableIds))
             .then(Mono.defer(() -> getColumnsByTableIdPort.findColumnsByTableId(tableId)))
             .flatMapMany(Flux::fromIterable)
             .concatMap(column -> deleteColumnUseCase.deleteColumn(
@@ -60,8 +59,19 @@ public class DeleteTableService implements DeleteTableUseCase {
                 .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                 .then())
             .then(Mono.defer(() -> deleteTablePort.deleteTable(tableId)))
-            .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
+        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
         .as(transactionalOperator::transactional);
+  }
+
+  private Mono<Void> deleteRelationshipIgnoringAlreadyDeleted(
+      String relationshipId,
+      Set<String> affectedTableIds) {
+    return deleteRelationshipUseCase.deleteRelationship(new DeleteRelationshipCommand(relationshipId))
+        .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
+        .then()
+        .onErrorResume(DomainException.class, ex -> ex.getErrorCode() == RelationshipErrorCode.NOT_FOUND
+            ? Mono.empty()
+            : Mono.error(ex));
   }
 
 }

--- a/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
+++ b/apps/backend/domain/src/main/java/com/schemafy/domain/erd/table/application/service/DeleteTableService.java
@@ -59,7 +59,7 @@ public class DeleteTableService implements DeleteTableUseCase {
                 .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                 .then())
             .then(Mono.defer(() -> deleteTablePort.deleteTable(tableId)))
-        .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
+            .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/application/service/DeleteTableServiceTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/application/service/DeleteTableServiceTest.java
@@ -1,6 +1,7 @@
 package com.schemafy.domain.erd.table.application.service;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.transaction.reactive.TransactionalOperator;
 
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.schemafy.domain.common.MutationResult;
 import com.schemafy.domain.common.exception.DomainException;
 import com.schemafy.domain.erd.column.application.port.in.DeleteColumnCommand;
 import com.schemafy.domain.erd.column.application.port.in.DeleteColumnUseCase;
@@ -20,6 +22,7 @@ import com.schemafy.domain.erd.column.fixture.ColumnFixture;
 import com.schemafy.domain.erd.relationship.application.port.in.DeleteRelationshipCommand;
 import com.schemafy.domain.erd.relationship.application.port.in.DeleteRelationshipUseCase;
 import com.schemafy.domain.erd.relationship.application.port.out.GetRelationshipsByTableIdPort;
+import com.schemafy.domain.erd.relationship.domain.exception.RelationshipErrorCode;
 import com.schemafy.domain.erd.relationship.fixture.RelationshipFixture;
 import com.schemafy.domain.erd.table.application.port.out.DeleteTablePort;
 import com.schemafy.domain.erd.table.application.port.out.GetTableByIdPort;
@@ -29,6 +32,7 @@ import com.schemafy.domain.erd.table.fixture.TableFixture;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -190,6 +194,86 @@ class DeleteTableServiceTest {
             .deleteColumn(eq(new DeleteColumnCommand(column2.id())));
         inOrderVerifier.verify(deleteTablePort)
             .deleteTable(command.tableId());
+      }
+
+      @Test
+      @DisplayName("초기 스냅샷의 관계가 cascade로 이미 삭제되었으면 건너뛰고 계속 삭제한다")
+      void ignoresRelationshipsAlreadyDeletedByCascade() {
+        var command = TableFixture.deleteCommand();
+        var relationship1 = RelationshipFixture.relationshipWithId("rel-1");
+        var relationship2 = RelationshipFixture.relationshipWithId("rel-2");
+        var column = ColumnFixture.defaultColumn();
+
+        given(getTableByIdPort.findTableById(command.tableId()))
+            .willReturn(Mono.just(TableFixture.tableWithId(command.tableId())));
+        given(getRelationshipsByTableIdPort.findRelationshipsByTableId(command.tableId()))
+            .willReturn(Mono.just(List.of(relationship1, relationship2)));
+        given(deleteRelationshipUseCase.deleteRelationship(new DeleteRelationshipCommand(relationship1.id())))
+            .willReturn(Mono.just(MutationResult.of(null, Set.of("cascade-table"))));
+        given(deleteRelationshipUseCase.deleteRelationship(new DeleteRelationshipCommand(relationship2.id())))
+            .willReturn(Mono.error(new DomainException(
+                RelationshipErrorCode.NOT_FOUND,
+                "Relationship not found: " + relationship2.id())));
+        given(getColumnsByTableIdPort.findColumnsByTableId(command.tableId()))
+            .willReturn(Mono.just(List.of(column)));
+        given(deleteColumnUseCase.deleteColumn(new DeleteColumnCommand(column.id())))
+            .willReturn(Mono.empty());
+        given(deleteTablePort.deleteTable(command.tableId()))
+            .willReturn(Mono.empty());
+        given(transactionalOperator.transactional(any(Mono.class)))
+            .willAnswer(invocation -> invocation.getArgument(0));
+
+        StepVerifier.create(sut.deleteTable(command))
+            .assertNext(result -> {
+              assertThat(result.affectedTableIds()).contains(command.tableId(), "cascade-table");
+              assertThat(result.affectedTableIds()).doesNotContain("stale-relationship-table");
+            })
+            .verifyComplete();
+
+        var inOrderVerifier = inOrder(
+            getRelationshipsByTableIdPort,
+            deleteRelationshipUseCase,
+            getColumnsByTableIdPort,
+            deleteColumnUseCase,
+            deleteTablePort);
+        inOrderVerifier.verify(getRelationshipsByTableIdPort)
+            .findRelationshipsByTableId(command.tableId());
+        inOrderVerifier.verify(deleteRelationshipUseCase)
+            .deleteRelationship(eq(new DeleteRelationshipCommand(relationship1.id())));
+        inOrderVerifier.verify(deleteRelationshipUseCase)
+            .deleteRelationship(eq(new DeleteRelationshipCommand(relationship2.id())));
+        inOrderVerifier.verify(getColumnsByTableIdPort)
+            .findColumnsByTableId(command.tableId());
+        inOrderVerifier.verify(deleteColumnUseCase)
+            .deleteColumn(eq(new DeleteColumnCommand(column.id())));
+        inOrderVerifier.verify(deleteTablePort)
+            .deleteTable(command.tableId());
+      }
+
+      @Test
+      @DisplayName("관계 삭제 중 NOT_FOUND 외 예외는 그대로 전파한다")
+      void propagatesUnexpectedRelationshipDeletionErrors() {
+        var command = TableFixture.deleteCommand();
+        var relationship = RelationshipFixture.relationshipWithId("rel-1");
+
+        given(getTableByIdPort.findTableById(command.tableId()))
+            .willReturn(Mono.just(TableFixture.tableWithId(command.tableId())));
+        given(getRelationshipsByTableIdPort.findRelationshipsByTableId(command.tableId()))
+            .willReturn(Mono.just(List.of(relationship)));
+        given(deleteRelationshipUseCase.deleteRelationship(new DeleteRelationshipCommand(relationship.id())))
+            .willReturn(Mono.error(new DomainException(
+                RelationshipErrorCode.INVALID_VALUE,
+                "Unexpected relationship deletion failure")));
+        given(transactionalOperator.transactional(any(Mono.class)))
+            .willAnswer(invocation -> invocation.getArgument(0));
+
+        StepVerifier.create(sut.deleteTable(command))
+            .expectErrorMatches(DomainException.hasErrorCode(RelationshipErrorCode.INVALID_VALUE))
+            .verify();
+
+        then(getColumnsByTableIdPort).shouldHaveNoInteractions();
+        then(deleteColumnUseCase).shouldHaveNoInteractions();
+        then(deleteTablePort).shouldHaveNoInteractions();
       }
 
       @Test

--- a/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/integration/DeleteTableIntegrationTest.java
+++ b/apps/backend/domain/src/test/java/com/schemafy/domain/erd/table/integration/DeleteTableIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.schemafy.domain.erd.table.integration;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -192,6 +193,149 @@ class DeleteTableIntegrationTest {
 
     }
 
+    @Nested
+    @DisplayName("다이아몬드 IDENTIFYING 관계가 있을 때")
+    class WithDiamondIdentifyingGraph {
+
+      private String parentTableId;
+      private String targetTableId;
+      private String childATableId;
+      private String childBTableId;
+      private String grandchildTableId;
+
+      @BeforeEach
+      void setUp() {
+        String schemaId = createSchema("table_delete_diamond");
+
+        parentTableId = createTable(schemaId, "parent_table");
+        targetTableId = createTable(schemaId, "target_table");
+        childATableId = createTable(schemaId, "child_a_table");
+        childBTableId = createTable(schemaId, "child_b_table");
+        grandchildTableId = createTable(schemaId, "grandchild_table");
+
+        String parentPkId = createColumn(parentTableId, "parent_id", "INT");
+        createPrimaryKey(parentTableId, "pk_parent_table", List.of(
+            new CreateConstraintColumnCommand(parentPkId, 0)));
+
+        String childAPkId = createColumn(childATableId, "child_a_id", "INT");
+        createPrimaryKey(childATableId, "pk_child_a_table", List.of(
+            new CreateConstraintColumnCommand(childAPkId, 0)));
+
+        String childBPkId = createColumn(childBTableId, "child_b_id", "INT");
+        createPrimaryKey(childBTableId, "pk_child_b_table", List.of(
+            new CreateConstraintColumnCommand(childBPkId, 0)));
+
+        String grandchildPkId = createColumn(grandchildTableId, "grandchild_id", "INT");
+        createPrimaryKey(grandchildTableId, "pk_grandchild_table", List.of(
+            new CreateConstraintColumnCommand(grandchildPkId, 0)));
+
+        createRelationship(targetTableId, parentTableId, RelationshipKind.IDENTIFYING);
+        createRelationship(childATableId, targetTableId, RelationshipKind.IDENTIFYING);
+        createRelationship(childBTableId, targetTableId, RelationshipKind.IDENTIFYING);
+        createRelationship(grandchildTableId, childATableId, RelationshipKind.IDENTIFYING);
+        createRelationship(grandchildTableId, childBTableId, RelationshipKind.IDENTIFYING);
+      }
+
+      @Test
+      @DisplayName("대상 테이블 삭제 시 이미 cascade 삭제된 관계가 있어도 완료된다")
+      void deletesTargetTableWhenRelationshipSnapshotBecomesStale() {
+        StepVerifier.create(deleteTableUseCase.deleteTable(new DeleteTableCommand(targetTableId)))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        StepVerifier.create(getTableUseCase.getTable(new GetTableQuery(targetTableId)))
+            .expectErrorMatches(DomainException.hasErrorCode(TableErrorCode.NOT_FOUND))
+            .verify();
+
+        StepVerifier.create(getTableUseCase.getTable(new GetTableQuery(parentTableId)))
+            .assertNext(table -> assertThat(table.id()).isEqualTo(parentTableId))
+            .verifyComplete();
+
+        StepVerifier.create(getRelationshipsByTableIdUseCase.getRelationshipsByTableId(
+            new GetRelationshipsByTableIdQuery(parentTableId)))
+            .assertNext(relationships -> assertThat(relationships).isEmpty())
+            .verifyComplete();
+
+        StepVerifier.create(getRelationshipsByTableIdUseCase.getRelationshipsByTableId(
+            new GetRelationshipsByTableIdQuery(childATableId)))
+            .assertNext(relationships -> assertThat(relationships)
+                .allMatch(relationship -> !relationship.fkTableId().equals(targetTableId)
+                    && !relationship.pkTableId().equals(targetTableId)))
+            .verifyComplete();
+
+        StepVerifier.create(getRelationshipsByTableIdUseCase.getRelationshipsByTableId(
+            new GetRelationshipsByTableIdQuery(childBTableId)))
+            .assertNext(relationships -> assertThat(relationships)
+                .allMatch(relationship -> !relationship.fkTableId().equals(targetTableId)
+                    && !relationship.pkTableId().equals(targetTableId)))
+            .verifyComplete();
+
+        StepVerifier.create(getColumnsByTableIdUseCase.getColumnsByTableId(
+            new GetColumnsByTableIdQuery(childATableId)))
+            .assertNext(columns -> assertThat(columns.stream().map(column -> column.name()).toList())
+                .contains("child_a_id")
+                .doesNotContain("parent_id"))
+            .verifyComplete();
+
+        StepVerifier.create(getColumnsByTableIdUseCase.getColumnsByTableId(
+            new GetColumnsByTableIdQuery(childBTableId)))
+            .assertNext(columns -> assertThat(columns.stream().map(column -> column.name()).toList())
+                .contains("child_b_id")
+                .doesNotContain("parent_id"))
+            .verifyComplete();
+
+        StepVerifier.create(getColumnsByTableIdUseCase.getColumnsByTableId(
+            new GetColumnsByTableIdQuery(grandchildTableId)))
+            .assertNext(columns -> assertThat(columns.stream().map(column -> column.name()).toList())
+                .contains("grandchild_id", "child_a_id", "child_b_id")
+                .doesNotContain("parent_id", "parent_id_1"))
+            .verifyComplete();
+      }
+
+    }
+
+  }
+
+  private String createSchema(String prefix) {
+    String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
+    var createSchemaCommand = new CreateSchemaCommand(
+        PROJECT_ID, "MySQL", prefix + "_" + uniqueSuffix,
+        "utf8mb4", "utf8mb4_general_ci");
+    var schemaResult = createSchemaUseCase.createSchema(createSchemaCommand).block().result();
+    return schemaResult.id();
+  }
+
+  private String createTable(String schemaId, String name) {
+    var createTableCommand = new CreateTableCommand(
+        schemaId, name, "utf8mb4", "utf8mb4_general_ci", null);
+    var tableResult = createTableUseCase.createTable(createTableCommand).block().result();
+    return tableResult.tableId();
+  }
+
+  private String createColumn(String tableId, String name, String dataType) {
+    var createColumnCommand = new CreateColumnCommand(
+        tableId, name, dataType, null, null, null, false, null, null, null);
+    var columnResult = createColumnUseCase.createColumn(createColumnCommand).block().result();
+    return columnResult.columnId();
+  }
+
+  private void createPrimaryKey(
+      String tableId,
+      String name,
+      List<CreateConstraintColumnCommand> columns) {
+    var createConstraintCommand = new CreateConstraintCommand(
+        tableId, name, ConstraintKind.PRIMARY_KEY, null, null, columns);
+    createConstraintUseCase.createConstraint(createConstraintCommand).block();
+  }
+
+  private void createRelationship(String fkTableId, String pkTableId, RelationshipKind kind) {
+    var createRelationshipCommand = new CreateRelationshipCommand(
+        fkTableId,
+        pkTableId,
+        kind,
+        Cardinality.ONE_TO_MANY,
+        null);
+    createRelationshipUseCase.createRelationship(createRelationshipCommand).block();
   }
 
 }


### PR DESCRIPTION
## 개요

- `DeleteTableService`가 초기 관계 스냅샷을 순회하는 동안, 앞선 식별 관계 cascade로 이미 삭제된 관계가 뒤에서 `NOT_FOUND`를 발생시키던 흐름 수정
- 테이블 삭제 플로우 내부에서만 `RelationshipErrorCode.NOT_FOUND`를 무시하고 계속 삭제하도록 처리해 직접 relationship 삭제 플로우는 유지
- stale relationship snapshot 회귀 단위 테스트 추가
- 다이아몬드 identifying graph에서 target table 삭제가 완료되는 통합 테스트 추가

## 이슈

- close #265
