### PR TITLE
hotfix(#263): sync project memberships for workspace admin role changes

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationService.java
@@ -80,7 +80,7 @@ class AcceptWorkspaceInvitationService
                                   ProjectErrorCode.INVITATION_DUPLICATE_WORKSPACE_MEMBER));
                             })
                         .flatMap(savedMember -> projectMembershipPropagationHelper
-                            .propagateToExistingProjects(
+                            .syncProjectMembershipsForWorkspaceRole(
                                 invitation.getWorkspaceId(),
                                 command.requesterId(),
                                 invitation.getWorkspaceRole())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
@@ -59,7 +59,7 @@ class AddWorkspaceMemberService implements AddWorkspaceMemberUseCase {
                         .save(WorkspaceMember.create(id, command.workspaceId(),
                             targetUser.id(), command.role()))))))
             .flatMap(savedMember -> projectMembershipPropagationHelper
-                .propagateToExistingProjects(
+                .syncProjectMembershipsForWorkspaceRole(
                     command.workspaceId(),
                     savedMember.getUserId(),
                     savedMember.getRoleAsEnum())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMembershipPropagationHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMembershipPropagationHelper.java
@@ -62,10 +62,11 @@ class ProjectMembershipPropagationHelper {
         .then();
   }
 
-  Mono<Void> updateRoleInAllProjects(
+  Mono<Void> updateActiveProjectMembershipRoles(
       String workspaceId,
       String userId,
       WorkspaceRole workspaceRole) {
+    // 현재 활성 상태인 프로젝트 멤버십의 역할만 변경한다.
     ProjectRole projectRole = workspaceRole.toProjectRole();
     return projectMemberPort
         .findByWorkspaceIdAndUserId(workspaceId, userId)
@@ -98,10 +99,11 @@ class ProjectMembershipPropagationHelper {
         .then();
   }
 
-  Mono<Void> propagateToExistingProjects(
+  Mono<Void> syncProjectMembershipsForWorkspaceRole(
       String workspaceId,
       String userId,
       WorkspaceRole workspaceRole) {
+    // 워크스페이스의 모든 프로젝트를 순회하며 멤버십을 승격, 복원, 생성해 상태를 맞춘다.
     ProjectRole projectRole = workspaceRole.toProjectRole();
 
     return projectPort.findByWorkspaceIdAndNotDeleted(workspaceId)
@@ -109,6 +111,11 @@ class ProjectMembershipPropagationHelper {
             .findLatestByProjectIdAndUserId(project.getId(), userId)
             .flatMap(existing -> {
               if (!existing.isDeleted()) {
+                if (workspaceRole.isAdmin()
+                    && existing.getRoleAsEnum() != projectRole) {
+                  existing.updateRole(projectRole);
+                  return projectMemberPort.save(existing);
+                }
                 return Mono.just(existing);
               }
               existing.restore();

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleCommand;
 import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleUseCase;
 import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -30,13 +31,29 @@ class UpdateWorkspaceMemberRoleService
             command.workspaceId(),
             targetMember,
             member -> member.updateRole(command.role())))
-        .flatMap(savedMember -> projectMembershipPropagationHelper
-            .updateRoleInAllProjects(
-                command.workspaceId(),
-                command.targetUserId(),
-                command.role())
+        .flatMap(savedMember -> applyWorkspaceRoleToProjectMemberships(
+            command.workspaceId(),
+            command.targetUserId(),
+            command.role())
             .thenReturn(savedMember))
         .as(transactionalOperator::transactional);
+  }
+
+  private Mono<Void> applyWorkspaceRoleToProjectMemberships(
+      String workspaceId,
+      String userId,
+      WorkspaceRole workspaceRole) {
+    if (workspaceRole.isAdmin()) {
+      return projectMembershipPropagationHelper.syncProjectMembershipsForWorkspaceRole(
+          workspaceId,
+          userId,
+          workspaceRole);
+    }
+
+    return projectMembershipPropagationHelper.updateActiveProjectMembershipRoles(
+        workspaceId,
+        userId,
+        workspaceRole);
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMembershipPropagationHelperTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMembershipPropagationHelperTest.java
@@ -1,0 +1,194 @@
+package com.schemafy.core.project.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProjectMembershipPropagationHelper")
+class ProjectMembershipPropagationHelperTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  ProjectMemberPort projectMemberPort;
+
+  @Mock
+  WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  UlidGeneratorPort ulidGeneratorPort;
+
+  @Test
+  @DisplayName("워크스페이스 ADMIN 합류 시 기존 활성 프로젝트 멤버십도 ADMIN으로 올리고 누락된 프로젝트 멤버십을 생성한다")
+  void syncProjectMembershipsForWorkspaceRole_upgradesExistingActiveMembershipForWorkspaceAdmin() {
+    Project joinedProject = Project.create("project-1", WORKSPACE_ID, "Joined Project",
+        "Description");
+    Project newProject = Project.create("project-2", WORKSPACE_ID, "New Project", "Description");
+    ProjectMember existingMember = ProjectMember.create("member-1", joinedProject.getId(), USER_ID,
+        ProjectRole.VIEWER);
+    ProjectMembershipPropagationHelper sut = new ProjectMembershipPropagationHelper(
+        projectPort,
+        projectMemberPort,
+        workspaceMemberPort,
+        ulidGeneratorPort);
+
+    given(projectPort.findByWorkspaceIdAndNotDeleted(WORKSPACE_ID))
+        .willReturn(Flux.just(joinedProject, newProject));
+    given(projectMemberPort.findLatestByProjectIdAndUserId(joinedProject.getId(), USER_ID))
+        .willReturn(Mono.just(existingMember));
+    given(projectMemberPort.findLatestByProjectIdAndUserId(newProject.getId(), USER_ID))
+        .willReturn(Mono.empty());
+    given(ulidGeneratorPort.generate())
+        .willReturn("member-2");
+    given(projectMemberPort.save(any(ProjectMember.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+    StepVerifier.create(sut.syncProjectMembershipsForWorkspaceRole(WORKSPACE_ID, USER_ID,
+        WorkspaceRole.ADMIN))
+        .verifyComplete();
+
+    assertThat(existingMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+
+    ArgumentCaptor<ProjectMember> savedMemberCaptor = ArgumentCaptor.forClass(ProjectMember.class);
+    then(projectMemberPort).should(times(2)).save(savedMemberCaptor.capture());
+    assertThat(savedMemberCaptor.getAllValues())
+        .extracting(ProjectMember::getProjectId, ProjectMember::getUserId, ProjectMember::getRole)
+        .containsExactlyInAnyOrder(
+            org.assertj.core.groups.Tuple.tuple(joinedProject.getId(), USER_ID,
+                ProjectRole.ADMIN.name()),
+            org.assertj.core.groups.Tuple.tuple(newProject.getId(), USER_ID,
+                ProjectRole.ADMIN.name()));
+  }
+
+  @Test
+  @DisplayName("워크스페이스 MEMBER 합류 시 기존 활성 프로젝트 역할은 유지한다")
+  void syncProjectMembershipsForWorkspaceRole_preservesExistingActiveMembershipForWorkspaceMember() {
+    Project project = Project.create("project-1", WORKSPACE_ID, "Project", "Description");
+    ProjectMember existingMember = ProjectMember.create("member-1", project.getId(), USER_ID,
+        ProjectRole.EDITOR);
+    ProjectMembershipPropagationHelper sut = new ProjectMembershipPropagationHelper(
+        projectPort,
+        projectMemberPort,
+        workspaceMemberPort,
+        ulidGeneratorPort);
+
+    given(projectPort.findByWorkspaceIdAndNotDeleted(WORKSPACE_ID))
+        .willReturn(Flux.just(project));
+    given(projectMemberPort.findLatestByProjectIdAndUserId(project.getId(), USER_ID))
+        .willReturn(Mono.just(existingMember));
+
+    StepVerifier.create(sut.syncProjectMembershipsForWorkspaceRole(WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER))
+        .verifyComplete();
+
+    assertThat(existingMember.getRoleAsEnum()).isEqualTo(ProjectRole.EDITOR);
+    then(projectMemberPort).should().findLatestByProjectIdAndUserId(project.getId(), USER_ID);
+    then(projectMemberPort).should(never()).save(any(ProjectMember.class));
+    then(ulidGeneratorPort).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 ADMIN 승격 시 삭제된 프로젝트 멤버십은 복원하고 ADMIN으로 보정한다")
+  void syncProjectMembershipsForWorkspaceRole_restoresDeletedMembershipForWorkspaceAdmin() {
+    Project project = Project.create("project-1", WORKSPACE_ID, "Project", "Description");
+    ProjectMember deletedMember = ProjectMember.create("member-1", project.getId(), USER_ID,
+        ProjectRole.VIEWER);
+    deletedMember.delete();
+    ProjectMembershipPropagationHelper sut = new ProjectMembershipPropagationHelper(
+        projectPort,
+        projectMemberPort,
+        workspaceMemberPort,
+        ulidGeneratorPort);
+
+    given(projectPort.findByWorkspaceIdAndNotDeleted(WORKSPACE_ID))
+        .willReturn(Flux.just(project));
+    given(projectMemberPort.findLatestByProjectIdAndUserId(project.getId(), USER_ID))
+        .willReturn(Mono.just(deletedMember));
+    given(projectMemberPort.save(deletedMember))
+        .willReturn(Mono.just(deletedMember));
+
+    StepVerifier.create(sut.syncProjectMembershipsForWorkspaceRole(WORKSPACE_ID, USER_ID,
+        WorkspaceRole.ADMIN))
+        .verifyComplete();
+
+    assertThat(deletedMember.isDeleted()).isFalse();
+    assertThat(deletedMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+    then(projectMemberPort).should().save(deletedMember);
+    then(ulidGeneratorPort).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 ADMIN을 MEMBER로 강등하면 활성 프로젝트 ADMIN은 VIEWER로 내려간다")
+  void updateActiveProjectMembershipRoles_demotesProjectAdminToViewer() {
+    ProjectMember projectAdminMember = ProjectMember.create("member-1", "project-1", USER_ID,
+        ProjectRole.ADMIN);
+    ProjectMembershipPropagationHelper sut = new ProjectMembershipPropagationHelper(
+        projectPort,
+        projectMemberPort,
+        workspaceMemberPort,
+        ulidGeneratorPort);
+
+    given(projectMemberPort.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(Flux.just(projectAdminMember));
+    given(projectMemberPort.save(projectAdminMember))
+        .willReturn(Mono.just(projectAdminMember));
+
+    StepVerifier.create(sut.updateActiveProjectMembershipRoles(WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER))
+        .verifyComplete();
+
+    assertThat(projectAdminMember.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
+    then(projectMemberPort).should().save(projectAdminMember);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 ADMIN을 MEMBER로 강등해도 프로젝트 EDITOR 역할은 유지된다")
+  void updateActiveProjectMembershipRoles_preservesEditorRoleOnDemotion() {
+    ProjectMember projectEditorMember = ProjectMember.create("member-1", "project-1", USER_ID,
+        ProjectRole.EDITOR);
+    ProjectMembershipPropagationHelper sut = new ProjectMembershipPropagationHelper(
+        projectPort,
+        projectMemberPort,
+        workspaceMemberPort,
+        ulidGeneratorPort);
+
+    given(projectMemberPort.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(Flux.just(projectEditorMember));
+
+    StepVerifier.create(sut.updateActiveProjectMembershipRoles(WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER))
+        .verifyComplete();
+
+    assertThat(projectEditorMember.getRoleAsEnum()).isEqualTo(ProjectRole.EDITOR);
+    then(projectMemberPort).should(never()).save(any(ProjectMember.class));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -305,4 +305,27 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     assertThat(deletedMember.isDeleted()).isTrue();
   }
 
+  @Test
+  @DisplayName("워크스페이스 관리자가 아닌 프로젝트 VIEWER는 프로젝트를 직접 나갈 수 있다")
+  void leaveProject_allowsProjectViewerWithoutWorkspaceAdmin() {
+    User projectViewer = signUpUser("requester-project-viewer-leave@test.com", "Requester");
+    User remainingMember = signUpUser("member-project-viewer-leave@test.com", "Member");
+    Workspace workspace = saveWorkspace("Project Viewer Leave WS", "Description");
+    saveWorkspaceMember(workspace, projectViewer, WorkspaceRole.MEMBER);
+    saveWorkspaceMember(workspace, remainingMember, WorkspaceRole.MEMBER);
+    var project = saveProject(workspace, "Project Viewer Leave Project");
+    ProjectMember projectViewerMember = saveProjectMember(project, projectViewer,
+        ProjectRole.VIEWER);
+    saveProjectMember(project, remainingMember, ProjectRole.ADMIN);
+
+    leaveProjectUseCase.leaveProject(new LeaveProjectCommand(project.getId(), projectViewer.id()))
+        .block();
+
+    ProjectMember deletedMember = projectMemberRepository.findById(projectViewerMember.getId())
+        .block();
+    assertThat(deletedMember).isNotNull();
+    assertThat(deletedMember.isDeleted()).isTrue();
+    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNotNull();
+  }
+
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
@@ -155,6 +155,38 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
+  @DisplayName("워크스페이스 ADMIN으로 합류하면 기존 참여 프로젝트는 ADMIN으로 승격하고 미참여 프로젝트는 ADMIN으로 추가한다")
+  void addWorkspaceMember_promotesJoinedProjectsAndCreatesMissingProjectsForWorkspaceAdmin() {
+    User admin = signUpUser("admin-add-admin@test.com", "Admin");
+    User target = signUpUser("target-add-admin@test.com", "Target");
+    Workspace workspace = saveWorkspace("Admin Join WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    var joinedProject = saveProject(workspace, "Joined Project");
+    var missingProject = saveProject(workspace, "Missing Project");
+    ProjectMember existingProjectMember = saveProjectMember(joinedProject, target,
+        ProjectRole.VIEWER);
+
+    WorkspaceMember addedMember = addWorkspaceMemberUseCase.addWorkspaceMember(
+        new AddWorkspaceMemberCommand(workspace.getId(), target.email(), WorkspaceRole.ADMIN,
+            admin.id()))
+        .block();
+
+    ProjectMember upgradedProjectMember = projectMemberRepository
+        .findByProjectIdAndUserIdAndNotDeleted(joinedProject.getId(), target.id())
+        .block();
+    ProjectMember createdProjectMember = projectMemberRepository
+        .findByProjectIdAndUserIdAndNotDeleted(missingProject.getId(), target.id())
+        .block();
+
+    assertThat(addedMember).isNotNull();
+    assertThat(addedMember.getRoleAsEnum()).isEqualTo(WorkspaceRole.ADMIN);
+    assertThat(upgradedProjectMember.getId()).isEqualTo(existingProjectMember.getId());
+    assertThat(upgradedProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+    assertThat(createdProjectMember).isNotNull();
+    assertThat(createdProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+  }
+
+  @Test
   @DisplayName("워크스페이스 멤버 추가 시 대문자 이메일 입력을 정규화한다")
   void addWorkspaceMember_normalizesUppercaseEmail() {
     User admin = signUpUser("admin-upper@test.com", "Admin");
@@ -197,8 +229,49 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("프로젝트 관리자여도 워크스페이스에서는 관리자 등급을 내릴 수 있다")
-  void updateWorkspaceMemberRole_allowsProjectAdminTarget() {
+  @DisplayName("워크스페이스 멤버를 ADMIN으로 승격하면 활성, 삭제, 누락 프로젝트 멤버십을 모두 ADMIN으로 맞춘다")
+  void updateWorkspaceMemberRole_promotesAndRestoresProjectMembershipsForAdmin() {
+    User requester = signUpUser("requester-workspace-promote@test.com", "Requester");
+    User target = signUpUser("target-workspace-promote@test.com", "Target");
+    Workspace workspace = saveWorkspace("Workspace Promote WS", "Description");
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.ADMIN);
+    WorkspaceMember targetWorkspaceMember = saveWorkspaceMember(workspace, target,
+        WorkspaceRole.MEMBER);
+    var activeProject = saveProject(workspace, "Workspace Promote Active Project");
+    var deletedProject = saveProject(workspace, "Workspace Promote Deleted Project");
+    var missingProject = saveProject(workspace, "Workspace Promote Missing Project");
+    ProjectMember activeProjectMember = saveProjectMember(activeProject, target, ProjectRole.VIEWER);
+    ProjectMember deletedProjectMember = saveProjectMember(deletedProject, target,
+        ProjectRole.VIEWER);
+    softDeleteProjectMember(deletedProjectMember.getId());
+
+    WorkspaceMember updatedMember = updateWorkspaceMemberRoleUseCase.updateWorkspaceMemberRole(
+        new UpdateWorkspaceMemberRoleCommand(workspace.getId(), target.id(), WorkspaceRole.ADMIN,
+            requester.id()))
+        .block();
+
+    ProjectMember promotedProjectMember = projectMemberRepository.findById(activeProjectMember.getId())
+        .block();
+    ProjectMember restoredProjectMember = projectMemberRepository.findById(deletedProjectMember.getId())
+        .block();
+    ProjectMember createdProjectMember = projectMemberRepository
+        .findByProjectIdAndUserIdAndNotDeleted(missingProject.getId(), target.id())
+        .block();
+
+    assertThat(updatedMember.getId()).isEqualTo(targetWorkspaceMember.getId());
+    assertThat(updatedMember.getRoleAsEnum()).isEqualTo(WorkspaceRole.ADMIN);
+    assertThat(promotedProjectMember).isNotNull();
+    assertThat(promotedProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+    assertThat(restoredProjectMember).isNotNull();
+    assertThat(restoredProjectMember.isDeleted()).isFalse();
+    assertThat(restoredProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+    assertThat(createdProjectMember).isNotNull();
+    assertThat(createdProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 ADMIN이자 프로젝트 ADMIN인 대상자를 워크스페이스 MEMBER로 강등하면 프로젝트 역할도 VIEWER로 내려간다")
+  void updateWorkspaceMemberRole_demotesWorkspaceAndProjectAdminToViewer() {
     User requester = signUpUser("requester-workspace-demote@test.com", "Requester");
     User target = signUpUser("target-workspace-demote@test.com", "Target");
     Workspace workspace = saveWorkspace("Workspace Demote WS", "Description");
@@ -206,15 +279,19 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     WorkspaceMember targetWorkspaceMember = saveWorkspaceMember(workspace, target,
         WorkspaceRole.ADMIN);
     var project = saveProject(workspace, "Workspace Demote Project");
-    saveProjectMember(project, target, ProjectRole.ADMIN);
+    ProjectMember targetProjectMember = saveProjectMember(project, target, ProjectRole.ADMIN);
 
     WorkspaceMember updatedMember = updateWorkspaceMemberRoleUseCase.updateWorkspaceMemberRole(
         new UpdateWorkspaceMemberRoleCommand(workspace.getId(), target.id(), WorkspaceRole.MEMBER,
             requester.id()))
         .block();
 
+    ProjectMember updatedProjectMember = projectMemberRepository.findById(targetProjectMember.getId())
+        .block();
+
     assertThat(updatedMember.getId()).isEqualTo(targetWorkspaceMember.getId());
     assertThat(updatedMember.getRoleAsEnum()).isEqualTo(WorkspaceRole.MEMBER);
+    assertThat(updatedProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
   }
 
   @Test


### PR DESCRIPTION
## 개요
- 워크스페이스 ADMIN 권한이 나중에 부여될 때, 기존 active 프로젝트 멤버십도 ADMIN으로 승격되도록 수정
- 기존 워크스페이스 MEMBER -> ADMIN 승격 시 active/deleted/missing 프로젝트 멤버십을 모두 정책대로 맞추도록 수정

## 이슈


- close #263