### PR TITLE
feat(#264): shared project query api

### DIFF
--- a/apps/backend/api/src/main/java/com/schemafy/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.schemafy.api.common.exception;
 
+import java.util.stream.Collectors;
+
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -67,7 +70,11 @@ public class GlobalExceptionHandler {
       ConstraintViolationException e, ServerWebExchange exchange) {
     DomainErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
     log.warn("[ConstraintViolationException] {}", e.getMessage());
-    return buildResponse(exchange, errorCode, e.getMessage());
+    return buildResponse(exchange, errorCode,
+        e.getConstraintViolations().stream()
+            .map(ConstraintViolation::getMessage)
+            .distinct()
+            .collect(Collectors.joining(", ")));
   }
 
   @ExceptionHandler(Exception.class)

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.schemafy.api.common.exception;
 
+import jakarta.validation.ConstraintViolationException;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -58,6 +60,14 @@ public class GlobalExceptionHandler {
     DomainErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
     log.warn("[ServerWebInputException] {}", e.getMessage());
     return buildResponse(exchange, errorCode, e.getReason());
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ProblemDetail> handleConstraintViolationException(
+      ConstraintViolationException e, ServerWebExchange exchange) {
+    DomainErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+    log.warn("[ConstraintViolationException] {}", e.getMessage());
+    return buildResponse(exchange, errorCode, e.getMessage());
   }
 
   @ExceptionHandler(Exception.class)

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java
@@ -1,11 +1,13 @@
 package com.schemafy.api.project.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import com.schemafy.api.common.constant.ApiPath;
@@ -26,6 +28,8 @@ import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkUseCase;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsUseCase;
 import com.schemafy.core.project.application.port.in.GetProjectMembersQuery;
 import com.schemafy.core.project.application.port.in.GetProjectQuery;
 import com.schemafy.core.project.application.port.in.GetProjectUseCase;
@@ -49,12 +53,14 @@ import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @RestController
+@Validated
 @RequestMapping(ApiPath.API)
 @RequiredArgsConstructor
 public class ProjectController {
 
   private final CreateProjectUseCase createProjectUseCase;
   private final GetProjectsUseCase getProjectsUseCase;
+  private final GetMySharedProjectsUseCase getMySharedProjectsUseCase;
   private final GetProjectUseCase getProjectUseCase;
   private final UpdateProjectUseCase updateProjectUseCase;
   private final DeleteProjectUseCase deleteProjectUseCase;
@@ -114,6 +120,23 @@ public class ProjectController {
     String userId = authentication.getName();
     return getProjectUseCase.getProject(new GetProjectQuery(projectId, userId))
         .map(ProjectResponse::from);
+  }
+
+  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
+  @GetMapping("/projects/shared/me")
+  public Mono<PageResponse<ProjectSummaryResponse>> getMySharedProjects(
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      Authentication authentication) {
+    int size = 5;
+    String userId = authentication.getName();
+    return getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(userId, page, size))
+        .map(result -> PageResponse.of(
+            result.content().stream()
+                .map(ProjectSummaryResponse::from).toList(),
+            result.page(),
+            result.size(),
+            result.totalElements()));
   }
 
   @PreAuthorize("hasAnyRole('ADMIN')")

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
@@ -239,7 +239,8 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
         .exchange()
         .expectStatus().isBadRequest()
         .expectBody()
-        .jsonPath("$.reason").isEqualTo(CommonErrorCode.INVALID_PARAMETER.code());
+        .jsonPath("$.reason").isEqualTo(CommonErrorCode.INVALID_PARAMETER.code())
+        .jsonPath("$.detail").isEqualTo("0 이상이어야 합니다");
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
@@ -240,7 +240,9 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
         .expectStatus().isBadRequest()
         .expectBody()
         .jsonPath("$.reason").isEqualTo(CommonErrorCode.INVALID_PARAMETER.code())
-        .jsonPath("$.detail").isEqualTo("0 이상이어야 합니다");
+        .jsonPath("$.detail").value(detail -> assertThat((String) detail)
+            .isNotBlank()
+            .doesNotContain("getMySharedProjects"));
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.schemafy.api.common.constant.ApiPath;
+import com.schemafy.api.common.exception.CommonErrorCode;
 import com.schemafy.api.project.controller.dto.request.CreateProjectRequest;
 import com.schemafy.api.project.controller.dto.request.UpdateProjectMemberRoleRequest;
 import com.schemafy.api.project.controller.dto.request.UpdateProjectRequest;
@@ -175,6 +176,70 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
         .header("Authorization", "Bearer " + accessToken2)
         .exchange()
         .expectStatus().isForbidden();
+  }
+
+  @Test
+  @DisplayName("프로젝트 전용 멤버는 공유 프로젝트 목록 조회에 성공한다")
+  void getMySharedProjectsSuccessForProjectOnlyMember() {
+    Workspace sharedWorkspace = saveWorkspace("Shared Workspace", "Description");
+    addWorkspaceMember(sharedWorkspace.getId(), testUserId, WorkspaceRole.ADMIN);
+
+    Project sharedProject = saveProject(sharedWorkspace.getId(), "Shared Project", "Description");
+    Project newerSharedProject = saveProject(sharedWorkspace.getId(), "Newer Shared Project", "Description");
+    addProjectMember(sharedProject.getId(), testUserId, ProjectRole.ADMIN);
+    addProjectMember(newerSharedProject.getId(), testUserId, ProjectRole.ADMIN);
+    addProjectMember(sharedProject.getId(), testUser2Id, ProjectRole.VIEWER);
+    addProjectMember(newerSharedProject.getId(), testUser2Id, ProjectRole.EDITOR);
+
+    webTestClient.get()
+        .uri(ApiPath.API.replace("{version}", "v1.0")
+            + "/projects/shared/me?page=0")
+        .header("Authorization", "Bearer " + accessToken2)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(document("project-my-shared-list",
+            ProjectApiSnippets.getMySharedProjectsRequestHeaders(),
+            ProjectApiSnippets.getMySharedProjectsQueryParameters(),
+            ProjectApiSnippets.getMySharedProjectsResponseHeaders(),
+            ProjectApiSnippets.getMySharedProjectsResponse()))
+        .jsonPath("$.content[0].id").isEqualTo(newerSharedProject.getId())
+        .jsonPath("$.content[0].workspaceId").isEqualTo(sharedWorkspace.getId())
+        .jsonPath("$.content[0].myRole").isEqualTo(ProjectRole.EDITOR.name())
+        .jsonPath("$.content[1].id").isEqualTo(sharedProject.getId())
+        .jsonPath("$.content[1].myRole").isEqualTo(ProjectRole.VIEWER.name())
+        .jsonPath("$.totalElements").isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("활성 워크스페이스 멤버인 프로젝트는 공유 프로젝트 목록에서 제외된다")
+  void getMySharedProjectsExcludesActiveWorkspaceMembership() {
+    Project project = saveProject(testWorkspaceId, "Workspace Project", "Description");
+    addProjectMember(project.getId(), testUser2Id, ProjectRole.VIEWER);
+
+    webTestClient.get()
+        .uri(ApiPath.API.replace("{version}", "v1.0")
+            + "/projects/shared/me?page=0")
+        .header("Authorization", "Bearer " + accessToken2)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.content").isArray()
+        .jsonPath("$.content").isEmpty()
+        .jsonPath("$.totalElements").isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("공유 프로젝트 목록 조회 시 page가 0 미만이면 400 Bad Request를 반환한다")
+  void getMySharedProjectsFailWhenPageIsInvalid() {
+    webTestClient.get()
+        .uri(ApiPath.API.replace("{version}", "v1.0")
+            + "/projects/shared/me?page=-1")
+        .header("Authorization", "Bearer " + accessToken2)
+        .exchange()
+        .expectStatus().isBadRequest()
+        .expectBody()
+        .jsonPath("$.reason").isEqualTo(CommonErrorCode.INVALID_PARAMETER.code());
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectApiSnippets.java
@@ -146,6 +146,49 @@ public class ProjectApiSnippets extends RestDocsSnippets {
             projectSummaryFields("content[]."))));
   }
 
+  // ========== GET /api/projects/shared/me - 공유 프로젝트 목록 조회 ==========
+
+  /** 공유 프로젝트 목록 조회 요청 헤더 */
+  public static Snippet getMySharedProjectsRequestHeaders() {
+    return createRequestHeadersSnippet(authorizationHeader());
+  }
+
+  /** 공유 프로젝트 목록 조회 쿼리 파라미터 */
+  public static Snippet getMySharedProjectsQueryParameters() {
+    return queryParameters(
+        parameterWithName("page").description("페이지 번호 (0부터 시작, 기본값: 0)")
+            .optional());
+  }
+
+  /** 공유 프로젝트 목록 조회 응답 헤더 */
+  public static Snippet getMySharedProjectsResponseHeaders() {
+    return createResponseHeadersSnippet(commonResponseHeaders());
+  }
+
+  /** 공유 프로젝트 목록 조회 응답 */
+  public static Snippet getMySharedProjectsResponse() {
+    return createResponseFieldsSnippet(
+        successResponseFields(concat(
+            new FieldDescriptor[] {
+              fieldWithPath("content[]")
+                  .type(JsonFieldType.ARRAY)
+                  .description("프로젝트 목록"),
+              fieldWithPath("page")
+                  .type(JsonFieldType.NUMBER)
+                  .description("현재 페이지 번호 (0부터 시작)"),
+              fieldWithPath("size")
+                  .type(JsonFieldType.NUMBER)
+                  .description("페이지 크기"),
+              fieldWithPath("totalElements")
+                  .type(JsonFieldType.NUMBER)
+                  .description("전체 프로젝트 개수"),
+              fieldWithPath("totalPages")
+                  .type(JsonFieldType.NUMBER)
+                  .description("전체 페이지 수")
+            },
+            projectSummaryFields("content[]."))));
+  }
+
   // ========== GET /api/projects/{projectId} - 프로젝트 상세 조회 ==========
 
   /** 프로젝트 상세 조회 경로 파라미터 */

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
@@ -51,6 +51,24 @@ public interface ProjectMemberRepository
       String userId, int limit, int offset);
 
   @Query("""
+      SELECT pm.role FROM project_members pm
+      INNER JOIN projects p ON pm.project_id = p.id
+      WHERE pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_members wm
+          WHERE wm.workspace_id = p.workspace_id
+            AND wm.user_id = :userId
+            AND wm.deleted_at IS NULL
+        )
+      ORDER BY p.created_at DESC, p.id DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<String> findSharedRolesByUserIdWithPaging(String userId, int limit,
+      int offset);
+
+  @Query("""
       SELECT COUNT(*) FROM project_members pm
       INNER JOIN projects p ON pm.project_id = p.id
       WHERE p.workspace_id = :workspaceId
@@ -81,5 +99,20 @@ public interface ProjectMemberRepository
       """)
   Flux<ProjectMember> findByWorkspaceIdAndUserId(String workspaceId,
       String userId);
+
+  @Query("""
+      SELECT COUNT(*) FROM project_members pm
+      INNER JOIN projects p ON pm.project_id = p.id
+      WHERE pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_members wm
+          WHERE wm.workspace_id = p.workspace_id
+            AND wm.user_id = :userId
+            AND wm.deleted_at IS NULL
+        )
+      """)
+  Mono<Long> countSharedByUserId(String userId);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -63,6 +63,13 @@ public class ProjectPersistenceAdapter
   }
 
   @Override
+  public Flux<Project> findSharedByUserIdWithPaging(String userId,
+      int limit, int offset) {
+    return projectRepository.findSharedByUserIdWithPaging(userId, limit,
+        offset);
+  }
+
+  @Override
   public Mono<ProjectMember> save(ProjectMember projectMember) {
     return projectMemberRepository.save(projectMember);
   }
@@ -125,6 +132,13 @@ public class ProjectPersistenceAdapter
   }
 
   @Override
+  public Flux<String> findSharedRolesByUserIdWithPaging(String userId,
+      int limit, int offset) {
+    return projectMemberRepository.findSharedRolesByUserIdWithPaging(userId,
+        limit, offset);
+  }
+
+  @Override
   public Mono<Long> countByWorkspaceIdAndUserId(String workspaceId,
       String userId) {
     return projectMemberRepository.countByWorkspaceIdAndUserId(workspaceId,
@@ -143,6 +157,11 @@ public class ProjectPersistenceAdapter
       String userId) {
     return projectMemberRepository.findByWorkspaceIdAndUserId(workspaceId,
         userId);
+  }
+
+  @Override
+  public Mono<Long> countSharedByUserId(String userId) {
+    return projectMemberRepository.countSharedByUserId(userId);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
@@ -35,4 +35,23 @@ public interface ProjectRepository extends ReactiveCrudRepository<Project, Strin
   Flux<Project> findByWorkspaceIdAndUserIdWithPaging(String workspaceId,
       String userId, int limit, int offset);
 
+  @Query("""
+      SELECT p.* FROM projects p
+      INNER JOIN project_members pm ON p.id = pm.project_id
+      WHERE pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_members wm
+          WHERE wm.workspace_id = p.workspace_id
+            AND wm.user_id = :userId
+            AND wm.deleted_at IS NULL
+        )
+      ORDER BY p.created_at DESC, p.id DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<Project> findSharedByUserIdWithPaging(String userId,
+      int limit,
+      int offset);
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMySharedProjectsQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMySharedProjectsQuery.java
@@ -1,0 +1,7 @@
+package com.schemafy.core.project.application.port.in;
+
+public record GetMySharedProjectsQuery(
+    String requesterId,
+    int page,
+    int size) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMySharedProjectsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMySharedProjectsUseCase.java
@@ -1,0 +1,12 @@
+package com.schemafy.core.project.application.port.in;
+
+import com.schemafy.core.common.PageResult;
+
+import reactor.core.publisher.Mono;
+
+public interface GetMySharedProjectsUseCase {
+
+  Mono<PageResult<ProjectSummary>> getMySharedProjects(
+      GetMySharedProjectsQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectMemberPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectMemberPort.java
@@ -40,6 +40,11 @@ public interface ProjectMemberPort {
       int limit,
       int offset);
 
+  Flux<String> findSharedRolesByUserIdWithPaging(
+      String userId,
+      int limit,
+      int offset);
+
   Mono<Long> countByWorkspaceIdAndUserId(String workspaceId, String userId);
 
   Mono<Long> softDeleteByWorkspaceIdAndUserId(String workspaceId,
@@ -47,5 +52,7 @@ public interface ProjectMemberPort {
 
   Flux<ProjectMember> findByWorkspaceIdAndUserId(String workspaceId,
       String userId);
+
+  Mono<Long> countSharedByUserId(String userId);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
@@ -25,4 +25,7 @@ public interface ProjectPort {
       int limit,
       int offset);
 
+  Flux<Project> findSharedByUserIdWithPaging(String userId, int limit,
+      int offset);
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMySharedProjectsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMySharedProjectsService.java
@@ -1,0 +1,45 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsUseCase;
+import com.schemafy.core.project.application.port.in.ProjectSummary;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.domain.ProjectRole;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class GetMySharedProjectsService implements GetMySharedProjectsUseCase {
+
+  private final ProjectPort projectPort;
+  private final ProjectMemberPort projectMemberPort;
+
+  @Override
+  public Mono<PageResult<ProjectSummary>> getMySharedProjects(
+      GetMySharedProjectsQuery query) {
+    int offset = query.page() * query.size();
+    return projectMemberPort.countSharedByUserId(query.requesterId())
+        .flatMap(totalElements -> Mono.zip(
+            projectPort.findSharedByUserIdWithPaging(query.requesterId(),
+                query.size(), offset)
+                .collectList(),
+            projectMemberPort.findSharedRolesByUserIdWithPaging(
+                query.requesterId(), query.size(), offset)
+                .collectList())
+            .flatMap(tuple -> Flux.range(0, tuple.getT1().size())
+                .map(index -> new ProjectSummary(
+                    tuple.getT1().get(index),
+                    ProjectRole.fromString(tuple.getT2().get(index))))
+                .collectList()
+                .map(content -> PageResult.of(content, query.page(),
+                    query.size(), totalElements))));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectDomainIntegrationSupport.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectDomainIntegrationSupport.java
@@ -201,6 +201,11 @@ abstract class ProjectDomainIntegrationSupport {
         memberId);
   }
 
+  protected void softDeleteProject(String projectId) {
+    update("UPDATE projects SET deleted_at = CURRENT_TIMESTAMP WHERE id = :id",
+        projectId);
+  }
+
   protected void softDeleteProjectMember(String memberId) {
     update("UPDATE project_members SET deleted_at = CURRENT_TIMESTAMP WHERE id = :id",
         memberId);

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -263,36 +263,20 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("공유받은 프로젝트 조회시 공유 받은 프로젝트만 포함하고 활성 워크스페이스 및 삭제된 행은 제외한다")
-  void getMySharedProjects_filtersBySharedMembershipRules() {
+  @DisplayName("워크스페이스 멤버가 아니고 프로젝트 멤버인 경우 shared 프로젝트로 조회된다")
+  void getMySharedProjects_includesProjectOnlyMembership() {
     User requester = signUpUser("shared-requester@test.com", "Requester");
     User owner = signUpUser("shared-owner@test.com", "Owner");
 
-    Workspace sharedWorkspace = saveWorkspace("Shared WS", "Description");
-    saveWorkspaceMember(sharedWorkspace, owner, WorkspaceRole.ADMIN);
-    var sharedProject = saveProject(sharedWorkspace, "Shared Project");
+    Workspace workspace = saveWorkspace("Shared WS", "Description");
+    saveWorkspaceMember(workspace, owner, WorkspaceRole.ADMIN);
+    var sharedProject = saveProject(workspace, "Shared Project");
     saveProjectMember(sharedProject, owner, ProjectRole.ADMIN);
     saveProjectMember(sharedProject, requester, ProjectRole.VIEWER);
 
-    var secondSharedProject = saveProject(sharedWorkspace, "Second Shared Project");
+    var secondSharedProject = saveProject(workspace, "Second Shared Project");
     saveProjectMember(secondSharedProject, owner, ProjectRole.ADMIN);
     saveProjectMember(secondSharedProject, requester, ProjectRole.EDITOR);
-
-    Workspace activeWorkspace = saveWorkspace("Active WS", "Description");
-    saveWorkspaceMember(activeWorkspace, owner, WorkspaceRole.ADMIN);
-    saveWorkspaceMember(activeWorkspace, requester, WorkspaceRole.MEMBER);
-    var activeWorkspaceProject = saveProject(activeWorkspace, "Active Workspace Project");
-    saveProjectMember(activeWorkspaceProject, owner, ProjectRole.ADMIN);
-    saveProjectMember(activeWorkspaceProject, requester, ProjectRole.VIEWER);
-
-    Workspace deletedMembershipWorkspace = saveWorkspace("Deleted PM WS", "Description");
-    saveWorkspaceMember(deletedMembershipWorkspace, owner, WorkspaceRole.ADMIN);
-    var deletedMembershipProject = saveProject(deletedMembershipWorkspace,
-        "Deleted Membership Project");
-    saveProjectMember(deletedMembershipProject, owner, ProjectRole.ADMIN);
-    ProjectMember deletedProjectMember = saveProjectMember(deletedMembershipProject, requester,
-        ProjectRole.VIEWER);
-    softDeleteProjectMember(deletedProjectMember.getId());
 
     var result = getMySharedProjectsUseCase.getMySharedProjects(
         new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
@@ -301,6 +285,135 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     assertThat(result.content().get(0).project().getId()).isEqualTo(secondSharedProject.getId());
     assertThat(result.content().get(0).role()).isEqualTo(ProjectRole.EDITOR);
     assertThat(result.content().get(1).project().getId()).isEqualTo(sharedProject.getId());
+    assertThat(result.content().get(1).role()).isEqualTo(ProjectRole.VIEWER);
+    assertThat(result.totalElements()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("해당 워크스페이스의 active MEMBER면 shared 프로젝트에서 제외된다")
+  void getMySharedProjects_excludesWorkspaceMember() {
+    User requester = signUpUser("shared-member-requester@test.com", "Requester");
+    User owner = signUpUser("shared-member-owner@test.com", "Owner");
+
+    Workspace workspace = saveWorkspace("Shared Member WS", "Description");
+    saveWorkspaceMember(workspace, owner, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.MEMBER);
+    var project = saveProject(workspace, "Shared Member Project");
+    saveProjectMember(project, owner, ProjectRole.ADMIN);
+    saveProjectMember(project, requester, ProjectRole.VIEWER);
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).isEmpty();
+    assertThat(result.totalElements()).isZero();
+  }
+
+  @Test
+  @DisplayName("해당 워크스페이스의 active ADMIN이어도 shared 프로젝트에서 제외된다")
+  void getMySharedProjects_excludesWorkspaceAdmin() {
+    User requester = signUpUser("shared-admin-requester@test.com", "Requester");
+    User owner = signUpUser("shared-admin-owner@test.com", "Owner");
+
+    Workspace workspace = saveWorkspace("Shared Admin WS", "Description");
+    saveWorkspaceMember(workspace, owner, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.ADMIN);
+    var project = saveProject(workspace, "Shared Admin Project");
+    saveProjectMember(project, owner, ProjectRole.ADMIN);
+    saveProjectMember(project, requester, ProjectRole.ADMIN);
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).isEmpty();
+    assertThat(result.totalElements()).isZero();
+  }
+
+  @Test
+  @DisplayName("삭제된 프로젝트는 shared 프로젝트에서 제외된다")
+  void getMySharedProjects_excludesDeletedProject() {
+    User requester = signUpUser("shared-deleted-project-requester@test.com", "Requester");
+    User owner = signUpUser("shared-deleted-project-owner@test.com", "Owner");
+
+    Workspace workspace = saveWorkspace("Deleted Shared Project WS", "Description");
+    saveWorkspaceMember(workspace, owner, WorkspaceRole.ADMIN);
+    var activeProject = saveProject(workspace, "Active Shared Project");
+    saveProjectMember(activeProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(activeProject, requester, ProjectRole.VIEWER);
+
+    var deletedProject = saveProject(workspace, "Deleted Shared Project");
+    saveProjectMember(deletedProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(deletedProject, requester, ProjectRole.EDITOR);
+    softDeleteProject(deletedProject.getId());
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).hasSize(1);
+    assertThat(result.content().getFirst().project().getId()).isEqualTo(activeProject.getId());
+    assertThat(result.content().getFirst().role()).isEqualTo(ProjectRole.VIEWER);
+    assertThat(result.totalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("삭제된 프로젝트 멤버십은 shared 프로젝트에서 제외된다")
+  void getMySharedProjects_excludesDeletedProjectMembership() {
+    User requester = signUpUser("shared-deleted-member-requester@test.com", "Requester");
+    User owner = signUpUser("shared-deleted-member-owner@test.com", "Owner");
+
+    Workspace workspace = saveWorkspace("Deleted Shared Membership WS", "Description");
+    saveWorkspaceMember(workspace, owner, WorkspaceRole.ADMIN);
+    var activeProject = saveProject(workspace, "Active Shared Membership Project");
+    saveProjectMember(activeProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(activeProject, requester, ProjectRole.VIEWER);
+
+    var deletedMembershipProject = saveProject(workspace, "Deleted Shared Membership Project");
+    saveProjectMember(deletedMembershipProject, owner, ProjectRole.ADMIN);
+    ProjectMember deletedProjectMember = saveProjectMember(
+        deletedMembershipProject, requester, ProjectRole.EDITOR);
+    softDeleteProjectMember(deletedProjectMember.getId());
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).hasSize(1);
+    assertThat(result.content().getFirst().project().getId()).isEqualTo(activeProject.getId());
+    assertThat(result.content().getFirst().role()).isEqualTo(ProjectRole.VIEWER);
+    assertThat(result.totalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("다른 워크스페이스에 속해 있어도 별도 워크스페이스의 shared 프로젝트는 role과 정렬을 유지한 채 조회된다")
+  void getMySharedProjects_keepsOtherWorkspaceSharedProjects() {
+    User requester = signUpUser("shared-cross-workspace-requester@test.com", "Requester");
+    User owner = signUpUser("shared-cross-workspace-owner@test.com", "Owner");
+
+    Workspace activeWorkspace = saveWorkspace("Active Workspace", "Description");
+    saveWorkspaceMember(activeWorkspace, owner, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(activeWorkspace, requester, WorkspaceRole.MEMBER);
+    var activeWorkspaceProject = saveProject(activeWorkspace, "Active Workspace Project");
+    saveProjectMember(activeWorkspaceProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(activeWorkspaceProject, requester, ProjectRole.VIEWER);
+
+    Workspace firstSharedWorkspace = saveWorkspace("First Shared Workspace", "Description");
+    saveWorkspaceMember(firstSharedWorkspace, owner, WorkspaceRole.ADMIN);
+    var olderSharedProject = saveProject(firstSharedWorkspace, "Older Shared Project");
+    saveProjectMember(olderSharedProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(olderSharedProject, requester, ProjectRole.VIEWER);
+
+    Workspace secondSharedWorkspace = saveWorkspace("Second Shared Workspace", "Description");
+    saveWorkspaceMember(secondSharedWorkspace, owner, WorkspaceRole.ADMIN);
+    var newerSharedProject = saveProject(secondSharedWorkspace, "Newer Shared Project");
+    saveProjectMember(newerSharedProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(newerSharedProject, requester, ProjectRole.EDITOR);
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).hasSize(2);
+    assertThat(result.content().get(0).project().getId()).isEqualTo(newerSharedProject.getId());
+    assertThat(result.content().get(0).role()).isEqualTo(ProjectRole.EDITOR);
+    assertThat(result.content().get(1).project().getId()).isEqualTo(olderSharedProject.getId());
     assertThat(result.content().get(1).role()).isEqualTo(ProjectRole.VIEWER);
     assertThat(result.totalElements()).isEqualTo(2);
   }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -10,6 +10,8 @@ import com.schemafy.core.project.application.port.in.CreateProjectCommand;
 import com.schemafy.core.project.application.port.in.CreateProjectUseCase;
 import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.GetMySharedProjectsUseCase;
 import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
 import com.schemafy.core.project.application.port.in.LeaveProjectUseCase;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
@@ -45,6 +47,9 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
   @Autowired
   private LeaveProjectUseCase leaveProjectUseCase;
+
+  @Autowired
+  private GetMySharedProjectsUseCase getMySharedProjectsUseCase;
 
   @Test
   @DisplayName("프로젝트 생성 시 활성 워크스페이스 멤버를 프로젝트 역할로 추가한다")
@@ -255,6 +260,49 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     leaveProjectUseCase.leaveProject(new LeaveProjectCommand(project.getId(), member.id())).block();
 
     assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
+  }
+
+  @Test
+  @DisplayName("공유받은 프로젝트 조회시 공유 받은 프로젝트만 포함하고 활성 워크스페이스 및 삭제된 행은 제외한다")
+  void getMySharedProjects_filtersBySharedMembershipRules() {
+    User requester = signUpUser("shared-requester@test.com", "Requester");
+    User owner = signUpUser("shared-owner@test.com", "Owner");
+
+    Workspace sharedWorkspace = saveWorkspace("Shared WS", "Description");
+    saveWorkspaceMember(sharedWorkspace, owner, WorkspaceRole.ADMIN);
+    var sharedProject = saveProject(sharedWorkspace, "Shared Project");
+    saveProjectMember(sharedProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(sharedProject, requester, ProjectRole.VIEWER);
+
+    var secondSharedProject = saveProject(sharedWorkspace, "Second Shared Project");
+    saveProjectMember(secondSharedProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(secondSharedProject, requester, ProjectRole.EDITOR);
+
+    Workspace activeWorkspace = saveWorkspace("Active WS", "Description");
+    saveWorkspaceMember(activeWorkspace, owner, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(activeWorkspace, requester, WorkspaceRole.MEMBER);
+    var activeWorkspaceProject = saveProject(activeWorkspace, "Active Workspace Project");
+    saveProjectMember(activeWorkspaceProject, owner, ProjectRole.ADMIN);
+    saveProjectMember(activeWorkspaceProject, requester, ProjectRole.VIEWER);
+
+    Workspace deletedMembershipWorkspace = saveWorkspace("Deleted PM WS", "Description");
+    saveWorkspaceMember(deletedMembershipWorkspace, owner, WorkspaceRole.ADMIN);
+    var deletedMembershipProject = saveProject(deletedMembershipWorkspace,
+        "Deleted Membership Project");
+    saveProjectMember(deletedMembershipProject, owner, ProjectRole.ADMIN);
+    ProjectMember deletedProjectMember = saveProjectMember(deletedMembershipProject, requester,
+        ProjectRole.VIEWER);
+    softDeleteProjectMember(deletedProjectMember.getId());
+
+    var result = getMySharedProjectsUseCase.getMySharedProjects(
+        new GetMySharedProjectsQuery(requester.id(), 0, 10)).block();
+
+    assertThat(result.content()).hasSize(2);
+    assertThat(result.content().get(0).project().getId()).isEqualTo(secondSharedProject.getId());
+    assertThat(result.content().get(0).role()).isEqualTo(ProjectRole.EDITOR);
+    assertThat(result.content().get(1).project().getId()).isEqualTo(sharedProject.getId());
+    assertThat(result.content().get(1).role()).isEqualTo(ProjectRole.VIEWER);
+    assertThat(result.totalElements()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
## 개요
공유받은 프로젝트 조회 API 구현 PR 입니다.

## 작성한 테스트 케이스
- 워크스페이스 멤버는 아니지만 프로젝트 멤버인 경우 shared 프로젝트 목록에 포함된다.
- 해당 프로젝트가 속한 워크스페이스의 active MEMBER, ADMIN이면 shared 프로젝트 목록에서 제외된다.
  - 워크스페이스에 이미 속해있는 멤버는 shared 기능이 아닌 프로젝트 재가입을 이용해야 합니다.(멤버였다가 프로젝트를 나간 경우)
- 삭제된 프로젝트는 shared 프로젝트 목록에서 제외된다.
- 삭제된 프로젝트 멤버는 shared 프로젝트 목록에서 제외된다.
- 다른 워크스페이스에 active membership이 있어도, 별도 워크스페이스의 shared 프로젝트는 정상적으로 조회된다.
- page가 0 미만이면 400 Bad Request를 반환한다.

## 이슈
구현하면서 persistence layer에서 조회하는 부분에 개선이 필요해 내용 남깁니다. 
엔티티 단위로 조회할 때 조인을 활용해 projection을 활용해 쿼리 조회를 개선해야 할 것 같습니다.
(e.g. ProjectSummary의 경우 project 와 project_member 모두 같은 조건절이지만 각각 조회해서 합쳐서 처리하고 있는데 이런 부분을 프로젝션을 활용하면 좋을 것 같습니다.)

이번 작업때 같이 할까 싶었지만 공통으로 작업할 내용도 많고, 브랜치가 커질까봐 내용만 남겼습니다.
추가적으로 해당 내용과 관련해 projection의 경우 어떤 패키지에 둘까 고민이 됩니다. 

같은 속성을 가지는 dto에 대해서 매번 엄격하게 분리를 해야할까에 대한 고민이었는데요.
아래 사례에서도 같은 속성이지만 레이어 마다 다르게 구분을 두어 구분해서 분리를 하더라구요. 다른분들의 고견 부탁드리겠습니다~
https://blog.hwahae.co.kr/all/tech/15004


- close #264