### PR TITLE
feat(#319): strengthen cursor-pr-review prompt output format instructions

### DIFF
--- a/.github/prompts/cursor-pr-review.md
+++ b/.github/prompts/cursor-pr-review.md
@@ -30,7 +30,7 @@ Commenting policy:
     - `<!-- cursor-pr-review:v1 -->`
 - Target only changed lines in the PR.
 - Line comments are optional. If no High/Medium issues exist, skip line comments entirely.
-- Do NOT post comments via GitHub API. Output them as structured JSON to stdout instead.
+- Do NOT post comments via GitHub API. Output them in the structured block below instead.
 
 Suggested command flow:
 
@@ -39,15 +39,13 @@ Suggested command flow:
 2. Filter by allowed extensions and exclusions.
 3. Analyze diff and identify High/Medium issues only.
 4. For each issue, confirm target line exists in changed lines of the current diff.
-5. Output line comments as JSON to stdout (see output format below). Do NOT call any GitHub API to post comments.
+5. Output results using the required format below.
 
-CRITICAL: You MUST end your final output with EXACTLY the block below. This is machine-parsed by a shell script. Any
-deviation — extra text, indentation, code fences, or natural-language summary instead of this block — will cause a parse
-failure.
+CRITICAL: Your output MUST end with the two blocks below in order. Do not output any text after `REVIEW_JSON_END`.
 
-REQUIRED OUTPUT BLOCK (copy exactly, do not paraphrase or reformat):
+REQUIRED OUTPUT FORMAT:
 
-PR_OVERALL_COMMENT_BEGIN
+OVERALL_COMMENT_BEGIN
 
 ### 요약
 
@@ -55,28 +53,41 @@ PR_OVERALL_COMMENT_BEGIN
 
 ### 주요 변경점
 
-(변경점 bullet list)
+- (변경점 bullet list)
 
 ### 개선 사항
 
-(개선 사항이 없으면 이 섹션 전체를 생략)
-PR_OVERALL_COMMENT_END
-LINE_COMMENTS_BEGIN
-[{"path":"<file>","line":<number>,"side":"RIGHT","body":"<Korean comment>\n<!-- cursor-pr-review:v1 -->"}]
-LINE_COMMENTS_END
-요약: High=<number>, Medium=<number>, Comments=<number>
-완료: cursor-pr-review:v1
+- (개선 사항이 없으면 이 섹션 전체를 생략)
+  OVERALL_COMMENT_END
+  REVIEW_JSON_BEGIN
+  {
+  "line_comments": [
+  {
+  "path": "<relative file path>",
+  "line": <line number>,
+  "side": "RIGHT",
+  "body": "<Korean comment text>\n<!-- cursor-pr-review:v1 -->"
+  }
+  ],
+  "summary": {
+  "high": <number>,
+  "medium": <number>,
+  "comments": <number>
+  }
+  }
+  REVIEW_JSON_END
 
-Rules for the output block:
+Rules for the output blocks:
 
-- The marker lines (`PR_OVERALL_COMMENT_BEGIN`, `PR_OVERALL_COMMENT_END`, `LINE_COMMENTS_BEGIN`, `LINE_COMMENTS_END`)
-  MUST appear as standalone lines with NO leading/trailing spaces or characters.
-- Do NOT wrap this block in markdown code fences (no ` ``` `).
-- Do NOT write a conversational summary before or after this block. The block IS your final output.
-- All text inside `PR_OVERALL_COMMENT_BEGIN` ~ `PR_OVERALL_COMMENT_END` and all `body` fields in LINE_COMMENTS MUST be
-  written in Korean.
-- If no High/Medium issues found: include `LGTM` in the 요약 section and output `[]` for LINE_COMMENTS.
-- LINE_COMMENTS must be a valid JSON array. For no issues, output exactly `[]` on a single line.
+- `OVERALL_COMMENT_BEGIN`, `OVERALL_COMMENT_END`, `REVIEW_JSON_BEGIN`, `REVIEW_JSON_END` must appear as standalone lines
+  with no leading/trailing spaces or characters.
+- All text inside `OVERALL_COMMENT_BEGIN` ~ `OVERALL_COMMENT_END` and all `body` fields MUST be written in Korean.
+- Do NOT wrap either block in markdown code fences (no ` ``` `).
+- The JSON between `REVIEW_JSON_BEGIN` ~ `REVIEW_JSON_END` must be valid. Do not include trailing commas or comments
+  inside JSON.
+- Newlines inside JSON string values (e.g. `body`) must be escaped as `\n`.
+- If no High/Medium issues found: include `LGTM` in the `### 요약` section and use `[]` for `line_comments`.
+- `summary.comments` must equal the length of the `line_comments` array.
 
 Quality bar:
 
@@ -88,4 +99,3 @@ Quality bar:
     - maintainability issues likely to cause production problems
 - Avoid style nitpicks and low-value comments.
 - Use related issues context to prioritize domain-specific regression checks when relevant.
-

--- a/.github/prompts/cursor-pr-review.md
+++ b/.github/prompts/cursor-pr-review.md
@@ -17,7 +17,7 @@ Execution context:
 Review scope rules:
 
 - Include only code/config file extensions:
-  - `.ts`, `.tsx`, `.js`, `.jsx`, `.java`, `.gradle`, `.sql`, `.yml`, `.yaml`
+    - `.ts`, `.tsx`, `.js`, `.jsx`, `.java`, `.gradle`, `.sql`, `.yml`, `.yaml`
 - Exclude:
     - `package-lock.json`
     - `*.md`
@@ -41,35 +41,42 @@ Suggested command flow:
 4. For each issue, confirm target line exists in changed lines of the current diff.
 5. Output line comments as JSON to stdout (see output format below). Do NOT call any GitHub API to post comments.
 
-Required output format to stdout (final lines):
+CRITICAL: You MUST end your final output with EXACTLY the block below. This is machine-parsed by a shell script. Any
+deviation — extra text, indentation, code fences, or natural-language summary instead of this block — will cause a parse
+failure.
 
-- `PR_OVERALL_COMMENT_BEGIN`
-- (한국어 마크다운으로 PR 전반 코멘트)
-  - 기본 포함:
-    - `### 요약`
-    - `### 주요 변경점`
-  - 선택 포함(개선 사항이 있을 때만):
-    - `### 개선 사항`
-  - High/Medium 이슈가 없으면 `LGTM` 문구를 반드시 포함
-- `PR_OVERALL_COMMENT_END`
-- `LINE_COMMENTS_BEGIN`
-- JSON array of line comment objects, one per line. Each object:
-    - `path`: relative file path
-    - `line`: line number in the diff
-    - `side`: `"RIGHT"`
-    - `body`: Korean comment text including `<!-- cursor-pr-review:v1 -->` marker
-- If no issues found, output an empty array `[]`.
-- `LINE_COMMENTS_END`
-- `요약: High=<number>, Medium=<number>, Comments=<number>`
-- `완료: cursor-pr-review:v1`
+REQUIRED OUTPUT BLOCK (copy exactly, do not paraphrase or reformat):
 
-Formatting requirements (strict):
+PR_OVERALL_COMMENT_BEGIN
 
-- Emit marker lines exactly as plain text (no indentation, no extra characters):
-  - `PR_OVERALL_COMMENT_BEGIN`, `PR_OVERALL_COMMENT_END`
-  - `LINE_COMMENTS_BEGIN`, `LINE_COMMENTS_END`
-- Do not wrap the final output section in markdown code fences.
-- For `LINE_COMMENTS` section, output a valid JSON array only (for no issues, exactly `[]`).
+### 요약
+
+(한 문단 요약)
+
+### 주요 변경점
+
+(변경점 bullet list)
+
+### 개선 사항
+
+(개선 사항이 없으면 이 섹션 전체를 생략)
+PR_OVERALL_COMMENT_END
+LINE_COMMENTS_BEGIN
+[{"path":"<file>","line":<number>,"side":"RIGHT","body":"<Korean comment>\n<!-- cursor-pr-review:v1 -->"}]
+LINE_COMMENTS_END
+요약: High=<number>, Medium=<number>, Comments=<number>
+완료: cursor-pr-review:v1
+
+Rules for the output block:
+
+- The marker lines (`PR_OVERALL_COMMENT_BEGIN`, `PR_OVERALL_COMMENT_END`, `LINE_COMMENTS_BEGIN`, `LINE_COMMENTS_END`)
+  MUST appear as standalone lines with NO leading/trailing spaces or characters.
+- Do NOT wrap this block in markdown code fences (no ` ``` `).
+- Do NOT write a conversational summary before or after this block. The block IS your final output.
+- All text inside `PR_OVERALL_COMMENT_BEGIN` ~ `PR_OVERALL_COMMENT_END` and all `body` fields in LINE_COMMENTS MUST be
+  written in Korean.
+- If no High/Medium issues found: include `LGTM` in the 요약 section and output `[]` for LINE_COMMENTS.
+- LINE_COMMENTS must be a valid JSON array. For no issues, output exactly `[]` on a single line.
 
 Quality bar:
 
@@ -81,3 +88,4 @@ Quality bar:
     - maintainability issues likely to cause production problems
 - Avoid style nitpicks and low-value comments.
 - Use related issues context to prioritize domain-specific regression checks when relevant.
+

--- a/.github/workflows/cursor-pr-review.yml
+++ b/.github/workflows/cursor-pr-review.yml
@@ -341,34 +341,33 @@ jobs:
             sanitized_output="$(sed -e 's/\x1b\[[0-9;]*m//g' cursor-review-output.txt | tr -d '\r')"
           fi
 
-          summary_line="$(printf '%s\n' "${sanitized_output}" | grep -E '요약:[[:space:]]*High=[0-9]+,[[:space:]]*Medium=[0-9]+,[[:space:]]*Comments=[0-9]+' | tail -n 1)"
-          overall_comment="$(printf '%s\n' "${sanitized_output}" | sed -n '/^[[:space:]]*PR_OVERALL_COMMENT_BEGIN[[:space:]]*$/,/^[[:space:]]*PR_OVERALL_COMMENT_END[[:space:]]*$/p' | sed '1d;$d')"
+          overall_comment="$(printf '%s\n' "${sanitized_output}" \
+            | sed -n '/^OVERALL_COMMENT_BEGIN$/,/^OVERALL_COMMENT_END$/p' | sed '1d;$d')"
 
-          # Parse line comments JSON (B3)
-          line_comments_json="$(printf '%s\n' "${sanitized_output}" \
-            | sed -n '/^[[:space:]]*LINE_COMMENTS_BEGIN[[:space:]]*$/,/^[[:space:]]*LINE_COMMENTS_END[[:space:]]*$/p' | sed '1d;$d')"
+          review_json="$(printf '%s\n' "${sanitized_output}" \
+            | sed -n '/^REVIEW_JSON_BEGIN$/,/^REVIEW_JSON_END$/p' | sed '1d;$d;/^```/d')"
 
-          if [ -z "$(printf '%s' "${line_comments_json:-}" | tr -d '[:space:]')" ]; then
-            line_comments_json="[]"
-          fi
-
-          # Validate JSON array, fallback to empty array
-          if ! echo "${line_comments_json:-[]}" | jq -e 'type == "array"' >/dev/null 2>&1; then
-            echo "Warning: LINE_COMMENTS JSON is invalid, falling back to empty array."
-            line_comments_json="[]"
-          fi
-
+          line_comments_json="[]"
           high_count="N/A"
           medium_count="N/A"
           comment_count="N/A"
-          if [[ "${summary_line}" =~ High=([0-9]+),[[:space:]]*Medium=([0-9]+),[[:space:]]*Comments=([0-9]+) ]]; then
-            high_count="${BASH_REMATCH[1]}"
-            medium_count="${BASH_REMATCH[2]}"
-            comment_count="${BASH_REMATCH[3]}"
+
+          if echo "${review_json:-}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            line_comments_json="$(echo "${review_json}" | jq -c '.line_comments // []')"
+            high_count="$(echo "${review_json}" | jq -r '.summary.high // "N/A"')"
+            medium_count="$(echo "${review_json}" | jq -r '.summary.medium // "N/A"')"
+            comment_count="$(echo "${review_json}" | jq -r '.summary.comments // "N/A"')"
+          else
+            echo "Warning: REVIEW_JSON not found or invalid JSON."
+          fi
+
+          if ! echo "${line_comments_json}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "Warning: line_comments is not a valid JSON array, falling back to []."
+            line_comments_json="[]"
           fi
 
           if [ -z "${overall_comment:-}" ]; then
-            overall_comment=$'### 요약\nPR 전반 코멘트를 생성하지 못했습니다.\n\n### 주요 변경점\n- (파싱 실패)\n\n### 개선 사항\n- Cursor 출력에서 전체 코멘트 블록을 찾지 못했습니다.\n- 재실행 후 전체 코멘트 생성 여부를 확인해주세요.'
+            overall_comment=$'### 요약\nPR 전반 코멘트를 생성하지 못했습니다.\n\n### 주요 변경점\n- (파싱 실패)\n\n### 개선 사항\n- Cursor 출력에서 코멘트 블록을 찾지 못했습니다.\n- 재실행 후 출력 생성 여부를 확인해주세요.'
           fi
 
           if [ "${high_count}" = "0" ] && [ "${medium_count}" = "0" ]; then


### PR DESCRIPTION
## 개요
claude-4.6-opus-max-thinking 모델이 cursor-agent를 통해 실행될 때 프롬프트의 출력 형식 지시를 따르지 않고 자체적으로 포맷을 결정하여 제대로 출력되지 않는 문제가 있었습니다.
출력 형식 지시를 더 강하게 작성하여 이를 수정하였습니다.

- close #319