### PR TITLE
fix(#267): email usage normalization

### DIFF
--- a/apps/backend/api/src/test/java/com/schemafy/api/user/controller/UserControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/user/controller/UserControllerTest.java
@@ -120,7 +120,7 @@ class UserControllerTest extends UserHttpTestSupport {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.id").isEqualTo(userBId)
-        .jsonPath("$.email").isEqualTo("userB@example.com");
+        .jsonPath("$.email").isEqualTo("userb@example.com");
   }
 
   @Test
@@ -140,7 +140,7 @@ class UserControllerTest extends UserHttpTestSupport {
   @Test
   @DisplayName("내 정보 조회에 성공한다")
   void getMyInfoSuccess() {
-    SignUpRequest signUpRequest = new SignUpRequest("test-me@example.com",
+    SignUpRequest signUpRequest = new SignUpRequest("TEST-ME@EXAMPLE.COM",
         "Test User Me", "password");
 
     EntityExchangeResult<byte[]> result = webTestClient.post()
@@ -165,7 +165,7 @@ class UserControllerTest extends UserHttpTestSupport {
             getUserResponseHeaders(),
             getUserResponse()))
         .jsonPath("$.id").isEqualTo(userId)
-        .jsonPath("$.email").isEqualTo(signUpRequest.email());
+        .jsonPath("$.email").isEqualTo("test-me@example.com");
   }
 
   @Test
@@ -246,7 +246,7 @@ class UserControllerTest extends UserHttpTestSupport {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.id").isEqualTo(userBId)
-        .jsonPath("$.email").isEqualTo("userB@example.com");
+        .jsonPath("$.email").isEqualTo("userb@example.com");
 
     // 사용자 B는 다른 API도 정상적으로 사용 가능
     webTestClient

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
@@ -14,6 +14,7 @@ import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
 import com.schemafy.core.project.domain.WorkspaceMember;
 import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+import com.schemafy.core.user.domain.Email;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -33,44 +34,45 @@ class AddWorkspaceMemberService implements AddWorkspaceMemberUseCase {
 
   @Override
   public Mono<WorkspaceMember> addWorkspaceMember(AddWorkspaceMemberCommand command) {
-    return workspaceAccessHelper.validateAdminAccess(command.workspaceId(),
-        command.requesterId())
-        .then(workspaceAccessHelper.findUserByEmailOrThrow(command.email()))
-        .flatMap(targetUser -> workspaceMemberPort
-            .findLatestByWorkspaceIdAndUserId(command.workspaceId(),
-                targetUser.id())
-            .flatMap(existing -> {
-              if (!existing.isDeleted()) {
-                log.warn("Member already exists and is active: memberId={}",
-                    existing.getId());
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .flatMap(email -> workspaceAccessHelper.validateAdminAccess(
+            command.workspaceId(), command.requesterId())
+            .then(workspaceAccessHelper.findUserByEmailOrThrow(email))
+            .flatMap(targetUser -> workspaceMemberPort
+                .findLatestByWorkspaceIdAndUserId(command.workspaceId(),
+                    targetUser.id())
+                .flatMap(existing -> {
+                  if (!existing.isDeleted()) {
+                    log.warn("Member already exists and is active: memberId={}",
+                        existing.getId());
+                    return Mono.error(new DomainException(
+                        WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
+                  }
+
+                  existing.restore();
+                  existing.updateRole(command.role());
+                  return workspaceMemberPort.save(existing);
+                })
+                .switchIfEmpty(Mono.defer(() -> Mono
+                    .fromCallable(ulidGeneratorPort::generate)
+                    .flatMap(id -> workspaceMemberPort
+                        .save(WorkspaceMember.create(id, command.workspaceId(),
+                            targetUser.id(), command.role()))))))
+            .flatMap(savedMember -> projectMembershipPropagationHelper
+                .propagateToExistingProjects(
+                    command.workspaceId(),
+                    savedMember.getUserId(),
+                    savedMember.getRoleAsEnum())
+                .thenReturn(savedMember))
+            .onErrorResume(error -> {
+              if (error instanceof DataIntegrityViolationException) {
+                log.warn("Duplicate key constraint: workspaceId={}, email={}",
+                    command.workspaceId(), email.address());
                 return Mono.error(new DomainException(
                     WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
               }
-
-              existing.restore();
-              existing.updateRole(command.role());
-              return workspaceMemberPort.save(existing);
-            })
-            .switchIfEmpty(Mono.defer(() -> Mono
-                .fromCallable(ulidGeneratorPort::generate)
-                .flatMap(id -> workspaceMemberPort
-                    .save(WorkspaceMember.create(id, command.workspaceId(),
-                        targetUser.id(), command.role()))))))
-        .flatMap(savedMember -> projectMembershipPropagationHelper
-            .propagateToExistingProjects(
-                command.workspaceId(),
-                savedMember.getUserId(),
-                savedMember.getRoleAsEnum())
-            .thenReturn(savedMember))
-        .onErrorResume(error -> {
-          if (error instanceof DataIntegrityViolationException) {
-            log.warn("Duplicate key constraint: workspaceId={}, email={}",
-                command.workspaceId(), command.email());
-            return Mono.error(new DomainException(
-                WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
-          }
-          return Mono.error(error);
-        })
+              return Mono.error(error);
+            }))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectInvitationService.java
@@ -8,6 +8,7 @@ import com.schemafy.core.project.application.port.in.CreateProjectInvitationUseC
 import com.schemafy.core.project.application.port.out.InvitationPort;
 import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+import com.schemafy.core.user.domain.Email;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -24,24 +25,24 @@ class CreateProjectInvitationService implements CreateProjectInvitationUseCase {
   @Override
   public Mono<Invitation> createProjectInvitation(
       CreateProjectInvitationCommand command) {
-    return projectInvitationHelper.validateProjectAdmin(command.projectId(),
-        command.requesterId())
-        .then(projectInvitationHelper.findProjectOrThrow(command.projectId()))
-        .flatMap(project -> projectInvitationHelper
-            .checkNotAlreadyProjectMemberByEmail(command.projectId(),
-                command.email())
-            .then(projectInvitationHelper.checkDuplicatePendingInvitation(
-                command.projectId(), command.email()))
-            .thenReturn(project))
-        .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
-            .flatMap(id -> invitationPort.save(
-                Invitation.createProjectInvitation(
-                    id,
-                    command.projectId(),
-                    project.getWorkspaceId(),
-                    command.email(),
-                    command.role(),
-                    command.requesterId()))))
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .flatMap(email -> projectInvitationHelper.validateProjectAdmin(
+            command.projectId(), command.requesterId())
+            .then(projectInvitationHelper.findProjectOrThrow(command.projectId()))
+            .flatMap(project -> projectInvitationHelper
+                .checkNotAlreadyProjectMemberByEmail(command.projectId(), email)
+                .then(projectInvitationHelper.checkDuplicatePendingInvitation(
+                    command.projectId(), email))
+                .thenReturn(project))
+            .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
+                .flatMap(id -> invitationPort.save(
+                    Invitation.createProjectInvitation(
+                        id,
+                        command.projectId(),
+                        project.getWorkspaceId(),
+                        email.address(),
+                        command.role(),
+                        command.requesterId())))))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationService.java
@@ -8,6 +8,7 @@ import com.schemafy.core.project.application.port.in.CreateWorkspaceInvitationUs
 import com.schemafy.core.project.application.port.out.InvitationPort;
 import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+import com.schemafy.core.user.domain.Email;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -25,24 +26,24 @@ class CreateWorkspaceInvitationService
   @Override
   public Mono<Invitation> createWorkspaceInvitation(
       CreateWorkspaceInvitationCommand command) {
-    return workspaceInvitationHelper.validateAdmin(command.workspaceId(),
-        command.requesterId())
-        .then(workspaceInvitationHelper.findWorkspaceOrThrow(
-            command.workspaceId()))
-        .flatMap(workspace -> workspaceInvitationHelper
-            .checkNotAlreadyMemberByEmail(command.workspaceId(),
-                command.email())
-            .then(workspaceInvitationHelper.checkDuplicatePendingInvitation(
-                command.workspaceId(), command.email()))
-            .thenReturn(workspace))
-        .flatMap(workspace -> Mono.fromCallable(ulidGeneratorPort::generate)
-            .flatMap(id -> invitationPort.save(
-                Invitation.createWorkspaceInvitation(
-                    id,
-                    command.workspaceId(),
-                    command.email(),
-                    command.role(),
-                    command.requesterId()))))
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .flatMap(email -> workspaceInvitationHelper.validateAdmin(
+            command.workspaceId(), command.requesterId())
+            .then(workspaceInvitationHelper.findWorkspaceOrThrow(
+                command.workspaceId()))
+            .flatMap(workspace -> workspaceInvitationHelper
+                .checkNotAlreadyMemberByEmail(command.workspaceId(), email)
+                .then(workspaceInvitationHelper.checkDuplicatePendingInvitation(
+                    command.workspaceId(), email))
+                .thenReturn(workspace))
+            .flatMap(workspace -> Mono.fromCallable(ulidGeneratorPort::generate)
+                .flatMap(id -> invitationPort.save(
+                    Invitation.createWorkspaceInvitation(
+                        id,
+                        command.workspaceId(),
+                        email.address(),
+                        command.role(),
+                        command.requesterId())))))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectInvitationHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectInvitationHelper.java
@@ -18,6 +18,7 @@ import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
 import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -62,16 +63,16 @@ class ProjectInvitationHelper {
         });
   }
 
-  Mono<Void> checkDuplicatePendingInvitation(String projectId, String email) {
+  Mono<Void> checkDuplicatePendingInvitation(String projectId, Email email) {
     return invitationPort.countByTargetAndEmailAndStatus(
         InvitationType.PROJECT.name(),
         projectId,
-        email,
+        email.address(),
         InvitationStatus.PENDING.name())
         .flatMap(count -> {
           if (count > 0) {
             log.warn("Duplicate pending invitation: project={}, email={}",
-                projectId, email);
+                projectId, email.address());
             return Mono.error(new DomainException(
                 ProjectErrorCode.INVITATION_ALREADY_EXISTS));
           }
@@ -91,8 +92,8 @@ class ProjectInvitationHelper {
         });
   }
 
-  Mono<Void> checkNotAlreadyProjectMemberByEmail(String projectId, String email) {
-    return findUserByEmailPort.findUserByEmail(email.toLowerCase())
+  Mono<Void> checkNotAlreadyProjectMemberByEmail(String projectId, Email email) {
+    return findUserByEmailPort.findUserByEmail(email.address())
         .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)))
         .flatMap(user -> projectMemberPort
             .existsByProjectIdAndUserIdAndNotDeleted(projectId, user.id())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
@@ -14,6 +14,7 @@ import com.schemafy.core.project.domain.WorkspaceMember;
 import com.schemafy.core.project.domain.WorkspaceRole;
 import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
@@ -29,8 +30,8 @@ class WorkspaceAccessHelper {
   private final ProjectPort projectPort;
   private final FindUserByEmailPort findUserByEmailPort;
 
-  Mono<User> findUserByEmailOrThrow(String email) {
-    return findUserByEmailPort.findUserByEmail(email.toLowerCase())
+  Mono<User> findUserByEmailOrThrow(Email email) {
+    return findUserByEmailPort.findUserByEmail(email.address())
         .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)));
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceInvitationHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceInvitationHelper.java
@@ -19,6 +19,7 @@ import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
 import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -63,16 +64,16 @@ class WorkspaceInvitationHelper {
         });
   }
 
-  Mono<Void> checkDuplicatePendingInvitation(String workspaceId, String email) {
+  Mono<Void> checkDuplicatePendingInvitation(String workspaceId, Email email) {
     return invitationPort.countByTargetAndEmailAndStatus(
         InvitationType.WORKSPACE.name(),
         workspaceId,
-        email,
+        email.address(),
         InvitationStatus.PENDING.name())
         .flatMap(count -> {
           if (count > 0) {
             log.warn("Duplicate pending invitation: workspace={}, email={}",
-                workspaceId, email);
+                workspaceId, email.address());
             return Mono.error(new DomainException(
                 ProjectErrorCode.INVITATION_ALREADY_EXISTS));
           }
@@ -92,8 +93,8 @@ class WorkspaceInvitationHelper {
         });
   }
 
-  Mono<Void> checkNotAlreadyMemberByEmail(String workspaceId, String email) {
-    return findUserByEmailPort.findUserByEmail(email.toLowerCase())
+  Mono<Void> checkNotAlreadyMemberByEmail(String workspaceId, Email email) {
+    return findUserByEmailPort.findUserByEmail(email.address())
         .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)))
         .flatMap(user -> workspaceMemberPort
             .existsByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, user.id())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/domain/Invitation.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/domain/Invitation.java
@@ -9,6 +9,7 @@ import org.springframework.data.relational.core.mapping.Table;
 import com.schemafy.core.common.BaseEntity;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.user.domain.Email;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -46,7 +47,7 @@ public class Invitation extends BaseEntity {
         InvitationType.WORKSPACE.name(),
         workspaceId,
         null,
-        invitedEmail.toLowerCase(),
+        Email.from(invitedEmail).address(),
         role.name(),
         invitedBy,
         InvitationStatus.PENDING.name(),
@@ -68,7 +69,7 @@ public class Invitation extends BaseEntity {
         InvitationType.PROJECT.name(),
         projectId,
         workspaceId,
-        invitedEmail.toLowerCase(),
+        Email.from(invitedEmail).address(),
         role.name(),
         invitedBy,
         InvitationStatus.PENDING.name(),
@@ -139,7 +140,7 @@ public class Invitation extends BaseEntity {
   }
 
   public void validateInvitedEmailMatches(String email) {
-    if (!this.invitedEmail.equals(email.toLowerCase())) {
+    if (!this.invitedEmail.equals(Email.from(email).address())) {
       throw new DomainException(ProjectErrorCode.INVITATION_EMAIL_MISMATCH);
     }
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/port/in/LoginOrSignUpOAuthCommand.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/port/in/LoginOrSignUpOAuthCommand.java
@@ -7,4 +7,9 @@ public record LoginOrSignUpOAuthCommand(
     String name,
     AuthProvider provider,
     String providerUserId) {
+
+  public LoginOrSignUpOAuthCommand withEmail(String email) {
+    return new LoginOrSignUpOAuthCommand(email, name, provider, providerUserId);
+  }
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/port/in/SignUpUserCommand.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/port/in/SignUpUserCommand.java
@@ -1,4 +1,9 @@
 package com.schemafy.core.user.application.port.in;
 
 public record SignUpUserCommand(String email, String name, String password) {
+
+  public SignUpUserCommand withEmail(String email) {
+    return new SignUpUserCommand(email, name, password);
+  }
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
@@ -14,9 +14,9 @@ import com.schemafy.core.user.application.port.out.CreateUserPort;
 import com.schemafy.core.user.application.port.out.FindUserAuthProviderPort;
 import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.UserAuthProvider;
-import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
@@ -45,15 +45,14 @@ class LoginOrSignUpOAuthService implements LoginOrSignUpOAuthUseCase {
               normalizedCommand.provider(), normalizedCommand.providerUserId())
               .flatMap(authProvider -> findUserByIdPort.findUserById(authProvider.userId()))
               .map(user -> new LoginOrSignUpOAuthResult(user, false))
-              .switchIfEmpty(linkOrCreateOAuthUser(normalizedCommand, email));
+              .switchIfEmpty(linkOrCreateOAuthUser(normalizedCommand));
         })
         .as(transactionalOperator::transactional);
   }
 
   private Mono<LoginOrSignUpOAuthResult> linkOrCreateOAuthUser(
-      LoginOrSignUpOAuthCommand command,
-      Email email) {
-    return findUserByEmailPort.findUserByEmail(email.address())
+      LoginOrSignUpOAuthCommand command) {
+    return findUserByEmailPort.findUserByEmail(command.email())
         .flatMap(existingUser -> linkExistingUserToOAuthIdempotent(existingUser, command)
             .map(linked -> new LoginOrSignUpOAuthResult(linked, false)))
         .switchIfEmpty(Mono.defer(() -> createOAuthUser(command)));

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthService.java
@@ -16,6 +16,7 @@ import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
 import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.UserAuthProvider;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -36,17 +37,23 @@ class LoginOrSignUpOAuthService implements LoginOrSignUpOAuthUseCase {
   @Override
   public Mono<LoginOrSignUpOAuthResult> loginOrSignUpOAuth(
       LoginOrSignUpOAuthCommand command) {
-    return findUserAuthProviderPort.findUserAuthProvider(
-        command.provider(), command.providerUserId())
-        .flatMap(authProvider -> findUserByIdPort.findUserById(authProvider.userId()))
-        .map(user -> new LoginOrSignUpOAuthResult(user, false))
-        .switchIfEmpty(linkOrCreateOAuthUser(command))
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .flatMap(email -> {
+          LoginOrSignUpOAuthCommand normalizedCommand = command.withEmail(
+              email.address());
+          return findUserAuthProviderPort.findUserAuthProvider(
+              normalizedCommand.provider(), normalizedCommand.providerUserId())
+              .flatMap(authProvider -> findUserByIdPort.findUserById(authProvider.userId()))
+              .map(user -> new LoginOrSignUpOAuthResult(user, false))
+              .switchIfEmpty(linkOrCreateOAuthUser(normalizedCommand, email));
+        })
         .as(transactionalOperator::transactional);
   }
 
   private Mono<LoginOrSignUpOAuthResult> linkOrCreateOAuthUser(
-      LoginOrSignUpOAuthCommand command) {
-    return findUserByEmailPort.findUserByEmail(command.email())
+      LoginOrSignUpOAuthCommand command,
+      Email email) {
+    return findUserByEmailPort.findUserByEmail(email.address())
         .flatMap(existingUser -> linkExistingUserToOAuthIdempotent(existingUser, command)
             .map(linked -> new LoginOrSignUpOAuthResult(linked, false)))
         .switchIfEmpty(Mono.defer(() -> createOAuthUser(command)));

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginUserService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/LoginUserService.java
@@ -7,6 +7,7 @@ import com.schemafy.core.user.application.port.in.LoginUserCommand;
 import com.schemafy.core.user.application.port.in.LoginUserUseCase;
 import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
 import com.schemafy.core.user.application.port.out.PasswordHashPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
@@ -22,17 +23,18 @@ class LoginUserService implements LoginUserUseCase {
 
   @Override
   public Mono<User> loginUser(LoginUserCommand command) {
-    return findUserByEmailPort.findUserByEmail(command.email())
-        .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)))
-        .flatMap(user -> {
-          if (user.password() == null) {
-            return Mono.error(new DomainException(UserErrorCode.LOGIN_FAILED));
-          }
-          return passwordHashPort.matches(command.password(), user.password())
-              .filter(Boolean::booleanValue)
-              .map(matches -> user)
-              .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.LOGIN_FAILED)));
-        });
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .flatMap(email -> findUserByEmailPort.findUserByEmail(email.address())
+            .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)))
+            .flatMap(user -> {
+              if (user.password() == null) {
+                return Mono.error(new DomainException(UserErrorCode.LOGIN_FAILED));
+              }
+              return passwordHashPort.matches(command.password(), user.password())
+                  .filter(Boolean::booleanValue)
+                  .map(matches -> user)
+                  .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.LOGIN_FAILED)));
+            }));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/SignUpUserService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/application/service/SignUpUserService.java
@@ -11,6 +11,7 @@ import com.schemafy.core.user.application.port.in.SignUpUserUseCase;
 import com.schemafy.core.user.application.port.out.CreateUserPort;
 import com.schemafy.core.user.application.port.out.ExistsUserByEmailPort;
 import com.schemafy.core.user.application.port.out.PasswordHashPort;
+import com.schemafy.core.user.domain.Email;
 import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
@@ -29,10 +30,13 @@ class SignUpUserService implements SignUpUserUseCase {
 
   @Override
   public Mono<User> signUpUser(SignUpUserCommand command) {
-    return existsUserByEmailPort.existsUserByEmail(command.email())
-        .flatMap(exists -> exists
-            ? Mono.error(new DomainException(UserErrorCode.ALREADY_EXISTS))
-            : createNewUser(command))
+    return Mono.fromSupplier(() -> Email.from(command.email()))
+        .map(email -> command.withEmail(email.address()))
+        .flatMap(normalizedCommand -> existsUserByEmailPort
+            .existsUserByEmail(normalizedCommand.email())
+            .flatMap(exists -> exists
+                ? Mono.error(new DomainException(UserErrorCode.ALREADY_EXISTS))
+                : createNewUser(normalizedCommand)))
         .onErrorMap(DuplicateKeyException.class,
             e -> new DomainException(UserErrorCode.ALREADY_EXISTS))
         .as(transactionalOperator::transactional);

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/domain/Email.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/domain/Email.java
@@ -1,0 +1,24 @@
+package com.schemafy.core.user.domain;
+
+import java.util.Locale;
+
+public record Email(String address) {
+
+  public static Email from(String address) {
+    return new Email(address);
+  }
+
+  public Email {
+    address = normalizeAddress(address);
+
+    if (address == null
+        || !address.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+      throw new IllegalArgumentException("Invalid email format");
+    }
+  }
+
+  private static String normalizeAddress(String address) {
+    return address == null ? null : address.toLowerCase(Locale.ROOT);
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/domain/Email.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/domain/Email.java
@@ -12,7 +12,7 @@ public record Email(String address) {
     address = normalizeAddress(address);
 
     if (address == null
-        || !address.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+        || !address.matches("^[a-z0-9+_.-]+@[a-z0-9.-]+$")) {
       throw new IllegalArgumentException("Invalid email format");
     }
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/domain/User.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/domain/User.java
@@ -1,14 +1,11 @@
 package com.schemafy.core.user.domain;
 
 import java.time.Instant;
-
 public record User(String id, String email, String name, String password, UserStatus status, Instant createdAt,
     Instant updatedAt, Instant deletedAt) {
 
-  private static final String EMAIL_REGEX = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
-
   public User {
-    validateEmail(email);
+    email = Email.from(email).address();
   }
 
   public static User signUp(
@@ -40,12 +37,6 @@ public record User(String id, String email, String name, String password, UserSt
         null,
         null,
         null);
-  }
-
-  private static void validateEmail(String email) {
-    if (email == null || !email.matches(EMAIL_REGEX)) {
-      throw new IllegalArgumentException("Invalid email format");
-    }
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/domain/User.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.schemafy.core.user.domain;
 
 import java.time.Instant;
+
 public record User(String id, String email, String name, String password, UserStatus status, Instant createdAt,
     Instant updatedAt, Instant deletedAt) {
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
@@ -98,6 +98,30 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   }
 
   @Test
+  @DisplayName("createProjectInvitation treats uppercase duplicate email as the same invitation")
+  void createProjectInvitation_duplicatePending_caseInsensitive() {
+    User admin = signUpUser("admin-pi-case@test.com", "Admin");
+    User invitee = signUpUser("invitee-pi-case@test.com", "Invitee");
+    var workspace = saveWorkspace("Case Project WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, invitee, WorkspaceRole.MEMBER);
+    var project = saveProject(workspace, "Case Project");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+
+    createProjectInvitationUseCase.createProjectInvitation(
+        new CreateProjectInvitationCommand(project.getId(), invitee.email(),
+            ProjectRole.EDITOR, admin.id()))
+        .block();
+
+    StepVerifier.create(createProjectInvitationUseCase.createProjectInvitation(
+        new CreateProjectInvitationCommand(project.getId(), "INVITEE-PI-CASE@TEST.COM",
+            ProjectRole.EDITOR, admin.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(
+            ProjectErrorCode.INVITATION_ALREADY_EXISTS))
+        .verify();
+  }
+
+  @Test
   @DisplayName("acceptProjectInvitation restores soft-deleted membership and cancels siblings")
   void acceptProjectInvitation_restoresMembership() {
     User admin = signUpUser("admin-pi-restore@test.com", "Admin");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
@@ -29,7 +29,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Project invitation usecase integration")
+@DisplayName("프로젝트 초대 유스케이스 통합 테스트")
 class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
   @Autowired
@@ -48,7 +48,7 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   private RejectProjectInvitationUseCase rejectProjectInvitationUseCase;
 
   @Test
-  @DisplayName("createProjectInvitation is visible in target and my invitation lists")
+  @DisplayName("프로젝트 초대 생성 후 대상 목록과 내 초대 목록에서 모두 조회된다")
   void createProjectInvitation_listsForAdminAndInvitee() {
     User admin = signUpUser("admin-pi@test.com", "Admin");
     User invitee = signUpUser("invitee-pi@test.com", "Invitee");
@@ -78,7 +78,7 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   }
 
   @Test
-  @DisplayName("createProjectInvitation rejects users who are already project members")
+  @DisplayName("프로젝트 초대 생성 시 이미 프로젝트 멤버인 사용자는 거부한다")
   void createProjectInvitation_rejectsDuplicateMembership() {
     User admin = signUpUser("admin-pi-dup@test.com", "Admin");
     User invitee = signUpUser("invitee-pi-dup@test.com", "Invitee");
@@ -98,7 +98,7 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   }
 
   @Test
-  @DisplayName("createProjectInvitation treats uppercase duplicate email as the same invitation")
+  @DisplayName("프로젝트 초대 생성 시 대문자 중복 이메일도 같은 초대로 처리한다")
   void createProjectInvitation_duplicatePending_caseInsensitive() {
     User admin = signUpUser("admin-pi-case@test.com", "Admin");
     User invitee = signUpUser("invitee-pi-case@test.com", "Invitee");
@@ -122,7 +122,7 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   }
 
   @Test
-  @DisplayName("acceptProjectInvitation restores soft-deleted membership and cancels siblings")
+  @DisplayName("프로젝트 초대 수락 시 soft delete 된 멤버십을 복원하고 형제 초대를 취소한다")
   void acceptProjectInvitation_restoresMembership() {
     User admin = signUpUser("admin-pi-restore@test.com", "Admin");
     User invitee = signUpUser("invitee-pi-restore@test.com", "Invitee");
@@ -152,7 +152,7 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
   }
 
   @Test
-  @DisplayName("rejectProjectInvitation marks invitation as rejected")
+  @DisplayName("프로젝트 초대 거절 시 초대 상태를 rejected로 바꾼다")
   void rejectProjectInvitation_marksResolved() {
     User admin = signUpUser("admin-pi-reject@test.com", "Admin");
     User invitee = signUpUser("invitee-pi-reject@test.com", "Invitee");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
@@ -31,7 +31,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Workspace invitation usecase integration")
+@DisplayName("워크스페이스 초대 유스케이스 통합 테스트")
 class WorkspaceInvitationUseCaseIntegrationTest
     extends ProjectDomainIntegrationSupport {
 
@@ -51,7 +51,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   private RejectWorkspaceInvitationUseCase rejectWorkspaceInvitationUseCase;
 
   @Test
-  @DisplayName("createWorkspaceInvitation is visible in target and my invitation lists")
+  @DisplayName("워크스페이스 초대 생성 후 대상 목록과 내 초대 목록에서 모두 조회된다")
   void createWorkspaceInvitation_listsForAdminAndInvitee() {
     User admin = signUpUser("admin-wi@test.com", "Admin");
     User invitee = signUpUser("invitee-wi@test.com", "Invitee");
@@ -78,7 +78,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
-  @DisplayName("createWorkspaceInvitation rejects unregistered emails")
+  @DisplayName("워크스페이스 초대 생성 시 미등록 이메일은 거부한다")
   void createWorkspaceInvitation_rejectsUnknownUser() {
     User admin = signUpUser("admin-wi-missing@test.com", "Admin");
     var workspace = saveWorkspace("Missing WS", "Description");
@@ -92,7 +92,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
-  @DisplayName("createWorkspaceInvitation treats uppercase duplicate email as the same invitation")
+  @DisplayName("워크스페이스 초대 생성 시 대문자 중복 이메일도 같은 초대로 처리한다")
   void createWorkspaceInvitation_duplicatePending_caseInsensitive() {
     User admin = signUpUser("admin-wi-case@test.com", "Admin");
     User invitee = signUpUser("invitee-wi-case@test.com", "Invitee");
@@ -113,7 +113,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
-  @DisplayName("acceptWorkspaceInvitation restores soft-deleted workspace and project memberships")
+  @DisplayName("워크스페이스 초대 수락 시 soft delete 된 워크스페이스와 프로젝트 멤버십을 복원한다")
   void acceptWorkspaceInvitation_restoresMemberships() {
     User admin = signUpUser("admin-wi-restore@test.com", "Admin");
     User invitee = signUpUser("invitee-wi-restore@test.com", "Invitee");
@@ -150,7 +150,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
-  @DisplayName("rejectWorkspaceInvitation marks invitation as rejected")
+  @DisplayName("워크스페이스 초대 거절 시 초대 상태를 rejected로 바꾼다")
   void rejectWorkspaceInvitation_marksResolved() {
     User admin = signUpUser("admin-wi-reject@test.com", "Admin");
     User invitee = signUpUser("invitee-wi-reject@test.com", "Invitee");
@@ -169,7 +169,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
-  @DisplayName("rejectWorkspaceInvitation rejects type-mismatched invitations")
+  @DisplayName("워크스페이스 초대 거절 시 타입이 다른 초대는 거부한다")
   void rejectWorkspaceInvitation_rejectsTypeMismatch() {
     User admin = signUpUser("admin-wi-type@test.com", "Admin");
     User invitee = signUpUser("invitee-wi-type@test.com", "Invitee");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
@@ -92,6 +92,27 @@ class WorkspaceInvitationUseCaseIntegrationTest
   }
 
   @Test
+  @DisplayName("createWorkspaceInvitation treats uppercase duplicate email as the same invitation")
+  void createWorkspaceInvitation_duplicatePending_caseInsensitive() {
+    User admin = signUpUser("admin-wi-case@test.com", "Admin");
+    User invitee = signUpUser("invitee-wi-case@test.com", "Invitee");
+    var workspace = saveWorkspace("Case WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+
+    createWorkspaceInvitationUseCase.createWorkspaceInvitation(
+        new CreateWorkspaceInvitationCommand(workspace.getId(), invitee.email(),
+            WorkspaceRole.MEMBER, admin.id()))
+        .block();
+
+    StepVerifier.create(createWorkspaceInvitationUseCase.createWorkspaceInvitation(
+        new CreateWorkspaceInvitationCommand(workspace.getId(), "INVITEE-WI-CASE@TEST.COM",
+            WorkspaceRole.MEMBER, admin.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(
+            ProjectErrorCode.INVITATION_ALREADY_EXISTS))
+        .verify();
+  }
+
+  @Test
   @DisplayName("acceptWorkspaceInvitation restores soft-deleted workspace and project memberships")
   void acceptWorkspaceInvitation_restoresMemberships() {
     User admin = signUpUser("admin-wi-restore@test.com", "Admin");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
@@ -143,6 +143,23 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
+  @DisplayName("addWorkspaceMember normalizes uppercase email input")
+  void addWorkspaceMember_normalizesUppercaseEmail() {
+    User admin = signUpUser("admin-upper@test.com", "Admin");
+    User target = signUpUser("target-upper@test.com", "Target");
+    Workspace workspace = saveWorkspace("Upper WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+
+    WorkspaceMember addedMember = addWorkspaceMemberUseCase.addWorkspaceMember(
+        new AddWorkspaceMemberCommand(workspace.getId(), "TARGET-UPPER@TEST.COM",
+            WorkspaceRole.MEMBER, admin.id()))
+        .block();
+
+    assertThat(addedMember).isNotNull();
+    assertThat(addedMember.getUserId()).isEqualTo(target.id());
+  }
+
+  @Test
   @DisplayName("updateWorkspaceMemberRole downgrades workspace role but preserves project editor role")
   void updateWorkspaceMemberRole_preservesEditorMembership() {
     User requester = signUpUser("requester-role@test.com", "Requester");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
@@ -31,7 +31,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Workspace usecase integration")
+@DisplayName("워크스페이스 유스케이스 통합 테스트")
 class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
   @Autowired
@@ -50,7 +50,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   private LeaveWorkspaceUseCase leaveWorkspaceUseCase;
 
   @Test
-  @DisplayName("createWorkspace creates workspace detail and admin membership")
+  @DisplayName("워크스페이스 생성 시 상세 정보와 관리자 멤버십을 함께 만든다")
   void createWorkspace_createsAdminMembership() {
     User admin = signUpUser("admin-workspace@test.com", "Admin");
 
@@ -71,7 +71,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("deleteWorkspace soft-deletes projects, memberships, invitations, and share links")
+  @DisplayName("워크스페이스 삭제 시 프로젝트, 멤버십, 초대, 공유 링크를 soft delete 한다")
   void deleteWorkspace_cascadesRelatedRows() {
     User admin = signUpUser("admin-delete@test.com", "Admin");
     User invitee = signUpUser("invitee-delete@test.com", "Invitee");
@@ -111,7 +111,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("addWorkspaceMember restores deleted member and project membership")
+  @DisplayName("워크스페이스 멤버 추가 시 삭제된 멤버와 프로젝트 멤버십을 복원한다")
   void addWorkspaceMember_restoresDeletedRows() {
     User admin = signUpUser("admin-add@test.com", "Admin");
     User target = signUpUser("target-add@test.com", "Target");
@@ -143,7 +143,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("addWorkspaceMember normalizes uppercase email input")
+  @DisplayName("워크스페이스 멤버 추가 시 대문자 이메일 입력을 정규화한다")
   void addWorkspaceMember_normalizesUppercaseEmail() {
     User admin = signUpUser("admin-upper@test.com", "Admin");
     User target = signUpUser("target-upper@test.com", "Target");
@@ -160,7 +160,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("updateWorkspaceMemberRole downgrades workspace role but preserves project editor role")
+  @DisplayName("워크스페이스 역할을 낮춰도 프로젝트 편집자 역할은 유지한다")
   void updateWorkspaceMemberRole_preservesEditorMembership() {
     User requester = signUpUser("requester-role@test.com", "Requester");
     User target = signUpUser("target-role@test.com", "Target");
@@ -185,7 +185,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("leaveWorkspace deletes workspace when last member leaves even with project-only members")
+  @DisplayName("마지막 워크스페이스 멤버가 나가면 프로젝트 전용 멤버가 있어도 워크스페이스를 삭제한다")
   void leaveWorkspace_lastMemberDeletesWorkspace() {
     User admin = signUpUser("admin-leave@test.com", "Admin");
     User outsider = signUpUser("outsider-leave@test.com", "Outsider");
@@ -206,7 +206,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("leaveWorkspace rejects last admin leaving when other members still exist")
+  @DisplayName("다른 멤버가 남아 있으면 마지막 관리자의 탈퇴를 거부한다")
   void leaveWorkspace_lastAdminCannotLeave() {
     User admin = signUpUser("admin-guard@test.com", "Admin");
     User member = signUpUser("member-guard@test.com", "Member");

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthServiceTest.java
@@ -141,6 +141,43 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
+  @DisplayName("loginOrSignUpOAuth: 대문자 이메일도 기존 유저에 자동 연동한다")
+  void loginOrSignUpOAuth_linkExistingUser_caseInsensitiveEmail() {
+    LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
+        "EXISTING@EXAMPLE.COM",
+        "Existing User",
+        AuthProvider.GITHUB,
+        "github-case");
+
+    User existing = new User(
+        "user-1",
+        "existing@example.com",
+        "Existing User",
+        "encoded",
+        UserStatus.ACTIVE,
+        null,
+        null,
+        null);
+
+    given(findUserAuthProviderPort.findUserAuthProvider(AuthProvider.GITHUB, "github-case"))
+        .willReturn(Mono.<UserAuthProvider>empty());
+    given(findUserByEmailPort.findUserByEmail("existing@example.com"))
+        .willReturn(Mono.just(existing));
+    given(ulidGeneratorPort.generate()).willReturn("provider-case");
+    given(createUserAuthProviderPort.createUserAuthProvider(any(UserAuthProvider.class)))
+        .willAnswer(
+            invocation -> Mono.just(invocation.getArgument(0, UserAuthProvider.class)));
+
+    StepVerifier.create(sut.loginOrSignUpOAuth(command))
+        .assertNext(result -> {
+          assertThat(result.newUser()).isFalse();
+          assertThat(result.user().id()).isEqualTo("user-1");
+          assertThat(result.user().email()).isEqualTo("existing@example.com");
+        })
+        .verifyComplete();
+  }
+
+  @Test
   @DisplayName("loginOrSignUpOAuth: 자동 연동 중 provider 중복이면 재조회로 복구한다")
   void loginOrSignUpOAuth_duplicateProviderDuringAutoLink_resolvesByReread() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginOrSignUpOAuthServiceTest.java
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("LoginOrSignUpOAuthService")
+@DisplayName("OAuth 로그인 또는 회원가입 서비스")
 class LoginOrSignUpOAuthServiceTest {
 
   @Mock
@@ -67,7 +67,7 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
-  @DisplayName("loginOrSignUpOAuth: 신규 OAuth 유저를 생성한다")
+  @DisplayName("OAuth 로그인 또는 회원가입 시 신규 유저를 생성한다")
   void loginOrSignUpOAuth_newUser() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
         "oauth@example.com",
@@ -105,7 +105,7 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
-  @DisplayName("loginOrSignUpOAuth: 같은 이메일의 기존 유저를 자동 연동한다")
+  @DisplayName("OAuth 로그인 또는 회원가입 시 같은 이메일의 기존 유저를 자동 연동한다")
   void loginOrSignUpOAuth_linkExistingUser() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
         "existing@example.com",
@@ -141,7 +141,7 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
-  @DisplayName("loginOrSignUpOAuth: 대문자 이메일도 기존 유저에 자동 연동한다")
+  @DisplayName("OAuth 로그인 또는 회원가입 시 대문자 이메일도 기존 유저에 자동 연동한다")
   void loginOrSignUpOAuth_linkExistingUser_caseInsensitiveEmail() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
         "EXISTING@EXAMPLE.COM",
@@ -178,7 +178,7 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
-  @DisplayName("loginOrSignUpOAuth: 자동 연동 중 provider 중복이면 재조회로 복구한다")
+  @DisplayName("OAuth 자동 연동 중 provider 중복이면 재조회로 복구한다")
   void loginOrSignUpOAuth_duplicateProviderDuringAutoLink_resolvesByReread() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
         "existing@example.com",
@@ -225,7 +225,7 @@ class LoginOrSignUpOAuthServiceTest {
   }
 
   @Test
-  @DisplayName("loginOrSignUpOAuth: OAuth 유저 생성 중 이메일 중복이면 ALREADY_EXISTS")
+  @DisplayName("OAuth 유저 생성 중 이메일이 중복이면 ALREADY_EXISTS를 반환한다")
   void loginOrSignUpOAuth_duplicateEmailDuringCreate_mapsAlreadyExists() {
     LoginOrSignUpOAuthCommand command = new LoginOrSignUpOAuthCommand(
         "oauth@example.com",

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginUserServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginUserServiceTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("LoginUserService")
+@DisplayName("로그인 유저 서비스")
 class LoginUserServiceTest {
 
   @Mock
@@ -35,7 +35,7 @@ class LoginUserServiceTest {
   LoginUserService sut;
 
   @Test
-  @DisplayName("loginUser: 이메일/비밀번호가 맞으면 로그인 성공")
+  @DisplayName("로그인 시 이메일과 비밀번호가 맞으면 성공한다")
   void loginUser_success() {
     LoginUserCommand command = new LoginUserCommand("test@example.com", "raw");
     User user = new User(
@@ -59,7 +59,7 @@ class LoginUserServiceTest {
   }
 
   @Test
-  @DisplayName("loginUser: 대문자 이메일 입력도 로그인 성공")
+  @DisplayName("로그인 시 대문자 이메일 입력도 성공한다")
   void loginUser_success_caseInsensitiveEmail() {
     LoginUserCommand command = new LoginUserCommand("TEST@EXAMPLE.COM", "raw");
     User user = new User(
@@ -83,7 +83,7 @@ class LoginUserServiceTest {
   }
 
   @Test
-  @DisplayName("loginUser: 이메일이 없으면 NOT_FOUND")
+  @DisplayName("로그인 시 이메일이 없으면 NOT_FOUND를 반환한다")
   void loginUser_notFound() {
     LoginUserCommand command = new LoginUserCommand("none@example.com", "raw");
 
@@ -100,7 +100,7 @@ class LoginUserServiceTest {
   }
 
   @Test
-  @DisplayName("loginUser: 비밀번호가 틀리면 LOGIN_FAILED")
+  @DisplayName("로그인 시 비밀번호가 틀리면 LOGIN_FAILED를 반환한다")
   void loginUser_passwordMismatch() {
     LoginUserCommand command = new LoginUserCommand("test@example.com", "raw");
     User user = new User(
@@ -128,7 +128,7 @@ class LoginUserServiceTest {
   }
 
   @Test
-  @DisplayName("loginUser: 잘못된 이메일 형식은 reactive error로 반환한다")
+  @DisplayName("로그인 시 잘못된 이메일 형식은 reactive error로 반환한다")
   void loginUser_invalidEmailFormat_returnsReactiveError() {
     LoginUserCommand command = new LoginUserCommand("invalid-email", "raw");
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginUserServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/LoginUserServiceTest.java
@@ -59,6 +59,30 @@ class LoginUserServiceTest {
   }
 
   @Test
+  @DisplayName("loginUser: 대문자 이메일 입력도 로그인 성공")
+  void loginUser_success_caseInsensitiveEmail() {
+    LoginUserCommand command = new LoginUserCommand("TEST@EXAMPLE.COM", "raw");
+    User user = new User(
+        "user-1",
+        "test@example.com",
+        "Tester",
+        "encoded",
+        UserStatus.ACTIVE,
+        null,
+        null,
+        null);
+
+    given(findUserByEmailPort.findUserByEmail("test@example.com"))
+        .willReturn(Mono.just(user));
+    given(passwordHashPort.matches("raw", "encoded"))
+        .willReturn(Mono.just(true));
+
+    StepVerifier.create(sut.loginUser(command))
+        .assertNext(found -> assertThat(found.email()).isEqualTo("test@example.com"))
+        .verifyComplete();
+  }
+
+  @Test
   @DisplayName("loginUser: 이메일이 없으면 NOT_FOUND")
   void loginUser_notFound() {
     LoginUserCommand command = new LoginUserCommand("none@example.com", "raw");
@@ -100,6 +124,16 @@ class LoginUserServiceTest {
           assertThat(((DomainException) error).getErrorCode())
               .isEqualTo(UserErrorCode.LOGIN_FAILED);
         })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("loginUser: 잘못된 이메일 형식은 reactive error로 반환한다")
+  void loginUser_invalidEmailFormat_returnsReactiveError() {
+    LoginUserCommand command = new LoginUserCommand("invalid-email", "raw");
+
+    StepVerifier.create(sut.loginUser(command))
+        .expectError(IllegalArgumentException.class)
         .verify();
   }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/SignUpUserServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/SignUpUserServiceTest.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("SignUpUserService")
+@DisplayName("회원가입 유저 서비스")
 class SignUpUserServiceTest {
 
   @Mock
@@ -56,7 +56,7 @@ class SignUpUserServiceTest {
   }
 
   @Test
-  @DisplayName("signUpUser: 신규 유저를 생성한다")
+  @DisplayName("회원가입 시 신규 유저를 생성한다")
   void signUpUser_success() {
     SignUpUserCommand command = new SignUpUserCommand(
         "test@example.com",
@@ -81,7 +81,7 @@ class SignUpUserServiceTest {
   }
 
   @Test
-  @DisplayName("signUpUser: 이메일을 소문자로 정규화해 저장한다")
+  @DisplayName("회원가입 시 이메일을 소문자로 정규화해 저장한다")
   void signUpUser_normalizesUppercaseEmail() {
     SignUpUserCommand command = new SignUpUserCommand(
         "TEST@EXAMPLE.COM",
@@ -101,7 +101,7 @@ class SignUpUserServiceTest {
   }
 
   @Test
-  @DisplayName("signUpUser: 이미 존재하는 이메일이면 ALREADY_EXISTS를 반환한다")
+  @DisplayName("회원가입 시 이미 존재하는 이메일이면 ALREADY_EXISTS를 반환한다")
   void signUpUser_alreadyExists() {
     SignUpUserCommand command = new SignUpUserCommand(
         "test@example.com",
@@ -121,7 +121,7 @@ class SignUpUserServiceTest {
   }
 
   @Test
-  @DisplayName("signUpUser: 대소문자가 달라도 중복 이메일로 처리한다")
+  @DisplayName("회원가입 시 대소문자가 달라도 중복 이메일로 처리한다")
   void signUpUser_alreadyExists_caseInsensitive() {
     SignUpUserCommand command = new SignUpUserCommand(
         "TEST@EXAMPLE.COM",
@@ -141,7 +141,7 @@ class SignUpUserServiceTest {
   }
 
   @Test
-  @DisplayName("signUpUser: 저장 시 unique 충돌이면 ALREADY_EXISTS로 매핑한다")
+  @DisplayName("회원가입 저장 시 unique 충돌이면 ALREADY_EXISTS로 매핑한다")
   void signUpUser_duplicateKey_mapsAlreadyExists() {
     SignUpUserCommand command = new SignUpUserCommand(
         "test@example.com",

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/SignUpUserServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/application/service/SignUpUserServiceTest.java
@@ -81,10 +81,50 @@ class SignUpUserServiceTest {
   }
 
   @Test
+  @DisplayName("signUpUser: 이메일을 소문자로 정규화해 저장한다")
+  void signUpUser_normalizesUppercaseEmail() {
+    SignUpUserCommand command = new SignUpUserCommand(
+        "TEST@EXAMPLE.COM",
+        "Tester",
+        "password");
+
+    given(existsUserByEmailPort.existsUserByEmail("test@example.com"))
+        .willReturn(Mono.just(false));
+    given(ulidGeneratorPort.generate()).willReturn("user-1");
+    given(passwordHashPort.hash("password")).willReturn(Mono.just("encoded"));
+    given(createUserPort.createUser(any(User.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0, User.class)));
+
+    StepVerifier.create(sut.signUpUser(command))
+        .assertNext(user -> assertThat(user.email()).isEqualTo("test@example.com"))
+        .verifyComplete();
+  }
+
+  @Test
   @DisplayName("signUpUser: 이미 존재하는 이메일이면 ALREADY_EXISTS를 반환한다")
   void signUpUser_alreadyExists() {
     SignUpUserCommand command = new SignUpUserCommand(
         "test@example.com",
+        "Tester",
+        "password");
+
+    given(existsUserByEmailPort.existsUserByEmail("test@example.com"))
+        .willReturn(Mono.just(true));
+
+    StepVerifier.create(sut.signUpUser(command))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(UserErrorCode.ALREADY_EXISTS);
+        })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("signUpUser: 대소문자가 달라도 중복 이메일로 처리한다")
+  void signUpUser_alreadyExists_caseInsensitive() {
+    SignUpUserCommand command = new SignUpUserCommand(
+        "TEST@EXAMPLE.COM",
         "Tester",
         "password");
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/domain/EmailTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/domain/EmailTest.java
@@ -1,0 +1,28 @@
+package com.schemafy.core.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Email")
+class EmailTest {
+
+  @Test
+  @DisplayName("대문자 이메일을 소문자로 정규화한다")
+  void createsNormalizedLowercaseEmail() {
+    Email email = Email.from("USER@EXAMPLE.COM");
+
+    assertThat(email.address()).isEqualTo("user@example.com");
+  }
+
+  @Test
+  @DisplayName("잘못된 이메일 형식이면 예외를 던진다")
+  void rejectsInvalidEmailFormat() {
+    assertThatThrownBy(() -> Email.from("invalid-email"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid email format");
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/domain/EmailTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/domain/EmailTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("Email")
+@DisplayName("이메일 값 객체")
 class EmailTest {
 
   @Test


### PR DESCRIPTION
## 개요
as-is: 이메일 string 값에 대한 전처리가 controller 레이어에만 존재 -> service layer 하위에서도 해당 값에 대한 처리가 필요하다고 판단
Email VO를 통해 해당 내용 개선. 관련 테스트 케이스 추가
## 이슈


- close #267