### PR TITLE
refactor(#314): remove Domain prefix from core persistence repositories

### DIFF
--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/PublicShareLinkControllerResilienceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/PublicShareLinkControllerResilienceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.schemafy.api.testsupport.project.ProjectHttpTestSupport;
-import com.schemafy.core.project.adapter.out.persistence.DomainShareLinkRepository;
+import com.schemafy.core.project.adapter.out.persistence.ShareLinkRepository;
 import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ShareLink;
 import com.schemafy.core.project.domain.Workspace;
@@ -40,7 +40,7 @@ class PublicShareLinkControllerResilienceTest extends ProjectHttpTestSupport {
   private WebTestClient webTestClient;
 
   @MockitoSpyBean
-  private DomainShareLinkRepository shareLinkRepository;
+  private ShareLinkRepository shareLinkRepository;
 
   private User testUser;
   private Workspace testWorkspace;

--- a/apps/backend/api/src/test/java/com/schemafy/api/testsupport/project/ProjectHttpTestSupport.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/testsupport/project/ProjectHttpTestSupport.java
@@ -5,12 +5,12 @@ import java.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.schemafy.api.testsupport.user.UserHttpTestSupport;
-import com.schemafy.core.project.adapter.out.persistence.DomainInvitationRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainProjectMemberRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainProjectRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainShareLinkRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainWorkspaceMemberRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainWorkspaceRepository;
+import com.schemafy.core.project.adapter.out.persistence.InvitationRepository;
+import com.schemafy.core.project.adapter.out.persistence.ProjectMemberRepository;
+import com.schemafy.core.project.adapter.out.persistence.ProjectRepository;
+import com.schemafy.core.project.adapter.out.persistence.ShareLinkRepository;
+import com.schemafy.core.project.adapter.out.persistence.WorkspaceMemberRepository;
+import com.schemafy.core.project.adapter.out.persistence.WorkspaceRepository;
 import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectMember;
@@ -26,22 +26,22 @@ import reactor.core.publisher.Mono;
 public abstract class ProjectHttpTestSupport extends UserHttpTestSupport {
 
   @Autowired
-  protected DomainWorkspaceRepository workspaceRepository;
+  protected WorkspaceRepository workspaceRepository;
 
   @Autowired
-  protected DomainWorkspaceMemberRepository workspaceMemberRepository;
+  protected WorkspaceMemberRepository workspaceMemberRepository;
 
   @Autowired
-  protected DomainProjectRepository projectRepository;
+  protected ProjectRepository projectRepository;
 
   @Autowired
-  protected DomainProjectMemberRepository projectMemberRepository;
+  protected ProjectMemberRepository projectMemberRepository;
 
   @Autowired
-  protected DomainInvitationRepository invitationRepository;
+  protected InvitationRepository invitationRepository;
 
   @Autowired
-  protected DomainShareLinkRepository shareLinkRepository;
+  protected ShareLinkRepository shareLinkRepository;
 
   protected Mono<Void> cleanupProjectFixtures() {
     return Mono.when(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class InvitationPersistenceAdapter implements InvitationPort {
 
-  private final DomainInvitationRepository invitationRepository;
+  private final InvitationRepository invitationRepository;
 
   @Override
   public Mono<Invitation> save(Invitation invitation) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationRepository.java
@@ -9,7 +9,7 @@ import com.schemafy.core.project.domain.Invitation;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainInvitationRepository
+public interface InvitationRepository
     extends ReactiveCrudRepository<Invitation, String> {
 
   @Query("""

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
@@ -8,7 +8,7 @@ import com.schemafy.core.project.domain.ProjectMember;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainProjectMemberRepository
+public interface ProjectMemberRepository
     extends ReactiveCrudRepository<ProjectMember, String> {
 
   @Query("SELECT * FROM project_members WHERE project_id = :projectId AND user_id = :userId AND deleted_at IS NULL")

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -14,8 +14,8 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ProjectPersistenceAdapter implements ProjectPort, ProjectMemberPort {
 
-  private final DomainProjectRepository projectRepository;
-  private final DomainProjectMemberRepository projectMemberRepository;
+  private final ProjectRepository projectRepository;
+  private final ProjectMemberRepository projectMemberRepository;
 
   @Override
   public Mono<Project> save(Project project) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
@@ -8,7 +8,7 @@ import com.schemafy.core.project.domain.Project;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainProjectRepository extends ReactiveCrudRepository<Project, String> {
+public interface ProjectRepository extends ReactiveCrudRepository<Project, String> {
 
   @Query("SELECT * FROM projects WHERE id = :id AND deleted_at IS NULL")
   Mono<Project> findByIdAndNotDeleted(String id);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkPersistenceAdapter.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ShareLinkPersistenceAdapter implements ShareLinkPort {
 
-  private final DomainShareLinkRepository shareLinkRepository;
+  private final ShareLinkRepository shareLinkRepository;
 
   @Override
   public Mono<ShareLink> save(ShareLink shareLink) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
@@ -8,7 +8,7 @@ import com.schemafy.core.project.domain.ShareLink;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainShareLinkRepository
+public interface ShareLinkRepository
     extends ReactiveCrudRepository<ShareLink, String> {
 
   @Query("SELECT * FROM share_links WHERE code = :code AND deleted_at IS NULL")

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
@@ -8,7 +8,7 @@ import com.schemafy.core.project.domain.WorkspaceMember;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainWorkspaceMemberRepository
+public interface WorkspaceMemberRepository
     extends ReactiveCrudRepository<WorkspaceMember, String> {
 
   @Query("""

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
@@ -15,8 +15,8 @@ import reactor.core.publisher.Mono;
 public class WorkspacePersistenceAdapter
     implements WorkspacePort, WorkspaceMemberPort {
 
-  private final DomainWorkspaceRepository workspaceRepository;
-  private final DomainWorkspaceMemberRepository workspaceMemberRepository;
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
 
   @Override
   public Mono<Workspace> save(Workspace workspace) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
@@ -8,7 +8,7 @@ import com.schemafy.core.project.domain.Workspace;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface DomainWorkspaceRepository
+public interface WorkspaceRepository
     extends ReactiveCrudRepository<Workspace, String> {
 
   @Query("""

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserAuthProviderPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserAuthProviderPersistenceAdapter.java
@@ -15,14 +15,14 @@ class UserAuthProviderPersistenceAdapter implements
     FindUserAuthProviderPort,
     CreateUserAuthProviderPort {
 
-  private final DomainUserAuthProviderRepository domainUserAuthProviderRepository;
+  private final UserAuthProviderRepository userAuthProviderRepository;
   private final UserAuthProviderMapper userAuthProviderMapper;
 
   @Override
   public Mono<UserAuthProvider> findUserAuthProvider(
       AuthProvider provider,
       String providerUserId) {
-    return domainUserAuthProviderRepository
+    return userAuthProviderRepository
         .findByProviderAndProviderUserId(provider.name(), providerUserId)
         .map(userAuthProviderMapper::toDomain);
   }
@@ -30,7 +30,7 @@ class UserAuthProviderPersistenceAdapter implements
   @Override
   public Mono<UserAuthProvider> createUserAuthProvider(
       UserAuthProvider userAuthProvider) {
-    return domainUserAuthProviderRepository
+    return userAuthProviderRepository
         .save(userAuthProviderMapper.toEntity(userAuthProvider))
         .map(userAuthProviderMapper::toDomain);
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserAuthProviderRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserAuthProviderRepository.java
@@ -4,8 +4,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import reactor.core.publisher.Mono;
 
-// TODO: core 모듈 정리 시에 해당 클래스 이름 변경
-interface DomainUserAuthProviderRepository
+interface UserAuthProviderRepository
     extends ReactiveCrudRepository<UserAuthProviderEntity, String> {
 
   Mono<UserAuthProviderEntity> findByProviderAndProviderUserId(

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -23,35 +23,35 @@ class UserPersistenceAdapter implements
     FindUserByIdPort,
     FindUsersByIdsPort {
 
-  private final DomainUserRepository domainUserRepository;
+  private final UserRepository userRepository;
   private final UserMapper userMapper;
 
   @Override
   public Mono<Boolean> existsUserByEmail(String email) {
-    return domainUserRepository.existsByEmail(email);
+    return userRepository.existsByEmail(email);
   }
 
   @Override
   public Mono<User> createUser(User user) {
-    return domainUserRepository.save(userMapper.toEntity(user))
+    return userRepository.save(userMapper.toEntity(user))
         .map(userMapper::toDomain);
   }
 
   @Override
   public Mono<User> findUserByEmail(String email) {
-    return domainUserRepository.findByEmail(email)
+    return userRepository.findByEmail(email)
         .map(userMapper::toDomain);
   }
 
   @Override
   public Mono<User> findUserById(String userId) {
-    return domainUserRepository.findById(userId)
+    return userRepository.findById(userId)
         .map(userMapper::toDomain);
   }
 
   @Override
   public Flux<User> findUsersByIds(Set<String> userIds) {
-    return domainUserRepository.findAllById(userIds)
+    return userRepository.findAllById(userIds)
         .map(userMapper::toDomain);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/user/adapter/out/persistence/UserRepository.java
@@ -4,8 +4,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import reactor.core.publisher.Mono;
 
-// TODO: core 모듈 정리 시에 해당 클래스 이름 변경
-interface DomainUserRepository extends ReactiveCrudRepository<UserEntity, String> {
+interface UserRepository extends ReactiveCrudRepository<UserEntity, String> {
 
   Mono<Boolean> existsByEmail(String email);
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
@@ -26,13 +26,13 @@ class ProjectPersistenceAdapterTest {
   private ProjectPersistenceAdapter sut;
 
   @Autowired
-  private DomainProjectRepository projectRepository;
+  private ProjectRepository projectRepository;
 
   @Autowired
-  private DomainProjectMemberRepository projectMemberRepository;
+  private ProjectMemberRepository projectMemberRepository;
 
   @Autowired
-  private DomainWorkspaceRepository workspaceRepository;
+  private WorkspaceRepository workspaceRepository;
 
   @BeforeEach
   void setUp() {

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapterTest.java
@@ -25,10 +25,10 @@ class WorkspacePersistenceAdapterTest {
   private WorkspacePersistenceAdapter sut;
 
   @Autowired
-  private DomainWorkspaceRepository workspaceRepository;
+  private WorkspaceRepository workspaceRepository;
 
   @Autowired
-  private DomainWorkspaceMemberRepository workspaceMemberRepository;
+  private WorkspaceMemberRepository workspaceMemberRepository;
 
   @BeforeEach
   void setUp() {

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectDomainIntegrationSupport.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectDomainIntegrationSupport.java
@@ -11,12 +11,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.BeforeEach;
 
 import com.schemafy.core.DomainTestApplication;
-import com.schemafy.core.project.adapter.out.persistence.DomainInvitationRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainProjectMemberRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainProjectRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainShareLinkRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainWorkspaceMemberRepository;
-import com.schemafy.core.project.adapter.out.persistence.DomainWorkspaceRepository;
+import com.schemafy.core.project.adapter.out.persistence.InvitationRepository;
+import com.schemafy.core.project.adapter.out.persistence.ProjectMemberRepository;
+import com.schemafy.core.project.adapter.out.persistence.ProjectRepository;
+import com.schemafy.core.project.adapter.out.persistence.ShareLinkRepository;
+import com.schemafy.core.project.adapter.out.persistence.WorkspaceMemberRepository;
+import com.schemafy.core.project.adapter.out.persistence.WorkspaceRepository;
 import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectMember;
@@ -43,22 +43,22 @@ abstract class ProjectDomainIntegrationSupport {
   protected SignUpUserUseCase signUpUserUseCase;
 
   @Autowired
-  protected DomainWorkspaceRepository workspaceRepository;
+  protected WorkspaceRepository workspaceRepository;
 
   @Autowired
-  protected DomainWorkspaceMemberRepository workspaceMemberRepository;
+  protected WorkspaceMemberRepository workspaceMemberRepository;
 
   @Autowired
-  protected DomainProjectRepository projectRepository;
+  protected ProjectRepository projectRepository;
 
   @Autowired
-  protected DomainProjectMemberRepository projectMemberRepository;
+  protected ProjectMemberRepository projectMemberRepository;
 
   @Autowired
-  protected DomainInvitationRepository invitationRepository;
+  protected InvitationRepository invitationRepository;
 
   @Autowired
-  protected DomainShareLinkRepository shareLinkRepository;
+  protected ShareLinkRepository shareLinkRepository;
 
   @BeforeEach
   void cleanProjectDomainTables() {

--- a/apps/backend/core/src/test/java/com/schemafy/core/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -41,15 +41,15 @@ class UserPersistenceAdapterTest {
   UserAuthProviderPersistenceAdapter userAuthProviderPersistenceAdapter;
 
   @Autowired
-  DomainUserRepository domainUserRepository;
+  UserRepository userRepository;
 
   @Autowired
-  DomainUserAuthProviderRepository domainUserAuthProviderRepository;
+  UserAuthProviderRepository userAuthProviderRepository;
 
   @BeforeEach
   void setUp() {
-    domainUserAuthProviderRepository.deleteAll().block();
-    domainUserRepository.deleteAll().block();
+    userAuthProviderRepository.deleteAll().block();
+    userRepository.deleteAll().block();
   }
 
   @Nested


### PR DESCRIPTION
## 개요
- core persistence repository 8개에서 `Domain` prefix 제거
- production/test 코드의 import, 주입 타입, 필드명을 새 이름으로 정리
- 동작 변경 없이 내부 타입명만 정리

## 이슈
- close #314