### PR TITLE
feat(#296): expand ERD mutation operation contract

### DIFF
--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -4,5 +4,155 @@
   ],
   ".github/workflows/save-pr-context.yml": [
     317
+  ],
+  "apps/backend/api/src/docs/asciidoc/api-guide.adoc": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/common/security/CorsProperties.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java": [
+    337
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/common/docs/RestDocsSnippets.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ErdOperationFixtures.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java": [
+    337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/CommittedErdOperation.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionResult.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionUseCase.java": [
+    337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionService.java": [
+    337
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionServiceTest.java": [
+    337
+  ],
+  "apps/bff/src/common/backend-client/backend-client.service.ts": [
+    337
+  ],
+  "apps/bff/src/common/decorators/collaboration-headers.decorator.ts": [
+    337
+  ],
+  "apps/bff/src/erd/column.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/column.service.ts": [
+    337
+  ],
+  "apps/bff/src/erd/constraint.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/constraint.service.ts": [
+    337
+  ],
+  "apps/bff/src/erd/erd.types.ts": [
+    337
+  ],
+  "apps/bff/src/erd/index.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/index.service.ts": [
+    337
+  ],
+  "apps/bff/src/erd/relationship.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/relationship.service.ts": [
+    337
+  ],
+  "apps/bff/src/erd/schema.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/schema.service.ts": [
+    337
+  ],
+  "apps/bff/src/erd/table.controller.ts": [
+    337
+  ],
+  "apps/bff/src/erd/table.service.ts": [
+    337
+  ],
+  "apps/bff/src/main.ts": [
+    337
+  ],
+  "apps/frontend/src/features/collaboration/api/types.ts": [
+    337
+  ],
+  "apps/frontend/src/features/drawing/api/column.api.ts": [
+    337
+  ],
+  "apps/frontend/src/features/drawing/api/constraint.api.ts": [
+    337
   ]
 }

--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -7,7 +7,8 @@
     317
   ],
   ".github/pr-contexts/file-index.json": [
-    335
+    335,
+    337
   ],
   "apps/backend/api/src/docs/asciidoc/api-guide.adoc": [
     337

--- a/apps/backend/api/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/api/src/docs/asciidoc/api-guide.adoc
@@ -1519,6 +1519,36 @@ ERD mutation API를 호출할 때 `X-Session-Id` 헤더를 함께 전송하면, 
 
 NOTE: `X-Session-Id`를 전송하지 않으면 모든 접속자에게 이벤트가 브로드캐스트됩니다.
 
+==== X-Client-Op-Id 헤더
+
+ERD mutation API를 호출할 때 `X-Client-Op-Id` 헤더를 함께 전송하면, 서버는 해당 값을 커밋된 operation metadata에 기록합니다. 이 값은 HTTP mutation 응답의 `operation.clientOperationId`와 `ERD_MUTATED.operation.clientOperationId`로 다시 전달됩니다.
+
+[cols="1,2,1"]
+|===
+|헤더 |설명 |필수
+
+|`X-Client-Op-Id`
+|클라이언트가 생성한 operation 상관관계 ID
+|선택
+|===
+
+TIP: 클라이언트는 재시도 중인 동일 요청에 같은 `X-Client-Op-Id`를 재사용하여 HTTP 응답과 WebSocket 이벤트를 안전하게 매칭할 수 있습니다.
+
+==== X-Base-Schema-Revision 헤더
+
+ERD mutation API를 호출할 때 `X-Base-Schema-Revision` 헤더를 함께 전송하면, 서버는 요청 시점에 클라이언트가 알고 있던 schema revision을 함께 수신합니다.
+
+[cols="1,2,1"]
+|===
+|헤더 |설명 |필수
+
+|`X-Base-Schema-Revision`
+|클라이언트가 요청 생성 시점에 알고 있던 schema revision
+|선택
+|===
+
+NOTE: mutation 성공 후 실제 커밋 revision은 HTTP mutation 응답의 `operation.committedRevision`과 `ERD_MUTATED.operation.committedRevision`으로 확인할 수 있습니다.
+
 ==== 대상 API
 
 다음 API들이 mutation 수행 후 `ERD_MUTATED` 이벤트를 발생시킵니다.
@@ -4089,6 +4119,12 @@ ERD가 변경(생성, 수정, 삭제)되었을 때 브로드캐스트됩니다. 
   "sessionId": "session-uuid",
   "schemaId": "01HNQD...",
   "affectedTableIds": ["01HNQE...", "01HNQF..."],
+  "operation": {
+    "opId": "01HNQG...",
+    "clientOperationId": "client-op-123",
+    "committedRevision": 42,
+    "derivationKind": "ORIGINAL"
+  },
   "timestamp": 1703577600000
 }
 ----
@@ -4114,6 +4150,26 @@ ERD가 변경(생성, 수정, 삭제)되었을 때 브로드캐스트됩니다. 
 |`affectedTableIds`
 |변경의 영향을 받은 테이블 ID 목록 (ULID). 스키마 수준 변경(스키마 생성/삭제 등)에서는 빈 배열일 수 있습니다.
 |Array<String>
+
+|`operation`
+|커밋된 ERD operation 메타데이터
+|Object
+
+|`operation.opId`
+|커밋된 operation ID
+|String
+
+|`operation.clientOperationId`
+|클라이언트가 보낸 operation ID. 헤더를 보내지 않은 경우 `null`일 수 있습니다.
+|String|null
+
+|`operation.committedRevision`
+|커밋 완료 후 schema revision
+|Number
+
+|`operation.derivationKind`
+|operation derivation kind
+|String
 
 |`timestamp`
 |이벤트 발생 시간 (Unix milliseconds)

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
@@ -3,6 +3,7 @@ package com.schemafy.api.collaboration.dto.event;
 import java.util.Set;
 
 import com.schemafy.api.collaboration.dto.CursorPosition;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public final class CollaborationOutboundFactory {
 
@@ -42,8 +43,15 @@ public final class CollaborationOutboundFactory {
 
   public static ErdMutatedEvent.Outbound erdMutated(String sessionId,
       String schemaId, Set<String> affectedTableIds) {
+    return erdMutated(sessionId, schemaId, affectedTableIds, null);
+  }
+
+  public static ErdMutatedEvent.Outbound erdMutated(String sessionId,
+      String schemaId,
+      Set<String> affectedTableIds,
+      CommittedErdOperation operation) {
     return ErdMutatedEvent.Outbound.of(sessionId, schemaId,
-        affectedTableIds);
+        affectedTableIds, operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
@@ -42,11 +42,6 @@ public final class CollaborationOutboundFactory {
   }
 
   public static ErdMutatedEvent.Outbound erdMutated(String sessionId,
-      String schemaId, Set<String> affectedTableIds) {
-    return erdMutated(sessionId, schemaId, affectedTableIds, null);
-  }
-
-  public static ErdMutatedEvent.Outbound erdMutated(String sessionId,
       String schemaId,
       Set<String> affectedTableIds,
       CommittedErdOperation operation) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public final class ErdMutatedEvent {
 
@@ -14,17 +15,30 @@ public final class ErdMutatedEvent {
       String sessionId,
       String schemaId,
       Set<String> affectedTableIds,
+      CommittedErdOperation operation,
       long timestamp) implements CollaborationOutbound {
 
     public static Outbound of(String sessionId, String schemaId,
         Set<String> affectedTableIds) {
+      return of(sessionId, schemaId, affectedTableIds, null);
+    }
+
+    public static Outbound of(String sessionId, String schemaId,
+        Set<String> affectedTableIds,
+        CommittedErdOperation operation) {
       return new Outbound(sessionId, schemaId, affectedTableIds,
-          System.currentTimeMillis());
+          operation, System.currentTimeMillis());
     }
 
     public static Outbound of(String schemaId,
         Set<String> affectedTableIds) {
-      return of(null, schemaId, affectedTableIds);
+      return of(null, schemaId, affectedTableIds, null);
+    }
+
+    public static Outbound of(String schemaId,
+        Set<String> affectedTableIds,
+        CommittedErdOperation operation) {
+      return of(null, schemaId, affectedTableIds, operation);
     }
 
     @Override

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java
@@ -19,26 +19,10 @@ public final class ErdMutatedEvent {
       long timestamp) implements CollaborationOutbound {
 
     public static Outbound of(String sessionId, String schemaId,
-        Set<String> affectedTableIds) {
-      return of(sessionId, schemaId, affectedTableIds, null);
-    }
-
-    public static Outbound of(String sessionId, String schemaId,
         Set<String> affectedTableIds,
         CommittedErdOperation operation) {
       return new Outbound(sessionId, schemaId, affectedTableIds,
           operation, System.currentTimeMillis());
-    }
-
-    public static Outbound of(String schemaId,
-        Set<String> affectedTableIds) {
-      return of(null, schemaId, affectedTableIds, null);
-    }
-
-    public static Outbound of(String schemaId,
-        Set<String> affectedTableIds,
-        CommittedErdOperation operation) {
-      return of(null, schemaId, affectedTableIds, operation);
     }
 
     @Override

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/security/CorsProperties.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/security/CorsProperties.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import com.schemafy.api.collaboration.constant.CollaborationConstants;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,7 +21,10 @@ public class CorsProperties {
 
   private final List<String> allowedHeaders = List.of("Authorization",
       "Content-Type", "X-Requested-With", "Accept",
-      "X-Hmac-Signature", "X-Hmac-Timestamp", "X-Hmac-Nonce");
+      "X-Hmac-Signature", "X-Hmac-Timestamp", "X-Hmac-Nonce",
+      CollaborationConstants.SESSION_ID_HEADER,
+      CollaborationConstants.CLIENT_OPERATION_ID_HEADER,
+      CollaborationConstants.BASE_SCHEMA_REVISION_HEADER);
 
   private final List<String> exposedHeaders = List.of("Authorization",
       "Content-Type");

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
@@ -12,10 +12,6 @@ public record MutationResponse<T>(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     CommittedErdOperation operation) {
 
-  public static <T> MutationResponse<T> of(T data, Collection<String> affectedTableIds) {
-    return of(data, affectedTableIds, null);
-  }
-
   public static <T> MutationResponse<T> of(T data,
       Collection<String> affectedTableIds,
       CommittedErdOperation operation) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
@@ -3,13 +3,27 @@ package com.schemafy.api.common.type;
 import java.util.Collection;
 import java.util.List;
 
-public record MutationResponse<T>(T data, List<String> affectedTableIds) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MutationResponse<T>(
+    T data,
+    List<String> affectedTableIds,
+    CommittedErdOperation operation) {
 
   public static <T> MutationResponse<T> of(T data, Collection<String> affectedTableIds) {
+    return of(data, affectedTableIds, null);
+  }
+
+  public static <T> MutationResponse<T> of(T data,
+      Collection<String> affectedTableIds,
+      CommittedErdOperation operation) {
     if (affectedTableIds == null || affectedTableIds.isEmpty()) {
-      return new MutationResponse<>(data, List.of());
+      return new MutationResponse<>(data, List.of(), operation);
     }
-    return new MutationResponse<>(data, List.copyOf(affectedTableIds));
+    return new MutationResponse<>(data, List.copyOf(affectedTableIds),
+        operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
@@ -9,8 +9,7 @@ import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 public record MutationResponse<T>(
     T data,
     List<String> affectedTableIds,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    CommittedErdOperation operation) {
+    @JsonInclude(JsonInclude.Include.NON_NULL) CommittedErdOperation operation) {
 
   public static <T> MutationResponse<T> of(T data,
       Collection<String> affectedTableIds,

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/type/MutationResponse.java
@@ -6,10 +6,10 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MutationResponse<T>(
     T data,
     List<String> affectedTableIds,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     CommittedErdOperation operation) {
 
   public static <T> MutationResponse<T> of(T data, Collection<String> affectedTableIds) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
@@ -29,10 +29,6 @@ public class ErdMutationBroadcaster {
   public record ResolvedContext(String projectId, String schemaId) {
   }
 
-  public Mono<Void> broadcast(Set<String> affectedTableIds) {
-    return broadcast(affectedTableIds, null);
-  }
-
   public Mono<Void> broadcast(Set<String> affectedTableIds,
       CommittedErdOperation operation) {
     if (affectedTableIds == null || affectedTableIds.isEmpty()) {
@@ -47,10 +43,6 @@ public class ErdMutationBroadcaster {
         .onErrorResume(e -> Mono.empty());
   }
 
-  public Mono<Void> broadcastSchemaChange(String schemaId) {
-    return broadcastSchemaChange(schemaId, null);
-  }
-
   public Mono<Void> broadcastSchemaChange(String schemaId,
       CommittedErdOperation operation) {
     return resolveFromSchemaId(schemaId)
@@ -59,11 +51,6 @@ public class ErdMutationBroadcaster {
             "[ErdMutationBroadcaster] broadcastSchemaChange failed: schemaId={}, error={}",
             schemaId, e.getMessage()))
         .onErrorResume(e -> Mono.empty());
-  }
-
-  public Mono<Void> broadcastWithContext(ResolvedContext ctx,
-      Set<String> affectedTableIds) {
-    return broadcastWithContext(ctx, affectedTableIds, null);
   }
 
   public Mono<Void> broadcastWithContext(ResolvedContext ctx,

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
@@ -8,6 +8,7 @@ import com.schemafy.api.collaboration.constant.CollaborationConstants;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;
 
@@ -29,12 +30,17 @@ public class ErdMutationBroadcaster {
   }
 
   public Mono<Void> broadcast(Set<String> affectedTableIds) {
+    return broadcast(affectedTableIds, null);
+  }
+
+  public Mono<Void> broadcast(Set<String> affectedTableIds,
+      CommittedErdOperation operation) {
     if (affectedTableIds == null || affectedTableIds.isEmpty()) {
       return Mono.empty();
     }
     String anyTableId = affectedTableIds.iterator().next();
     return resolveFromTableId(anyTableId)
-        .flatMap(ctx -> publish(ctx, affectedTableIds))
+        .flatMap(ctx -> publish(ctx, affectedTableIds, operation))
         .doOnError(e -> log.warn(
             "[ErdMutationBroadcaster] broadcast failed: {}",
             e.getMessage()))
@@ -42,8 +48,13 @@ public class ErdMutationBroadcaster {
   }
 
   public Mono<Void> broadcastSchemaChange(String schemaId) {
+    return broadcastSchemaChange(schemaId, null);
+  }
+
+  public Mono<Void> broadcastSchemaChange(String schemaId,
+      CommittedErdOperation operation) {
     return resolveFromSchemaId(schemaId)
-        .flatMap(ctx -> publish(ctx, Set.of()))
+        .flatMap(ctx -> publish(ctx, Set.of(), operation))
         .doOnError(e -> log.warn(
             "[ErdMutationBroadcaster] broadcastSchemaChange failed: schemaId={}, error={}",
             schemaId, e.getMessage()))
@@ -52,7 +63,13 @@ public class ErdMutationBroadcaster {
 
   public Mono<Void> broadcastWithContext(ResolvedContext ctx,
       Set<String> affectedTableIds) {
-    return publish(ctx, affectedTableIds)
+    return broadcastWithContext(ctx, affectedTableIds, null);
+  }
+
+  public Mono<Void> broadcastWithContext(ResolvedContext ctx,
+      Set<String> affectedTableIds,
+      CommittedErdOperation operation) {
+    return publish(ctx, affectedTableIds, operation)
         .doOnError(e -> log.warn(
             "[ErdMutationBroadcaster] broadcastWithContext failed: {}",
             e.getMessage()))
@@ -71,13 +88,14 @@ public class ErdMutationBroadcaster {
   }
 
   private Mono<Void> publish(ResolvedContext ctx,
-      Set<String> affectedTableIds) {
+      Set<String> affectedTableIds,
+      CommittedErdOperation operation) {
     return Mono.deferContextual(reactorCtx -> {
       String sessionId = reactorCtx.getOrDefault(
           CollaborationConstants.SESSION_ID_CONTEXT_KEY, null);
       return eventPublisher.publish(ctx.projectId(),
           CollaborationOutboundFactory.erdMutated(sessionId,
-              ctx.schemaId(), affectedTableIds));
+              ctx.schemaId(), affectedTableIds, operation));
     });
   }
 

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
@@ -41,6 +41,7 @@ import com.schemafy.core.erd.column.application.port.in.GetColumnQuery;
 import com.schemafy.core.erd.column.application.port.in.GetColumnUseCase;
 import com.schemafy.core.erd.column.application.port.in.GetColumnsByTableIdQuery;
 import com.schemafy.core.erd.column.application.port.in.GetColumnsByTableIdUseCase;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -194,7 +195,7 @@ public class ColumnController {
   }
 
   private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
@@ -80,11 +80,13 @@ public class ColumnController {
         request.comment(),
         request.values());
     return createColumnUseCase.createColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             ColumnResponse.from(result.result(), request.tableId()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -116,9 +118,11 @@ public class ColumnController {
         columnId,
         request.newName());
     return changeColumnNameUseCase.changeColumnName(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -134,9 +138,11 @@ public class ColumnController {
         request.scale(),
         request.values());
     return changeColumnTypeUseCase.changeColumnType(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -151,9 +157,11 @@ public class ColumnController {
         toPatchField(request.collation()),
         toPatchField(request.comment()));
     return changeColumnMetaUseCase.changeColumnMeta(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -165,9 +173,11 @@ public class ColumnController {
         columnId,
         request.seqNo());
     return changeColumnPositionUseCase.changeColumnPosition(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -176,17 +186,20 @@ public class ColumnController {
       @PathVariable String columnId) {
     DeleteColumnCommand command = new DeleteColumnCommand(columnId);
     return deleteColumnUseCase.deleteColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastMutation(Set<String> affectedTableIds) {
+  private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcast(affectedTableIds);
+    return broadcaster.broadcast(affectedTableIds, operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
@@ -92,11 +92,13 @@ public class ConstraintController {
         request.defaultExpr(),
         mapConstraintColumns(request.columns()));
     return createConstraintUseCase.createConstraint(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             ConstraintResponse.from(result.result(), request.tableId()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -131,9 +133,11 @@ public class ConstraintController {
         constraintId,
         request.checkExpr().orElse(null));
     return changeConstraintCheckExprUseCase.changeConstraintCheckExpr(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -148,9 +152,11 @@ public class ConstraintController {
         constraintId,
         request.defaultExpr().orElse(null));
     return changeConstraintDefaultExprUseCase.changeConstraintDefaultExpr(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -162,9 +168,11 @@ public class ConstraintController {
         constraintId,
         request.newName());
     return changeConstraintNameUseCase.changeConstraintName(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -173,9 +181,11 @@ public class ConstraintController {
       @PathVariable String constraintId) {
     DeleteConstraintCommand command = new DeleteConstraintCommand(constraintId);
     return deleteConstraintUseCase.deleteConstraint(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -199,11 +209,13 @@ public class ConstraintController {
         request.columnId(),
         request.seqNo());
     return addConstraintColumnUseCase.addConstraintColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             AddConstraintColumnResponse.from(result.result()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -213,9 +225,11 @@ public class ConstraintController {
     RemoveConstraintColumnCommand command = new RemoveConstraintColumnCommand(
         constraintColumnId);
     return removeConstraintColumnUseCase.removeConstraintColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -236,17 +250,20 @@ public class ConstraintController {
         constraintColumnId,
         request.seqNo());
     return changeConstraintColumnPositionUseCase.changeConstraintColumnPosition(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastMutation(Set<String> affectedTableIds) {
+  private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcast(affectedTableIds);
+    return broadcaster.broadcast(affectedTableIds, operation);
   }
 
   private static List<CreateConstraintColumnCommand> mapConstraintColumns(

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
@@ -56,6 +56,7 @@ import com.schemafy.core.erd.constraint.application.port.in.GetConstraintsByTabl
 import com.schemafy.core.erd.constraint.application.port.in.RemoveConstraintColumnCommand;
 import com.schemafy.core.erd.constraint.application.port.in.RemoveConstraintColumnUseCase;
 import com.schemafy.core.erd.constraint.domain.exception.ConstraintErrorCode;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -258,7 +259,7 @@ public class ConstraintController {
   }
 
   private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
@@ -54,6 +54,7 @@ import com.schemafy.core.erd.index.application.port.in.GetIndexesByTableIdQuery;
 import com.schemafy.core.erd.index.application.port.in.GetIndexesByTableIdUseCase;
 import com.schemafy.core.erd.index.application.port.in.RemoveIndexColumnCommand;
 import com.schemafy.core.erd.index.application.port.in.RemoveIndexColumnUseCase;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -248,7 +249,7 @@ public class IndexController {
   }
 
   private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
@@ -88,11 +88,13 @@ public class IndexController {
         request.type(),
         mapIndexColumns(request.columns()));
     return createIndexUseCase.createIndex(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             IndexResponse.from(result.result(), request.tableId()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -124,9 +126,11 @@ public class IndexController {
         indexId,
         request.newName());
     return changeIndexNameUseCase.changeIndexName(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -138,9 +142,11 @@ public class IndexController {
         indexId,
         request.type());
     return changeIndexTypeUseCase.changeIndexType(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -149,9 +155,11 @@ public class IndexController {
       @PathVariable String indexId) {
     DeleteIndexCommand command = new DeleteIndexCommand(indexId);
     return deleteIndexUseCase.deleteIndex(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -176,11 +184,13 @@ public class IndexController {
         request.seqNo(),
         request.sortDirection());
     return addIndexColumnUseCase.addIndexColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             AddIndexColumnResponse.from(result.result()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -189,9 +199,11 @@ public class IndexController {
       @PathVariable String indexColumnId) {
     RemoveIndexColumnCommand command = new RemoveIndexColumnCommand(indexColumnId);
     return removeIndexColumnUseCase.removeIndexColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -212,9 +224,11 @@ public class IndexController {
         indexColumnId,
         request.seqNo());
     return changeIndexColumnPositionUseCase.changeIndexColumnPosition(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -226,17 +240,20 @@ public class IndexController {
         indexColumnId,
         request.sortDirection());
     return changeIndexColumnSortDirectionUseCase.changeIndexColumnSortDirection(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastMutation(Set<String> affectedTableIds) {
+  private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcast(affectedTableIds);
+    return broadcaster.broadcast(affectedTableIds, operation);
   }
 
   private static List<CreateIndexColumnCommand> mapIndexColumns(

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
@@ -31,6 +31,7 @@ import com.schemafy.api.erd.controller.dto.response.RelationshipColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.RelationshipResponse;
 import com.schemafy.api.erd.service.relationship.RelationshipApiResponseMapper;
 import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.relationship.application.port.in.AddRelationshipColumnCommand;
 import com.schemafy.core.erd.relationship.application.port.in.AddRelationshipColumnUseCase;
 import com.schemafy.core.erd.relationship.application.port.in.ChangeRelationshipCardinalityCommand;
@@ -274,7 +275,7 @@ public class RelationshipController {
   }
 
   private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
@@ -95,12 +95,14 @@ public class RelationshipController {
         request.cardinality(),
         jsonCodec.canonicalizeOptional(request.extra()));
     return createRelationshipUseCase.createRelationship(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             relationshipResponseMapper.toRelationshipResponse(
                 result.result()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -132,9 +134,11 @@ public class RelationshipController {
         relationshipId,
         request.newName());
     return changeRelationshipNameUseCase.changeRelationshipName(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -146,9 +150,11 @@ public class RelationshipController {
         relationshipId,
         request.kind());
     return changeRelationshipKindUseCase.changeRelationshipKind(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -160,9 +166,11 @@ public class RelationshipController {
         relationshipId,
         request.cardinality());
     return changeRelationshipCardinalityUseCase.changeRelationshipCardinality(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -174,9 +182,11 @@ public class RelationshipController {
         relationshipId,
         jsonCodec.canonicalizeOptional(request.extra()));
     return changeRelationshipExtraUseCase.changeRelationshipExtra(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -185,9 +195,11 @@ public class RelationshipController {
       @PathVariable String relationshipId) {
     DeleteRelationshipCommand command = new DeleteRelationshipCommand(relationshipId);
     return deleteRelationshipUseCase.deleteRelationship(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -213,11 +225,13 @@ public class RelationshipController {
         request.fkColumnId(),
         request.seqNo());
     return addRelationshipColumnUseCase.addRelationshipColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             AddRelationshipColumnResponse.from(result.result()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -227,9 +241,11 @@ public class RelationshipController {
     RemoveRelationshipColumnCommand command = new RemoveRelationshipColumnCommand(
         relationshipColumnId);
     return removeRelationshipColumnUseCase.removeRelationshipColumn(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -250,17 +266,20 @@ public class RelationshipController {
         relationshipColumnId,
         request.seqNo());
     return changeRelationshipColumnPositionUseCase.changeRelationshipColumnPosition(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastMutation(Set<String> affectedTableIds) {
+  private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcast(affectedTableIds);
+    return broadcaster.broadcast(affectedTableIds, operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
@@ -60,11 +60,13 @@ public class SchemaController {
         request.collation());
     return createSchemaUseCase.createSchema(command)
         .flatMap(result -> broadcastSchemaChange(
-            result.result().id())
+            result.result().id(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             SchemaResponse.from(result.result()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -95,9 +97,10 @@ public class SchemaController {
         schemaId,
         request.newName());
     return changeSchemaNameUseCase.changeSchemaName(command)
-        .flatMap(result -> broadcastSchemaChange(schemaId)
+        .flatMap(result -> broadcastSchemaChange(schemaId, result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -108,22 +111,26 @@ public class SchemaController {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return deleteSchemaUseCase.deleteSchema(command)
-          .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+          .map(result -> MutationResponse.<Void>of(null,
+              result.affectedTableIds(), result.operation()));
     }
     return broadcaster.resolveFromSchemaId(schemaId)
         .flatMap(ctx -> deleteSchemaUseCase.deleteSchema(command)
             .flatMap(result -> broadcaster
-                .broadcastWithContext(ctx, result.affectedTableIds())
+                .broadcastWithContext(ctx, result.affectedTableIds(),
+                    result.operation())
                 .thenReturn(result)))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastSchemaChange(String schemaId) {
+  private Mono<Void> broadcastSchemaChange(String schemaId,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcastSchemaChange(schemaId);
+    return broadcaster.broadcastSchemaChange(schemaId, operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
@@ -22,6 +22,7 @@ import com.schemafy.api.erd.controller.dto.request.ChangeSchemaNameRequest;
 import com.schemafy.api.erd.controller.dto.request.CreateSchemaRequest;
 import com.schemafy.api.erd.controller.dto.response.SchemaResponse;
 import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameCommand;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameUseCase;
 import com.schemafy.core.erd.schema.application.port.in.CreateSchemaCommand;
@@ -129,7 +130,7 @@ public class SchemaController {
   }
 
   private Mono<Void> broadcastSchemaChange(String schemaId,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
@@ -21,7 +21,6 @@ import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.ChangeSchemaNameRequest;
 import com.schemafy.api.erd.controller.dto.request.CreateSchemaRequest;
 import com.schemafy.api.erd.controller.dto.response.SchemaResponse;
-import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameCommand;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameUseCase;
@@ -30,7 +29,7 @@ import com.schemafy.core.erd.schema.application.port.in.CreateSchemaUseCase;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaCommand;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaUseCase;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemaQuery;
-import com.schemafy.core.erd.schema.application.port.in.GetSchemaUseCase;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaWithRevisionUseCase;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemasByProjectIdQuery;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemasByProjectIdUseCase;
 
@@ -43,11 +42,10 @@ import reactor.core.publisher.Mono;
 public class SchemaController {
 
   private final CreateSchemaUseCase createSchemaUseCase;
-  private final GetSchemaUseCase getSchemaUseCase;
+  private final GetSchemaWithRevisionUseCase getSchemaWithRevisionUseCase;
   private final GetSchemasByProjectIdUseCase getSchemasByProjectIdUseCase;
   private final ChangeSchemaNameUseCase changeSchemaNameUseCase;
   private final DeleteSchemaUseCase deleteSchemaUseCase;
-  private final FindSchemaCollaborationStatePort findSchemaCollaborationStatePort;
 
   private final ObjectProvider<ErdMutationBroadcaster> broadcasterProvider;
 
@@ -77,10 +75,8 @@ public class SchemaController {
   public Mono<SchemaResponse> getSchema(
       @PathVariable String schemaId) {
     GetSchemaQuery query = new GetSchemaQuery(schemaId);
-    return getSchemaUseCase.getSchema(query)
-        .flatMap(schema -> findSchemaCollaborationStatePort.findBySchemaId(schemaId)
-            .map(state -> SchemaResponse.from(schema, state.currentRevision()))
-            .defaultIfEmpty(SchemaResponse.from(schema, 0L)));
+    return getSchemaWithRevisionUseCase.getSchemaWithRevision(query)
+        .map(result -> SchemaResponse.from(result.schema(), result.currentRevision()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
@@ -21,6 +21,7 @@ import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.ChangeSchemaNameRequest;
 import com.schemafy.api.erd.controller.dto.request.CreateSchemaRequest;
 import com.schemafy.api.erd.controller.dto.response.SchemaResponse;
+import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameCommand;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameUseCase;
 import com.schemafy.core.erd.schema.application.port.in.CreateSchemaCommand;
@@ -45,6 +46,7 @@ public class SchemaController {
   private final GetSchemasByProjectIdUseCase getSchemasByProjectIdUseCase;
   private final ChangeSchemaNameUseCase changeSchemaNameUseCase;
   private final DeleteSchemaUseCase deleteSchemaUseCase;
+  private final FindSchemaCollaborationStatePort findSchemaCollaborationStatePort;
 
   private final ObjectProvider<ErdMutationBroadcaster> broadcasterProvider;
 
@@ -75,7 +77,9 @@ public class SchemaController {
       @PathVariable String schemaId) {
     GetSchemaQuery query = new GetSchemaQuery(schemaId);
     return getSchemaUseCase.getSchema(query)
-        .map(SchemaResponse::from);
+        .flatMap(schema -> findSchemaCollaborationStatePort.findBySchemaId(schemaId)
+            .map(state -> SchemaResponse.from(schema, state.currentRevision()))
+            .defaultIfEmpty(SchemaResponse.from(schema, 0L)));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
@@ -30,6 +30,7 @@ import com.schemafy.api.erd.controller.dto.response.TableSnapshotResponse;
 import com.schemafy.api.erd.service.TableSnapshotOrchestrator;
 import com.schemafy.api.erd.service.table.TableApiResponseMapper;
 import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraCommand;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraUseCase;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableMetaCommand;
@@ -193,7 +194,7 @@ public class TableController {
   }
 
   private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
-      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
+      CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
@@ -79,12 +79,14 @@ public class TableController {
         request.collation(),
         jsonCodec.canonicalizeOptional(request.extra()));
     return createTableUseCase.createTable(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
         .map(result -> MutationResponse.of(
             tableResponseMapper.toTableResponse(result.result(),
                 request.schemaId()),
-            result.affectedTableIds()));
+            result.affectedTableIds(),
+            result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR','COMMENTER','VIEWER')")
@@ -129,9 +131,11 @@ public class TableController {
         tableId,
         request.newName());
     return changeTableNameUseCase.changeTableName(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -144,9 +148,11 @@ public class TableController {
         toPatchField(request.charset()),
         toPatchField(request.collation()));
     return changeTableMetaUseCase.changeTableMeta(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN','EDITOR')")
@@ -158,9 +164,11 @@ public class TableController {
         tableId,
         jsonCodec.canonicalizeOptional(request.extra()));
     return changeTableExtraUseCase.changeTableExtra(command)
-        .flatMap(result -> broadcastMutation(result.affectedTableIds())
+        .flatMap(result -> broadcastMutation(result.affectedTableIds(),
+            result.operation())
             .thenReturn(result))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
   @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
@@ -171,22 +179,26 @@ public class TableController {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return deleteTableUseCase.deleteTable(command)
-          .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+          .map(result -> MutationResponse.<Void>of(null,
+              result.affectedTableIds(), result.operation()));
     }
     return broadcaster.resolveFromTableId(tableId)
         .flatMap(ctx -> deleteTableUseCase.deleteTable(command)
             .flatMap(result -> broadcaster
-                .broadcastWithContext(ctx, result.affectedTableIds())
+                .broadcastWithContext(ctx, result.affectedTableIds(),
+                    result.operation())
                 .thenReturn(result)))
-        .map(result -> MutationResponse.<Void>of(null, result.affectedTableIds()));
+        .map(result -> MutationResponse.<Void>of(null,
+            result.affectedTableIds(), result.operation()));
   }
 
-  private Mono<Void> broadcastMutation(Set<String> affectedTableIds) {
+  private Mono<Void> broadcastMutation(Set<String> affectedTableIds,
+      com.schemafy.core.erd.operation.domain.CommittedErdOperation operation) {
     ErdMutationBroadcaster broadcaster = broadcasterProvider.getIfAvailable();
     if (broadcaster == null) {
       return Mono.empty();
     }
-    return broadcaster.broadcast(affectedTableIds);
+    return broadcaster.broadcast(affectedTableIds, operation);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java
@@ -1,5 +1,6 @@
 package com.schemafy.api.erd.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.schemafy.core.erd.schema.application.port.in.CreateSchemaResult;
 import com.schemafy.core.erd.schema.domain.Schema;
 
@@ -9,7 +10,9 @@ public record SchemaResponse(
     String dbVendorName,
     String name,
     String charset,
-    String collation) {
+    String collation,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Long currentRevision) {
 
   public static SchemaResponse from(CreateSchemaResult result) {
     return new SchemaResponse(
@@ -18,7 +21,8 @@ public record SchemaResponse(
         result.dbVendorName(),
         result.name(),
         result.charset(),
-        result.collation());
+        result.collation(),
+        null);
   }
 
   public static SchemaResponse from(Schema schema) {
@@ -28,7 +32,19 @@ public record SchemaResponse(
         schema.dbVendorName(),
         schema.name(),
         schema.charset(),
-        schema.collation());
+        schema.collation(),
+        null);
+  }
+
+  public static SchemaResponse from(Schema schema, long currentRevision) {
+    return new SchemaResponse(
+        schema.id(),
+        schema.projectId(),
+        schema.dbVendorName(),
+        schema.name(),
+        schema.charset(),
+        schema.collation(),
+        currentRevision);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java
@@ -11,8 +11,7 @@ public record SchemaResponse(
     String name,
     String charset,
     String collation,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    Long currentRevision) {
+    @JsonInclude(JsonInclude.Include.NON_NULL) Long currentRevision) {
 
   public static SchemaResponse from(CreateSchemaResult result) {
     return new SchemaResponse(

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java
@@ -7,11 +7,19 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("ErdMutatedEvent 직렬화 테스트")
 class ErdMutatedEventTest {
+
+  private static final CommittedErdOperation OPERATION = new CommittedErdOperation(
+      "op-1",
+      "client-op-1",
+      42L,
+      ErdOperationDerivationKind.ORIGINAL);
 
   private final ObjectMapper objectMapper = new ObjectMapper()
       .findAndRegisterModules();
@@ -20,12 +28,14 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound 직렬화 시 type 디스크리미네이터가 포함된다")
   void serialize_includes_type_discriminator() throws Exception {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of("table-1", "table-2"));
+        "schema-1", Set.of("table-1", "table-2"), OPERATION);
 
     String json = objectMapper.writeValueAsString(event);
 
     assertThat(json).contains("\"type\":\"ERD_MUTATED\"");
     assertThat(json).contains("\"schemaId\":\"schema-1\"");
+    assertThat(json).contains("\"opId\":\"op-1\"");
+    assertThat(json).contains("\"committedRevision\":42");
     assertThat(json).contains("\"table-1\"");
     assertThat(json).contains("\"table-2\"");
   }
@@ -34,7 +44,7 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound 역직렬화 시 올바른 타입으로 복원된다")
   void deserialize_restores_correct_type() throws Exception {
     ErdMutatedEvent.Outbound original = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of("table-1"));
+        "schema-1", Set.of("table-1"), OPERATION);
 
     String json = objectMapper.writeValueAsString(original);
     CollaborationOutbound deserialized = objectMapper.readValue(json,
@@ -45,6 +55,7 @@ class ErdMutatedEventTest {
     assertThat(event.type()).isEqualTo(CollaborationEventType.ERD_MUTATED);
     assertThat(event.schemaId()).isEqualTo("schema-1");
     assertThat(event.affectedTableIds()).containsExactly("table-1");
+    assertThat(event.operation()).isEqualTo(OPERATION);
     assertThat(event.sessionId()).isNull();
   }
 
@@ -52,9 +63,10 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound of 팩토리 메서드가 sessionId를 null로 설정한다")
   void of_sets_null_session_id() {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of());
+        "schema-1", Set.of(), OPERATION);
 
     assertThat(event.sessionId()).isNull();
+    assertThat(event.operation()).isEqualTo(OPERATION);
     assertThat(event.timestamp()).isGreaterThan(0);
   }
 
@@ -62,22 +74,24 @@ class ErdMutatedEventTest {
   @DisplayName("sessionId가 있는 이벤트는 직렬화 시 sessionId를 포함한다")
   void serialize_with_session_id_includes_session_id() throws Exception {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "session-1", "schema-1", Set.of("table-1"));
+        "session-1", "schema-1", Set.of("table-1"), OPERATION);
 
     String json = objectMapper.writeValueAsString(event);
 
     assertThat(json).contains("\"sessionId\":\"session-1\"");
     assertThat(json).contains("\"schemaId\":\"schema-1\"");
+    assertThat(json).contains("\"derivationKind\":\"ORIGINAL\"");
   }
 
   @Test
   @DisplayName("sessionId가 있는 팩토리 메서드가 정상 동작한다")
   void of_with_session_id() {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "session-1", "schema-1", Set.of("table-1"));
+        "session-1", "schema-1", Set.of("table-1"), OPERATION);
 
     assertThat(event.sessionId()).isEqualTo("session-1");
     assertThat(event.schemaId()).isEqualTo("schema-1");
+    assertThat(event.operation()).isEqualTo(OPERATION);
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java
@@ -28,7 +28,7 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound 직렬화 시 type 디스크리미네이터가 포함된다")
   void serialize_includes_type_discriminator() throws Exception {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of("table-1", "table-2"), OPERATION);
+        null, "schema-1", Set.of("table-1", "table-2"), OPERATION);
 
     String json = objectMapper.writeValueAsString(event);
 
@@ -44,7 +44,7 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound 역직렬화 시 올바른 타입으로 복원된다")
   void deserialize_restores_correct_type() throws Exception {
     ErdMutatedEvent.Outbound original = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of("table-1"), OPERATION);
+        null, "schema-1", Set.of("table-1"), OPERATION);
 
     String json = objectMapper.writeValueAsString(original);
     CollaborationOutbound deserialized = objectMapper.readValue(json,
@@ -63,7 +63,7 @@ class ErdMutatedEventTest {
   @DisplayName("Outbound of 팩토리 메서드가 sessionId를 null로 설정한다")
   void of_sets_null_session_id() {
     ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
-        "schema-1", Set.of(), OPERATION);
+        null, "schema-1", Set.of(), OPERATION);
 
     assertThat(event.sessionId()).isNull();
     assertThat(event.operation()).isEqualTo(OPERATION);

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
@@ -11,6 +11,8 @@ import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.dto.event.CursorEvent;
 import com.schemafy.api.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 
 import reactor.test.StepVerifier;
 
@@ -18,6 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("CollaborationPayloadSerializer 테스트")
 class CollaborationPayloadSerializerTest {
+
+  private static final CommittedErdOperation OPERATION = new CommittedErdOperation(
+      "op-1",
+      "client-op-1",
+      42L,
+      ErdOperationDerivationKind.ORIGINAL);
 
   private final CollaborationPayloadSerializer serializer = new CollaborationPayloadSerializer(
       new JsonCodec(new ObjectMapper().findAndRegisterModules()));
@@ -58,11 +66,12 @@ class CollaborationPayloadSerializerTest {
   void serialize_includes_session_id_for_erd_mutated() {
     StepVerifier.create(serializer.serialize(
         CollaborationOutboundFactory.erdMutated("session-1", "schema-1",
-            Set.of("table-1"))))
+            Set.of("table-1"), OPERATION)))
         .assertNext(json -> {
           assertThat(json).contains("\"type\":\"ERD_MUTATED\"");
           assertThat(json).contains("\"sessionId\":\"session-1\"");
           assertThat(json).contains("\"schemaId\":\"schema-1\"");
+          assertThat(json).contains("\"opId\":\"op-1\"");
         })
         .verifyComplete();
   }
@@ -71,10 +80,12 @@ class CollaborationPayloadSerializerTest {
   @DisplayName("sessionId가 없는 ERD_MUTATED 직렬화 시 sessionId를 생략한다")
   void serialize_omits_session_id_when_erd_mutated_has_no_session() {
     StepVerifier.create(serializer.serialize(
-        ErdMutatedEvent.Outbound.of("schema-1", Set.of("table-1"))))
+        ErdMutatedEvent.Outbound.of("schema-1", Set.of("table-1"),
+            OPERATION)))
         .assertNext(json -> {
           assertThat(json).contains("\"type\":\"ERD_MUTATED\"");
           assertThat(json).contains("\"schemaId\":\"schema-1\"");
+          assertThat(json).contains("\"committedRevision\":42");
           assertThat(json).doesNotContain("sessionId");
         })
         .verifyComplete();

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
@@ -80,8 +80,8 @@ class CollaborationPayloadSerializerTest {
   @DisplayName("sessionId가 없는 ERD_MUTATED 직렬화 시 sessionId를 생략한다")
   void serialize_omits_session_id_when_erd_mutated_has_no_session() {
     StepVerifier.create(serializer.serialize(
-        ErdMutatedEvent.Outbound.of("schema-1", Set.of("table-1"),
-            OPERATION)))
+        ErdMutatedEvent.Outbound.of(null, "schema-1",
+            Set.of("table-1"), OPERATION)))
         .assertNext(json -> {
           assertThat(json).contains("\"type\":\"ERD_MUTATED\"");
           assertThat(json).contains("\"schemaId\":\"schema-1\"");

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/docs/RestDocsSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/docs/RestDocsSnippets.java
@@ -71,7 +71,20 @@ public abstract class RestDocsSnippets {
       fieldWithPath("data").type(JsonFieldType.OBJECT)
           .description("생성/수정된 데이터").optional(),
       fieldWithPath("affectedTableIds").type(JsonFieldType.ARRAY)
-          .description("영향받은 테이블 ID 목록")
+          .description("영향받은 테이블 ID 목록"),
+      fieldWithPath("operation").type(JsonFieldType.OBJECT)
+          .description("커밋된 ERD operation 메타데이터").optional(),
+      fieldWithPath("operation.opId").type(JsonFieldType.STRING)
+          .description("커밋된 operation ID").optional(),
+      fieldWithPath("operation.clientOperationId")
+          .type(JsonFieldType.VARIES)
+          .description("클라이언트가 보낸 operation ID").optional(),
+      fieldWithPath("operation.committedRevision")
+          .type(JsonFieldType.NUMBER)
+          .description("커밋 후 schema revision").optional(),
+      fieldWithPath("operation.derivationKind")
+          .type(JsonFieldType.STRING)
+          .description("operation derivation kind").optional()
     };
     return concat(baseFields, dataFields);
   }
@@ -82,7 +95,20 @@ public abstract class RestDocsSnippets {
       fieldWithPath("data").type(JsonFieldType.NULL)
           .description("응답 데이터 (없음)").optional(),
       fieldWithPath("affectedTableIds").type(JsonFieldType.ARRAY)
-          .description("영향받은 테이블 ID 목록")
+          .description("영향받은 테이블 ID 목록"),
+      fieldWithPath("operation").type(JsonFieldType.OBJECT)
+          .description("커밋된 ERD operation 메타데이터").optional(),
+      fieldWithPath("operation.opId").type(JsonFieldType.STRING)
+          .description("커밋된 operation ID").optional(),
+      fieldWithPath("operation.clientOperationId")
+          .type(JsonFieldType.VARIES)
+          .description("클라이언트가 보낸 operation ID").optional(),
+      fieldWithPath("operation.committedRevision")
+          .type(JsonFieldType.NUMBER)
+          .description("커밋 후 schema revision").optional(),
+      fieldWithPath("operation.derivationKind")
+          .type(JsonFieldType.STRING)
+          .description("operation derivation kind").optional()
     };
   }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
@@ -132,7 +132,7 @@ class ErdMutationBroadcasterTest {
     @Test
     @DisplayName("빈 affectedTableIds이면 skip한다")
     void skips_when_empty_table_ids() {
-      StepVerifier.create(broadcaster.broadcast(Set.of()))
+      StepVerifier.create(broadcaster.broadcast(Set.of(), null))
           .verifyComplete();
 
       verify(getTableByIdPort, never()).findTableById(any());
@@ -141,7 +141,7 @@ class ErdMutationBroadcasterTest {
     @Test
     @DisplayName("null이면 skip한다")
     void skips_when_null() {
-      StepVerifier.create(broadcaster.broadcast(null))
+      StepVerifier.create(broadcaster.broadcast(null, null))
           .verifyComplete();
 
       verify(getTableByIdPort, never()).findTableById(any());
@@ -156,7 +156,7 @@ class ErdMutationBroadcasterTest {
       given(getTableByIdPort.findTableById(tableId))
           .willReturn(Mono.error(new RuntimeException("DB down")));
 
-      StepVerifier.create(broadcaster.broadcast(tableIds))
+      StepVerifier.create(broadcaster.broadcast(tableIds, null))
           .verifyComplete();
 
       verify(eventPublisher, never()).publish(any(), any());
@@ -180,7 +180,7 @@ class ErdMutationBroadcasterTest {
           any(CollaborationOutbound.class)))
           .willReturn(Mono.error(new RuntimeException("Redis down")));
 
-      StepVerifier.create(broadcaster.broadcast(tableIds))
+      StepVerifier.create(broadcaster.broadcast(tableIds, null))
           .verifyComplete();
     }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
@@ -15,6 +15,8 @@ import com.schemafy.api.collaboration.constant.CollaborationConstants;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.api.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
 import com.schemafy.core.erd.schema.domain.Schema;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;
@@ -33,6 +35,12 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ErdMutationBroadcaster 단위 테스트")
 class ErdMutationBroadcasterTest {
+
+  private static final CommittedErdOperation OPERATION = new CommittedErdOperation(
+      "op-1",
+      "client-op-1",
+      42L,
+      ErdOperationDerivationKind.ORIGINAL);
 
   @InjectMocks
   private ErdMutationBroadcaster broadcaster;
@@ -68,7 +76,7 @@ class ErdMutationBroadcasterTest {
           any(CollaborationOutbound.class)))
           .willReturn(Mono.empty());
 
-      StepVerifier.create(broadcaster.broadcast(tableIds))
+      StepVerifier.create(broadcaster.broadcast(tableIds, OPERATION))
           .verifyComplete();
 
       ArgumentCaptor<CollaborationOutbound> captor = ArgumentCaptor
@@ -80,6 +88,7 @@ class ErdMutationBroadcasterTest {
           .getValue();
       assertThat(event.sessionId()).isNull();
       assertThat(event.schemaId()).isEqualTo(schemaId);
+      assertThat(event.operation()).isEqualTo(OPERATION);
       assertThat(event.affectedTableIds()).containsExactly(tableId);
     }
 
@@ -101,7 +110,7 @@ class ErdMutationBroadcasterTest {
           any(CollaborationOutbound.class)))
           .willReturn(Mono.empty());
 
-      StepVerifier.create(broadcaster.broadcast(tableIds)
+      StepVerifier.create(broadcaster.broadcast(tableIds, OPERATION)
           .contextWrite(ctx -> ctx.put(
               CollaborationConstants.SESSION_ID_CONTEXT_KEY,
               "session-1")))
@@ -116,6 +125,7 @@ class ErdMutationBroadcasterTest {
           .getValue();
       assertThat(event.sessionId()).isEqualTo("session-1");
       assertThat(event.schemaId()).isEqualTo(schemaId);
+      assertThat(event.operation()).isEqualTo(OPERATION);
       assertThat(event.affectedTableIds()).containsExactly(tableId);
     }
 
@@ -193,11 +203,16 @@ class ErdMutationBroadcasterTest {
           any(CollaborationOutbound.class)))
           .willReturn(Mono.empty());
 
-      StepVerifier.create(broadcaster.broadcastSchemaChange(schemaId))
+      StepVerifier.create(broadcaster.broadcastSchemaChange(schemaId,
+          OPERATION))
           .verifyComplete();
 
-      verify(eventPublisher).publish(eq(projectId),
-          any(CollaborationOutbound.class));
+      ArgumentCaptor<CollaborationOutbound> captor = ArgumentCaptor
+          .forClass(CollaborationOutbound.class);
+      verify(eventPublisher).publish(eq(projectId), captor.capture());
+      ErdMutatedEvent.Outbound event = (ErdMutatedEvent.Outbound) captor
+          .getValue();
+      assertThat(event.operation()).isEqualTo(OPERATION);
     }
 
   }
@@ -220,11 +235,15 @@ class ErdMutationBroadcasterTest {
           .willReturn(Mono.empty());
 
       StepVerifier.create(
-          broadcaster.broadcastWithContext(ctx, tableIds))
+          broadcaster.broadcastWithContext(ctx, tableIds, OPERATION))
           .verifyComplete();
 
-      verify(eventPublisher).publish(eq(projectId),
-          any(CollaborationOutbound.class));
+      ArgumentCaptor<CollaborationOutbound> captor = ArgumentCaptor
+          .forClass(CollaborationOutbound.class);
+      verify(eventPublisher).publish(eq(projectId), captor.capture());
+      ErdMutatedEvent.Outbound event = (ErdMutatedEvent.Outbound) captor
+          .getValue();
+      assertThat(event.operation()).isEqualTo(OPERATION);
     }
 
   }

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
@@ -48,6 +48,8 @@ import reactor.core.publisher.Mono;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -121,7 +123,9 @@ class ColumnControllerTest {
         "사용자 ID");
 
     given(createColumnUseCase.createColumn(any(CreateColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/columns")
@@ -132,6 +136,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(columnId)
         .consumeWith(document("column-create",
             ColumnApiSnippets.createColumnRequestHeaders(),
@@ -214,7 +219,9 @@ class ColumnControllerTest {
     ChangeColumnNameRequest request = new ChangeColumnNameRequest("new_user_id");
 
     given(changeColumnNameUseCase.changeColumnName(any(ChangeColumnNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/name", columnId)
@@ -225,6 +232,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("column-change-name",
             ColumnApiSnippets.changeColumnNamePathParameters(),
             ColumnApiSnippets.changeColumnNameRequestHeaders(),
@@ -242,7 +250,9 @@ class ColumnControllerTest {
     ChangeColumnTypeRequest request = new ChangeColumnTypeRequest("VARCHAR", 100, null, null, null);
 
     given(changeColumnTypeUseCase.changeColumnType(any(ChangeColumnTypeCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/type", columnId)
@@ -253,6 +263,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("column-change-type",
             ColumnApiSnippets.changeColumnTypePathParameters(),
             ColumnApiSnippets.changeColumnTypeRequestHeaders(),
@@ -268,7 +279,9 @@ class ColumnControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeColumnMetaUseCase.changeColumnMeta(any(ChangeColumnMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/meta", columnId)
@@ -281,6 +294,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("column-change-meta",
             ColumnApiSnippets.changeColumnMetaPathParameters(),
             ColumnApiSnippets.changeColumnMetaRequestHeaders(),
@@ -296,7 +310,9 @@ class ColumnControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeColumnMetaUseCase.changeColumnMeta(any(ChangeColumnMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/meta", columnId)
@@ -308,7 +324,8 @@ class ColumnControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -318,7 +335,9 @@ class ColumnControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeColumnMetaUseCase.changeColumnMeta(any(ChangeColumnMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/meta", columnId)
@@ -330,7 +349,8 @@ class ColumnControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -342,7 +362,9 @@ class ColumnControllerTest {
     ChangeColumnPositionRequest request = new ChangeColumnPositionRequest(3);
 
     given(changeColumnPositionUseCase.changeColumnPosition(any(ChangeColumnPositionCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/columns/{columnId}/position", columnId)
@@ -353,6 +375,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("column-change-position",
             ColumnApiSnippets.changeColumnPositionPathParameters(),
             ColumnApiSnippets.changeColumnPositionRequestHeaders(),
@@ -369,7 +392,9 @@ class ColumnControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(deleteColumnUseCase.deleteColumn(any(DeleteColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/columns/{columnId}", columnId)
@@ -378,6 +403,7 @@ class ColumnControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("column-delete",
             ColumnApiSnippets.deleteColumnPathParameters(),
             ColumnApiSnippets.deleteColumnRequestHeaders(),

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
@@ -45,11 +45,11 @@ import com.schemafy.core.erd.column.domain.ColumnTypeArguments;
 
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
@@ -65,6 +65,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -142,7 +144,9 @@ class ConstraintControllerTest {
         null);
 
     given(createConstraintUseCase.createConstraint(any(CreateConstraintCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/constraints")
@@ -153,6 +157,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(constraintId)
         .consumeWith(document("constraint-create",
             ConstraintApiSnippets.createConstraintRequestHeaders(),
@@ -256,7 +261,9 @@ class ConstraintControllerTest {
     ChangeConstraintCheckExprRequest request = new ChangeConstraintCheckExprRequest(JsonNullable.of("value > 0"));
 
     given(changeConstraintCheckExprUseCase.changeConstraintCheckExpr(any(ChangeConstraintCheckExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/check-expr", constraintId)
@@ -267,6 +274,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-change-check-expr",
             ConstraintApiSnippets.changeConstraintCheckExprPathParameters(),
             ConstraintApiSnippets.changeConstraintCheckExprRequestHeaders(),
@@ -282,7 +290,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeConstraintCheckExprUseCase.changeConstraintCheckExpr(any(ChangeConstraintCheckExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/check-expr", constraintId)
@@ -296,7 +306,8 @@ class ConstraintControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -306,7 +317,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeConstraintCheckExprUseCase.changeConstraintCheckExpr(any(ChangeConstraintCheckExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/check-expr", constraintId)
@@ -320,7 +333,8 @@ class ConstraintControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -352,7 +366,9 @@ class ConstraintControllerTest {
     ChangeConstraintDefaultExprRequest request = new ChangeConstraintDefaultExprRequest(JsonNullable.of("0"));
 
     given(changeConstraintDefaultExprUseCase.changeConstraintDefaultExpr(any(ChangeConstraintDefaultExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/default-expr", constraintId)
@@ -363,6 +379,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-change-default-expr",
             ConstraintApiSnippets.changeConstraintDefaultExprPathParameters(),
             ConstraintApiSnippets.changeConstraintDefaultExprRequestHeaders(),
@@ -378,7 +395,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeConstraintDefaultExprUseCase.changeConstraintDefaultExpr(any(ChangeConstraintDefaultExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/default-expr", constraintId)
@@ -392,7 +411,8 @@ class ConstraintControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -402,7 +422,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeConstraintDefaultExprUseCase.changeConstraintDefaultExpr(any(ChangeConstraintDefaultExprCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/default-expr", constraintId)
@@ -416,7 +438,8 @@ class ConstraintControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -448,7 +471,9 @@ class ConstraintControllerTest {
     ChangeConstraintNameRequest request = new ChangeConstraintNameRequest("pk_users_new");
 
     given(changeConstraintNameUseCase.changeConstraintName(any(ChangeConstraintNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/name", constraintId)
@@ -459,6 +484,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-change-name",
             ConstraintApiSnippets.changeConstraintNamePathParameters(),
             ConstraintApiSnippets.changeConstraintNameRequestHeaders(),
@@ -475,7 +501,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(deleteConstraintUseCase.deleteConstraint(any(DeleteConstraintCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/constraints/{constraintId}", constraintId)
@@ -484,6 +512,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-delete",
             ConstraintApiSnippets.deleteConstraintPathParameters(),
             ConstraintApiSnippets.deleteConstraintRequestHeaders(),
@@ -542,7 +571,9 @@ class ConstraintControllerTest {
         List.of());
 
     given(addConstraintColumnUseCase.addConstraintColumn(any(AddConstraintColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/constraints/{constraintId}/columns", constraintId)
@@ -552,6 +583,7 @@ class ConstraintControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(constraintColumnId)
         .consumeWith(document("constraint-column-add",
             ConstraintApiSnippets.addConstraintColumnPathParameters(),
@@ -568,7 +600,9 @@ class ConstraintControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(removeConstraintColumnUseCase.removeConstraintColumn(any(RemoveConstraintColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/constraint-columns/{constraintColumnId}", constraintColumnId)
@@ -577,6 +611,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-column-remove",
             ConstraintApiSnippets.removeConstraintColumnPathParameters(),
             ConstraintApiSnippets.removeConstraintColumnRequestHeaders(),
@@ -621,7 +656,9 @@ class ConstraintControllerTest {
 
     given(changeConstraintColumnPositionUseCase.changeConstraintColumnPosition(
         any(ChangeConstraintColumnPositionCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/constraint-columns/{constraintColumnId}/position", constraintColumnId)
@@ -632,6 +669,7 @@ class ConstraintControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("constraint-column-change-position",
             ConstraintApiSnippets.changeConstraintColumnPositionPathParameters(),
             ConstraintApiSnippets.changeConstraintColumnPositionRequestHeaders(),

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
@@ -61,12 +61,12 @@ import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
 
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ErdOperationFixtures.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ErdOperationFixtures.java
@@ -9,8 +9,7 @@ final class ErdOperationFixtures {
   static final String CLIENT_OPERATION_ID = "client-op-1";
   static final long COMMITTED_REVISION = 42L;
 
-  private ErdOperationFixtures() {
-  }
+  private ErdOperationFixtures() {}
 
   static CommittedErdOperation committedOperation() {
     return new CommittedErdOperation(

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ErdOperationFixtures.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ErdOperationFixtures.java
@@ -1,0 +1,23 @@
+package com.schemafy.api.erd.controller;
+
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+
+final class ErdOperationFixtures {
+
+  static final String OP_ID = "op-1";
+  static final String CLIENT_OPERATION_ID = "client-op-1";
+  static final long COMMITTED_REVISION = 42L;
+
+  private ErdOperationFixtures() {
+  }
+
+  static CommittedErdOperation committedOperation() {
+    return new CommittedErdOperation(
+        OP_ID,
+        CLIENT_OPERATION_ID,
+        COMMITTED_REVISION,
+        ErdOperationDerivationKind.ORIGINAL);
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
@@ -62,6 +62,8 @@ import reactor.core.publisher.Mono;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -135,7 +137,9 @@ class IndexControllerTest {
         IndexType.BTREE);
 
     given(createIndexUseCase.createIndex(any(CreateIndexCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/indexes")
@@ -145,6 +149,7 @@ class IndexControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(indexId)
         .consumeWith(document("index-create",
             IndexApiSnippets.createIndexRequestHeaders(),
@@ -215,7 +220,9 @@ class IndexControllerTest {
     ChangeIndexNameRequest request = new ChangeIndexNameRequest("idx_users_email_new");
 
     given(changeIndexNameUseCase.changeIndexName(any(ChangeIndexNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/indexes/{indexId}/name", indexId)
@@ -226,6 +233,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-change-name",
             IndexApiSnippets.changeIndexNamePathParameters(),
             IndexApiSnippets.changeIndexNameRequestHeaders(),
@@ -243,7 +251,9 @@ class IndexControllerTest {
     ChangeIndexTypeRequest request = new ChangeIndexTypeRequest(IndexType.HASH);
 
     given(changeIndexTypeUseCase.changeIndexType(any(ChangeIndexTypeCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/indexes/{indexId}/type", indexId)
@@ -254,6 +264,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-change-type",
             IndexApiSnippets.changeIndexTypePathParameters(),
             IndexApiSnippets.changeIndexTypeRequestHeaders(),
@@ -270,7 +281,9 @@ class IndexControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(deleteIndexUseCase.deleteIndex(any(DeleteIndexCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/indexes/{indexId}", indexId)
@@ -279,6 +292,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-delete",
             IndexApiSnippets.deleteIndexPathParameters(),
             IndexApiSnippets.deleteIndexRequestHeaders(),
@@ -337,7 +351,9 @@ class IndexControllerTest {
         SortDirection.ASC);
 
     given(addIndexColumnUseCase.addIndexColumn(any(AddIndexColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/indexes/{indexId}/columns", indexId)
@@ -347,6 +363,7 @@ class IndexControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(indexColumnId)
         .consumeWith(document("index-column-add",
             IndexApiSnippets.addIndexColumnPathParameters(),
@@ -363,7 +380,9 @@ class IndexControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(removeIndexColumnUseCase.removeIndexColumn(any(RemoveIndexColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/index-columns/{indexColumnId}", indexColumnId)
@@ -372,6 +391,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-column-remove",
             IndexApiSnippets.removeIndexColumnPathParameters(),
             IndexApiSnippets.removeIndexColumnRequestHeaders(),
@@ -416,7 +436,9 @@ class IndexControllerTest {
 
     given(changeIndexColumnPositionUseCase.changeIndexColumnPosition(
         any(ChangeIndexColumnPositionCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/index-columns/{indexColumnId}/position", indexColumnId)
@@ -427,6 +449,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-column-change-position",
             IndexApiSnippets.changeIndexColumnPositionPathParameters(),
             IndexApiSnippets.changeIndexColumnPositionRequestHeaders(),
@@ -445,7 +468,9 @@ class IndexControllerTest {
 
     given(changeIndexColumnSortDirectionUseCase.changeIndexColumnSortDirection(
         any(ChangeIndexColumnSortDirectionCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/index-columns/{indexColumnId}/sort-direction", indexColumnId)
@@ -456,6 +481,7 @@ class IndexControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("index-column-change-sort-direction",
             IndexApiSnippets.changeIndexColumnSortDirectionPathParameters(),
             IndexApiSnippets.changeIndexColumnSortDirectionRequestHeaders(),

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
@@ -59,11 +59,11 @@ import com.schemafy.core.erd.index.domain.type.SortDirection;
 
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
@@ -66,6 +66,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -147,7 +149,9 @@ class RelationshipControllerTest {
         null);
 
     given(createRelationshipUseCase.createRelationship(any(CreateRelationshipCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.of(result, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/relationships")
@@ -157,6 +161,7 @@ class RelationshipControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(relationshipId)
         .consumeWith(document("relationship-create",
             RelationshipApiSnippets.createRelationshipRequestHeaders(),
@@ -182,7 +187,9 @@ class RelationshipControllerTest {
         "{\"fkHandle\":\"left\",\"pkHandle\":\"right\"}");
 
     given(createRelationshipUseCase.createRelationship(any(CreateRelationshipCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.of(result, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/relationships")
@@ -391,7 +398,9 @@ class RelationshipControllerTest {
     ChangeRelationshipNameRequest request = new ChangeRelationshipNameRequest("fk_orders_users_new");
 
     given(changeRelationshipNameUseCase.changeRelationshipName(any(ChangeRelationshipNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/name", relationshipId)
@@ -402,6 +411,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-change-name",
             RelationshipApiSnippets.changeRelationshipNamePathParameters(),
             RelationshipApiSnippets.changeRelationshipNameRequestHeaders(),
@@ -420,7 +430,9 @@ class RelationshipControllerTest {
     ChangeRelationshipKindRequest request = new ChangeRelationshipKindRequest(RelationshipKind.IDENTIFYING);
 
     given(changeRelationshipKindUseCase.changeRelationshipKind(any(ChangeRelationshipKindCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/kind", relationshipId)
@@ -431,6 +443,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-change-kind",
             RelationshipApiSnippets.changeRelationshipKindPathParameters(),
             RelationshipApiSnippets.changeRelationshipKindRequestHeaders(),
@@ -450,7 +463,9 @@ class RelationshipControllerTest {
 
     given(changeRelationshipCardinalityUseCase.changeRelationshipCardinality(
         any(ChangeRelationshipCardinalityCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/cardinality", relationshipId)
@@ -461,6 +476,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-change-cardinality",
             RelationshipApiSnippets.changeRelationshipCardinalityPathParameters(),
             RelationshipApiSnippets.changeRelationshipCardinalityRequestHeaders(),
@@ -477,7 +493,9 @@ class RelationshipControllerTest {
     String pkTableId = "06D6W2CAHD51T5NJPK29Q6BCRA";
 
     given(changeRelationshipExtraUseCase.changeRelationshipExtra(any(ChangeRelationshipExtraCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/extra", relationshipId)
@@ -490,6 +508,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-change-extra",
             RelationshipApiSnippets.changeRelationshipExtraPathParameters(),
             RelationshipApiSnippets.changeRelationshipExtraRequestHeaders(),
@@ -506,7 +525,9 @@ class RelationshipControllerTest {
     String pkTableId = "06D6W2CAHD51T5NJPK29Q6BCRA";
 
     given(changeRelationshipExtraUseCase.changeRelationshipExtra(any(ChangeRelationshipExtraCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/extra", relationshipId)
@@ -518,7 +539,8 @@ class RelationshipControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
 
     then(changeRelationshipExtraUseCase).should().changeRelationshipExtra(
         new ChangeRelationshipExtraCommand(relationshipId, "{\"position\":{\"x\":60,\"y\":90},\"color\":\"#6366f1\"}"));
@@ -554,7 +576,9 @@ class RelationshipControllerTest {
     String pkTableId = "06D6W2CAHD51T5NJPK29Q6BCRA";
 
     given(deleteRelationshipUseCase.deleteRelationship(any(DeleteRelationshipCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}", relationshipId)
@@ -563,6 +587,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-delete",
             RelationshipApiSnippets.deleteRelationshipPathParameters(),
             RelationshipApiSnippets.deleteRelationshipRequestHeaders(),
@@ -623,7 +648,9 @@ class RelationshipControllerTest {
         1);
 
     given(addRelationshipColumnUseCase.addRelationshipColumn(any(AddRelationshipColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.of(result, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/relationships/{relationshipId}/columns", relationshipId)
@@ -633,6 +660,7 @@ class RelationshipControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(relationshipColumnId)
         .consumeWith(document("relationship-column-add",
             RelationshipApiSnippets.addRelationshipColumnPathParameters(),
@@ -650,7 +678,9 @@ class RelationshipControllerTest {
     String pkTableId = "06D6W2CAHD51T5NJPK29Q6BCRA";
 
     given(removeRelationshipColumnUseCase.removeRelationshipColumn(any(RemoveRelationshipColumnCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/relationship-columns/{relationshipColumnId}", relationshipColumnId)
@@ -659,6 +689,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-column-remove",
             RelationshipApiSnippets.removeRelationshipColumnPathParameters(),
             RelationshipApiSnippets.removeRelationshipColumnRequestHeaders(),
@@ -705,7 +736,9 @@ class RelationshipControllerTest {
 
     given(changeRelationshipColumnPositionUseCase.changeRelationshipColumnPosition(
         any(ChangeRelationshipColumnPositionCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, Set.of(fkTableId, pkTableId))
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/relationship-columns/{relationshipColumnId}/position", relationshipColumnId)
@@ -716,6 +749,7 @@ class RelationshipControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("relationship-column-change-position",
             RelationshipApiSnippets.changeRelationshipColumnPositionPathParameters(),
             RelationshipApiSnippets.changeRelationshipColumnPositionRequestHeaders(),

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
@@ -62,12 +62,12 @@ import com.schemafy.core.erd.relationship.domain.type.RelationshipKind;
 
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
@@ -48,6 +48,10 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.CLIENT_OPERATION_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.COMMITTED_REVISION;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -100,7 +104,9 @@ class SchemaControllerTest {
         "utf8mb4_general_ci");
 
     given(createSchemaUseCase.createSchema(any(CreateSchemaCommand.class)))
-        .willReturn(Mono.just(MutationResult.empty(result)));
+        .willReturn(Mono.just(
+            MutationResult.empty(result)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/schemas")
@@ -110,6 +116,12 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
+        .jsonPath("$.operation.clientOperationId")
+        .isEqualTo(CLIENT_OPERATION_ID)
+        .jsonPath("$.operation.committedRevision")
+        .isEqualTo((int) COMMITTED_REVISION)
+        .jsonPath("$.operation.derivationKind").isEqualTo("ORIGINAL")
         .consumeWith(document("schema-create",
             requestHeaders(
                 headerWithName("Content-Type")
@@ -133,7 +145,16 @@ class SchemaControllerTest {
                 fieldWithPath("data.name").description("스키마 이름"),
                 fieldWithPath("data.charset").description("문자셋").optional(),
                 fieldWithPath("data.collation").description("콜레이션").optional(),
-                fieldWithPath("affectedTableIds").description("영향받은 테이블 ID 목록"))));
+                fieldWithPath("affectedTableIds").description("영향받은 테이블 ID 목록"),
+                fieldWithPath("operation").type(JsonFieldType.OBJECT)
+                    .description("커밋된 ERD operation 메타데이터"),
+                fieldWithPath("operation.opId").description("커밋된 operation ID"),
+                fieldWithPath("operation.clientOperationId")
+                    .description("클라이언트가 보낸 operation ID"),
+                fieldWithPath("operation.committedRevision")
+                    .description("커밋 후 schema revision"),
+                fieldWithPath("operation.derivationKind")
+                    .description("operation derivation kind"))));
   }
 
   @Test
@@ -279,7 +300,9 @@ class SchemaControllerTest {
     ChangeSchemaNameRequest request = new ChangeSchemaNameRequest("new_schema_name");
 
     given(changeSchemaNameUseCase.changeSchemaName(any(ChangeSchemaNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.empty(null)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>empty(null)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/schemas/{schemaId}/name", schemaId)
@@ -289,6 +312,7 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("schema-change-name",
             pathParameters(
                 parameterWithName("schemaId")
@@ -310,7 +334,22 @@ class SchemaControllerTest {
                     .optional(),
                 fieldWithPath("affectedTableIds")
                     .type(JsonFieldType.ARRAY)
-                    .description("영향받은 테이블 ID 목록"))));
+                    .description("영향받은 테이블 ID 목록"),
+                fieldWithPath("operation")
+                    .type(JsonFieldType.OBJECT)
+                    .description("커밋된 ERD operation 메타데이터"),
+                fieldWithPath("operation.opId")
+                    .type(JsonFieldType.STRING)
+                    .description("커밋된 operation ID"),
+                fieldWithPath("operation.clientOperationId")
+                    .type(JsonFieldType.STRING)
+                    .description("클라이언트가 보낸 operation ID"),
+                fieldWithPath("operation.committedRevision")
+                    .type(JsonFieldType.NUMBER)
+                    .description("커밋 후 schema revision"),
+                fieldWithPath("operation.derivationKind")
+                    .type(JsonFieldType.STRING)
+                    .description("operation derivation kind"))));
   }
 
   @Test
@@ -320,7 +359,9 @@ class SchemaControllerTest {
     String schemaId = "06D6W1GAHD51T5NJPK29Q6BCR8";
 
     given(deleteSchemaUseCase.deleteSchema(any(DeleteSchemaCommand.class)))
-        .willReturn(Mono.just(MutationResult.empty(null)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>empty(null)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/schemas/{schemaId}", schemaId)
@@ -328,6 +369,7 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("schema-delete",
             pathParameters(
                 parameterWithName("schemaId")
@@ -345,7 +387,22 @@ class SchemaControllerTest {
                     .optional(),
                 fieldWithPath("affectedTableIds")
                     .type(JsonFieldType.ARRAY)
-                    .description("영향받은 테이블 ID 목록"))));
+                    .description("영향받은 테이블 ID 목록"),
+                fieldWithPath("operation")
+                    .type(JsonFieldType.OBJECT)
+                    .description("커밋된 ERD operation 메타데이터"),
+                fieldWithPath("operation.opId")
+                    .type(JsonFieldType.STRING)
+                    .description("커밋된 operation ID"),
+                fieldWithPath("operation.clientOperationId")
+                    .type(JsonFieldType.STRING)
+                    .description("클라이언트가 보낸 operation ID"),
+                fieldWithPath("operation.committedRevision")
+                    .type(JsonFieldType.NUMBER)
+                    .description("커밋 후 schema revision"),
+                fieldWithPath("operation.derivationKind")
+                    .type(JsonFieldType.STRING)
+                    .description("operation derivation kind"))));
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
@@ -38,6 +38,10 @@ import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.CLIENT_OPERATION_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.COMMITTED_REVISION;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -49,10 +53,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.CLIENT_OPERATION_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.COMMITTED_REVISION;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
@@ -28,7 +28,8 @@ import com.schemafy.core.erd.schema.application.port.in.CreateSchemaUseCase;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaCommand;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaUseCase;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemaQuery;
-import com.schemafy.core.erd.schema.application.port.in.GetSchemaUseCase;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaWithRevisionResult;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaWithRevisionUseCase;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemasByProjectIdQuery;
 import com.schemafy.core.erd.schema.application.port.in.GetSchemasByProjectIdUseCase;
 import com.schemafy.core.erd.schema.domain.Schema;
@@ -74,7 +75,7 @@ class SchemaControllerTest {
   private CreateSchemaUseCase createSchemaUseCase;
 
   @MockitoBean
-  private GetSchemaUseCase getSchemaUseCase;
+  private GetSchemaWithRevisionUseCase getSchemaWithRevisionUseCase;
 
   @MockitoBean
   private GetSchemasByProjectIdUseCase getSchemasByProjectIdUseCase;
@@ -196,8 +197,8 @@ class SchemaControllerTest {
         "utf8mb4",
         "utf8mb4_general_ci");
 
-    given(getSchemaUseCase.getSchema(any(GetSchemaQuery.class)))
-        .willReturn(Mono.just(schema));
+    given(getSchemaWithRevisionUseCase.getSchemaWithRevision(any(GetSchemaQuery.class)))
+        .willReturn(Mono.just(new GetSchemaWithRevisionResult(schema, 0L)));
 
     webTestClient.get()
         .uri(API_BASE_PATH + "/schemas/{schemaId}", schemaId)

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
@@ -205,6 +205,7 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.currentRevision").isEqualTo(0)
         .consumeWith(document("schema-get",
             pathParameters(
                 parameterWithName("schemaId")
@@ -221,7 +222,8 @@ class SchemaControllerTest {
                 fieldWithPath("dbVendorName").description("DB 벤더 이름"),
                 fieldWithPath("name").description("스키마 이름"),
                 fieldWithPath("charset").description("문자셋"),
-                fieldWithPath("collation").description("콜레이션"))));
+                fieldWithPath("collation").description("콜레이션"),
+                fieldWithPath("currentRevision").description("현재 schema revision"))));
   }
 
   @Test
@@ -312,6 +314,7 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.data").isEqualTo(null)
         .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("schema-change-name",
             pathParameters(
@@ -369,6 +372,7 @@ class SchemaControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
+        .jsonPath("$.data").isEqualTo(null)
         .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("schema-delete",
             pathParameters(

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
@@ -44,13 +44,13 @@ import com.schemafy.core.erd.table.domain.Table;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
-import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
@@ -49,6 +49,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.OP_ID;
+import static com.schemafy.api.erd.controller.ErdOperationFixtures.committedOperation;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -112,7 +114,9 @@ class TableControllerTest {
         null);
 
     given(createTableUseCase.createTable(any(CreateTableCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/tables")
@@ -123,6 +127,7 @@ class TableControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .jsonPath("$.data.id").isEqualTo(tableId)
         .consumeWith(document("table-create",
             TableApiSnippets.createTableRequestHeaders(),
@@ -145,7 +150,9 @@ class TableControllerTest {
         "{\"position\":{\"x\":12,\"y\":24},\"color\":\"#22c55e\"}");
 
     given(createTableUseCase.createTable(any(CreateTableCommand.class)))
-        .willReturn(Mono.just(MutationResult.of(result, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.of(result, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.post()
         .uri(API_BASE_PATH + "/tables")
@@ -445,7 +452,9 @@ class TableControllerTest {
     ChangeTableNameRequest request = new ChangeTableNameRequest("new_users");
 
     given(changeTableNameUseCase.changeTableName(any(ChangeTableNameCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/name", tableId)
@@ -456,6 +465,7 @@ class TableControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("table-change-name",
             TableApiSnippets.changeTableNamePathParameters(),
             TableApiSnippets.changeTableNameRequestHeaders(),
@@ -470,7 +480,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeTableMetaUseCase.changeTableMeta(any(ChangeTableMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/meta", tableId)
@@ -483,6 +495,7 @@ class TableControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("table-change-meta",
             TableApiSnippets.changeTableMetaPathParameters(),
             TableApiSnippets.changeTableMetaRequestHeaders(),
@@ -497,7 +510,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeTableMetaUseCase.changeTableMeta(any(ChangeTableMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/meta", tableId)
@@ -509,7 +524,8 @@ class TableControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -518,7 +534,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeTableMetaUseCase.changeTableMeta(any(ChangeTableMetaCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/meta", tableId)
@@ -530,7 +548,8 @@ class TableControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
   }
 
   @Test
@@ -539,7 +558,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeTableExtraUseCase.changeTableExtra(any(ChangeTableExtraCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/extra", tableId)
@@ -552,6 +573,7 @@ class TableControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("table-change-extra",
             TableApiSnippets.changeTableExtraPathParameters(),
             TableApiSnippets.changeTableExtraRequestHeaders(),
@@ -566,7 +588,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(changeTableExtraUseCase.changeTableExtra(any(ChangeTableExtraCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.patch()
         .uri(API_BASE_PATH + "/tables/{tableId}/extra", tableId)
@@ -578,7 +602,8 @@ class TableControllerTest {
         .exchange()
         .expectStatus().isOk()
         .expectBody()
-        .jsonPath("$.affectedTableIds").isArray();
+        .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID);
 
     then(changeTableExtraUseCase).should()
         .changeTableExtra(new ChangeTableExtraCommand(tableId,
@@ -613,7 +638,9 @@ class TableControllerTest {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";
 
     given(deleteTableUseCase.deleteTable(any(DeleteTableCommand.class)))
-        .willReturn(Mono.just(MutationResult.<Void>of(null, tableId)));
+        .willReturn(Mono.just(
+            MutationResult.<Void>of(null, tableId)
+                .withOperation(committedOperation())));
 
     webTestClient.delete()
         .uri(API_BASE_PATH + "/tables/{tableId}", tableId)
@@ -622,6 +649,7 @@ class TableControllerTest {
         .expectStatus().isOk()
         .expectBody()
         .jsonPath("$.affectedTableIds").isArray()
+        .jsonPath("$.operation.opId").isEqualTo(OP_ID)
         .consumeWith(document("table-delete",
             TableApiSnippets.deleteTablePathParameters(),
             TableApiSnippets.deleteTableRequestHeaders(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
@@ -2,8 +2,6 @@ package com.schemafy.core.common;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
@@ -35,16 +33,6 @@ public record MutationResult<T>(
 
   public MutationResult<T> withOperation(CommittedErdOperation operation) {
     return new MutationResult<>(result, affectedTableIds, operation);
-  }
-
-  public MutationResult<T> merge(Set<String> additionalTableIds) {
-    if (additionalTableIds == null || additionalTableIds.isEmpty()) {
-      return this;
-    }
-    return new MutationResult<>(result,
-        Stream.concat(affectedTableIds.stream(), additionalTableIds.stream())
-            .collect(Collectors.toUnmodifiableSet()),
-        operation);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
@@ -5,9 +5,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+
 public record MutationResult<T>(
     T result,
-    Set<String> affectedTableIds) {
+    Set<String> affectedTableIds,
+    CommittedErdOperation operation) {
 
   public MutationResult {
     affectedTableIds = affectedTableIds == null
@@ -16,18 +19,22 @@ public record MutationResult<T>(
   }
 
   public static <T> MutationResult<T> empty(T result) {
-    return new MutationResult<>(result, Collections.emptySet());
+    return new MutationResult<>(result, Collections.emptySet(), null);
   }
 
   public static <T> MutationResult<T> of(T result, String tableId) {
     if (tableId == null) {
-      return new MutationResult<>(result, Collections.emptySet());
+      return new MutationResult<>(result, Collections.emptySet(), null);
     }
-    return new MutationResult<>(result, Set.of(tableId));
+    return new MutationResult<>(result, Set.of(tableId), null);
   }
 
   public static <T> MutationResult<T> of(T result, Set<String> tableIds) {
-    return new MutationResult<>(result, tableIds);
+    return new MutationResult<>(result, tableIds, null);
+  }
+
+  public MutationResult<T> withOperation(CommittedErdOperation operation) {
+    return new MutationResult<>(result, affectedTableIds, operation);
   }
 
   public MutationResult<T> merge(Set<String> additionalTableIds) {
@@ -36,7 +43,8 @@ public record MutationResult<T>(
     }
     return new MutationResult<>(result,
         Stream.concat(affectedTableIds.stream(), additionalTableIds.stream())
-            .collect(Collectors.toUnmodifiableSet()));
+            .collect(Collectors.toUnmodifiableSet()),
+        operation);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
@@ -128,7 +128,8 @@ class DefaultErdMutationCoordinator implements ErdMutationCoordinator {
                 finalizedTarget,
                 updatedState,
                 metadata)))
-            .thenReturn(mutationResult));
+            .map(operationLog -> mutationResult.withOperation(
+                CommittedErdOperation.from(operationLog))));
   }
 
   private Mono<SchemaCollaborationState> resolveSchemaState(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/CommittedErdOperation.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/CommittedErdOperation.java
@@ -1,0 +1,17 @@
+package com.schemafy.core.erd.operation.domain;
+
+public record CommittedErdOperation(
+    String opId,
+    String clientOperationId,
+    long committedRevision,
+    ErdOperationDerivationKind derivationKind) {
+
+  public static CommittedErdOperation from(ErdOperationLog operationLog) {
+    return new CommittedErdOperation(
+        operationLog.opId(),
+        operationLog.clientOperationId(),
+        operationLog.committedRevision(),
+        operationLog.derivationKind());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionResult.java
@@ -1,0 +1,8 @@
+package com.schemafy.core.erd.schema.application.port.in;
+
+import com.schemafy.core.erd.schema.domain.Schema;
+
+public record GetSchemaWithRevisionResult(
+    Schema schema,
+    long currentRevision) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionUseCase.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.erd.schema.application.port.in;
+
+import reactor.core.publisher.Mono;
+
+public interface GetSchemaWithRevisionUseCase {
+
+  Mono<GetSchemaWithRevisionResult> getSchemaWithRevision(GetSchemaQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionService.java
@@ -1,0 +1,33 @@
+package com.schemafy.core.erd.schema.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaQuery;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaWithRevisionResult;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaWithRevisionUseCase;
+import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
+import com.schemafy.core.erd.schema.domain.exception.SchemaErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class GetSchemaWithRevisionService implements GetSchemaWithRevisionUseCase {
+
+  private final GetSchemaByIdPort getSchemaByIdPort;
+  private final FindSchemaCollaborationStatePort findSchemaCollaborationStatePort;
+
+  @Override
+  public Mono<GetSchemaWithRevisionResult> getSchemaWithRevision(GetSchemaQuery query) {
+    return getSchemaByIdPort.findSchemaById(query.schemaId())
+        .switchIfEmpty(Mono.error(
+            new DomainException(SchemaErrorCode.NOT_FOUND, "Schema not found: " + query.schemaId())))
+        .flatMap(schema -> findSchemaCollaborationStatePort.findBySchemaId(query.schemaId())
+            .map(state -> new GetSchemaWithRevisionResult(schema, state.currentRevision()))
+            .defaultIfEmpty(new GetSchemaWithRevisionResult(schema, 0L)));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionServiceTest.java
@@ -1,0 +1,114 @@
+package com.schemafy.core.erd.schema.application.service;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
+import com.schemafy.core.erd.operation.domain.SchemaCollaborationState;
+import com.schemafy.core.erd.schema.application.port.in.GetSchemaQuery;
+import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
+import com.schemafy.core.erd.schema.domain.exception.SchemaErrorCode;
+import com.schemafy.core.erd.schema.fixture.SchemaFixture;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSchemaWithRevisionService")
+class GetSchemaWithRevisionServiceTest {
+
+  @Mock
+  GetSchemaByIdPort getSchemaByIdPort;
+
+  @Mock
+  FindSchemaCollaborationStatePort findSchemaCollaborationStatePort;
+
+  @InjectMocks
+  GetSchemaWithRevisionService sut;
+
+  @Nested
+  @DisplayName("getSchemaWithRevision 메서드는")
+  class GetSchemaWithRevision {
+
+    @Test
+    @DisplayName("스키마와 collaboration state가 존재하면 현재 revision과 함께 반환한다")
+    void returnsSchemaWithCurrentRevision() {
+      var query = new GetSchemaQuery(SchemaFixture.DEFAULT_ID);
+      var schema = SchemaFixture.defaultSchema();
+      var state = new SchemaCollaborationState(
+          schema.id(),
+          schema.projectId(),
+          42L,
+          Instant.parse("2026-01-01T00:00:00Z"),
+          Instant.parse("2026-01-01T00:00:00Z"));
+
+      given(getSchemaByIdPort.findSchemaById(any()))
+          .willReturn(Mono.just(schema));
+      given(findSchemaCollaborationStatePort.findBySchemaId(any()))
+          .willReturn(Mono.just(state));
+
+      StepVerifier.create(sut.getSchemaWithRevision(query))
+          .assertNext(result -> {
+            assertThat(result.schema().id()).isEqualTo(schema.id());
+            assertThat(result.currentRevision()).isEqualTo(42L);
+          })
+          .verifyComplete();
+
+      then(getSchemaByIdPort).should().findSchemaById(query.schemaId());
+      then(findSchemaCollaborationStatePort).should().findBySchemaId(query.schemaId());
+    }
+
+    @Test
+    @DisplayName("collaboration state가 없으면 revision 0과 함께 반환한다")
+    void returnsSchemaWithZeroRevisionWhenStateMissing() {
+      var query = new GetSchemaQuery(SchemaFixture.DEFAULT_ID);
+      var schema = SchemaFixture.defaultSchema();
+
+      given(getSchemaByIdPort.findSchemaById(any()))
+          .willReturn(Mono.just(schema));
+      given(findSchemaCollaborationStatePort.findBySchemaId(any()))
+          .willReturn(Mono.empty());
+
+      StepVerifier.create(sut.getSchemaWithRevision(query))
+          .assertNext(result -> {
+            assertThat(result.schema().id()).isEqualTo(schema.id());
+            assertThat(result.currentRevision()).isZero();
+          })
+          .verifyComplete();
+
+      then(getSchemaByIdPort).should().findSchemaById(query.schemaId());
+      then(findSchemaCollaborationStatePort).should().findBySchemaId(query.schemaId());
+    }
+
+    @Test
+    @DisplayName("스키마가 존재하지 않으면 NOT_FOUND 예외를 발생시킨다")
+    void throwsNotFoundWhenSchemaMissing() {
+      var query = new GetSchemaQuery("non-existent-id");
+
+      given(getSchemaByIdPort.findSchemaById(any()))
+          .willReturn(Mono.empty());
+
+      StepVerifier.create(sut.getSchemaWithRevision(query))
+          .expectErrorMatches(DomainException.hasErrorCode(SchemaErrorCode.NOT_FOUND))
+          .verify();
+
+      then(getSchemaByIdPort).should().findSchemaById(query.schemaId());
+      then(findSchemaCollaborationStatePort).shouldHaveNoInteractions();
+    }
+
+  }
+
+}

--- a/apps/bff/src/common/backend-client/backend-client.service.ts
+++ b/apps/bff/src/common/backend-client/backend-client.service.ts
@@ -4,6 +4,12 @@ import { ConfigService } from '@nestjs/config';
 
 import { createHmacHeaders } from '../hmac/hmac.util';
 
+export type CollaborationRequestHeaders = {
+  sessionId?: string;
+  clientOperationId?: string;
+  baseSchemaRevision?: string;
+};
+
 @Injectable()
 export class BackendClientService {
   readonly client: AxiosInstance;
@@ -51,10 +57,20 @@ export class BackendClientService {
     });
   }
 
-  getAuthConfig(authHeader: string, sessionId?: string) {
+  getAuthConfig(
+    authHeader: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
+  ) {
     const headers: Record<string, string> = { Authorization: authHeader };
-    if (sessionId) {
-      headers['X-Session-Id'] = sessionId;
+    if (collaborationHeaders?.sessionId) {
+      headers['X-Session-Id'] = collaborationHeaders.sessionId;
+    }
+    if (collaborationHeaders?.clientOperationId) {
+      headers['X-Client-Op-Id'] = collaborationHeaders.clientOperationId;
+    }
+    if (collaborationHeaders?.baseSchemaRevision) {
+      headers['X-Base-Schema-Revision'] =
+        collaborationHeaders.baseSchemaRevision;
     }
     return { headers };
   }

--- a/apps/bff/src/common/decorators/collaboration-headers.decorator.ts
+++ b/apps/bff/src/common/decorators/collaboration-headers.decorator.ts
@@ -15,9 +15,7 @@ export const CollaborationHeaders = createParamDecorator(
 
     return {
       sessionId: firstHeaderValue(request.headers['x-session-id']),
-      clientOperationId: firstHeaderValue(
-        request.headers['x-client-op-id'],
-      ),
+      clientOperationId: firstHeaderValue(request.headers['x-client-op-id']),
       baseSchemaRevision: firstHeaderValue(
         request.headers['x-base-schema-revision'],
       ),

--- a/apps/bff/src/common/decorators/collaboration-headers.decorator.ts
+++ b/apps/bff/src/common/decorators/collaboration-headers.decorator.ts
@@ -1,0 +1,26 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { Request } from 'express';
+
+import type { CollaborationRequestHeaders } from '../backend-client/backend-client.service';
+
+function firstHeaderValue(
+  raw: string | string[] | undefined,
+): string | undefined {
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+export const CollaborationHeaders = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): CollaborationRequestHeaders => {
+    const request = ctx.switchToHttp().getRequest<Request>();
+
+    return {
+      sessionId: firstHeaderValue(request.headers['x-session-id']),
+      clientOperationId: firstHeaderValue(
+        request.headers['x-client-op-id'],
+      ),
+      baseSchemaRevision: firstHeaderValue(
+        request.headers['x-base-schema-revision'],
+      ),
+    };
+  },
+);

--- a/apps/bff/src/erd/column.controller.ts
+++ b/apps/bff/src/erd/column.controller.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/common';
 import { ColumnService } from './column.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type {
   ChangeColumnMetaRequest,
   ChangeColumnNameRequest,
@@ -26,9 +27,14 @@ export class ColumnController {
   async createColumn(
     @Body() data: CreateColumnRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.columnService.createColumn(data, authHeader, sessionId);
+    return this.columnService.createColumn(
+      data,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('columns/:columnId')
@@ -52,13 +58,14 @@ export class ColumnController {
     @Param('columnId') columnId: string,
     @Body() data: ChangeColumnNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.columnService.changeColumnName(
       columnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -67,13 +74,14 @@ export class ColumnController {
     @Param('columnId') columnId: string,
     @Body() data: ChangeColumnTypeRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.columnService.changeColumnType(
       columnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -82,13 +90,14 @@ export class ColumnController {
     @Param('columnId') columnId: string,
     @Body() data: ChangeColumnMetaRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.columnService.changeColumnMeta(
       columnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -97,13 +106,14 @@ export class ColumnController {
     @Param('columnId') columnId: string,
     @Body() data: ChangeColumnPositionRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.columnService.changeColumnPosition(
       columnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -111,8 +121,13 @@ export class ColumnController {
   async deleteColumn(
     @Param('columnId') columnId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.columnService.deleteColumn(columnId, authHeader, sessionId);
+    return this.columnService.deleteColumn(
+      columnId,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 }

--- a/apps/bff/src/erd/column.service.ts
+++ b/apps/bff/src/erd/column.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   ChangeColumnMetaRequest,
   ChangeColumnNameRequest,
@@ -17,14 +20,14 @@ export class ColumnService {
   async createColumn(
     data: CreateColumnRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<ColumnResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<ColumnResponse>
     >(
       '/api/v1.0/columns',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -55,12 +58,12 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -69,12 +72,12 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnTypeRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/type`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -83,12 +86,12 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnMetaRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/meta`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -97,12 +100,12 @@ export class ColumnService {
     columnId: string,
     data: ChangeColumnPositionRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/columns/${columnId}/position`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -110,11 +113,11 @@ export class ColumnService {
   async deleteColumn(
     columnId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/columns/${columnId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/erd/constraint.controller.ts
+++ b/apps/bff/src/erd/constraint.controller.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/common';
 import { ConstraintService } from './constraint.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type {
   AddConstraintColumnRequest,
   ChangeConstraintCheckExprRequest,
@@ -27,9 +28,14 @@ export class ConstraintController {
   async createConstraint(
     @Body() data: CreateConstraintRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.constraintService.createConstraint(data, authHeader, sessionId);
+    return this.constraintService.createConstraint(
+      data,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('constraints/:constraintId')
@@ -53,13 +59,14 @@ export class ConstraintController {
     @Param('constraintId') constraintId: string,
     @Body() data: ChangeConstraintNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.changeConstraintName(
       constraintId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -68,13 +75,14 @@ export class ConstraintController {
     @Param('constraintId') constraintId: string,
     @Body() data: ChangeConstraintCheckExprRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.changeConstraintCheckExpr(
       constraintId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -83,13 +91,14 @@ export class ConstraintController {
     @Param('constraintId') constraintId: string,
     @Body() data: ChangeConstraintDefaultExprRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.changeConstraintDefaultExpr(
       constraintId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -97,12 +106,13 @@ export class ConstraintController {
   async deleteConstraint(
     @Param('constraintId') constraintId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.deleteConstraint(
       constraintId,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -122,13 +132,14 @@ export class ConstraintController {
     @Param('constraintId') constraintId: string,
     @Body() data: AddConstraintColumnRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.addConstraintColumn(
       constraintId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -136,12 +147,13 @@ export class ConstraintController {
   async removeConstraintColumn(
     @Param('constraintColumnId') constraintColumnId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.removeConstraintColumn(
       constraintColumnId,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -161,13 +173,14 @@ export class ConstraintController {
     @Param('constraintColumnId') constraintColumnId: string,
     @Body() data: ChangeConstraintColumnPositionRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.constraintService.changeConstraintColumnPosition(
       constraintColumnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 }

--- a/apps/bff/src/erd/constraint.service.ts
+++ b/apps/bff/src/erd/constraint.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   AddConstraintColumnRequest,
   AddConstraintColumnResponse,
@@ -20,14 +23,14 @@ export class ConstraintService {
   async createConstraint(
     data: CreateConstraintRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<ConstraintResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<ConstraintResponse>
     >(
       '/api/v1.0/constraints',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -58,12 +61,12 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -72,12 +75,12 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintCheckExprRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/check-expr`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -86,12 +89,12 @@ export class ConstraintService {
     constraintId: string,
     data: ChangeConstraintDefaultExprRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}/default-expr`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -99,11 +102,11 @@ export class ConstraintService {
   async deleteConstraint(
     constraintId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/constraints/${constraintId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -125,14 +128,14 @@ export class ConstraintService {
     constraintId: string,
     data: AddConstraintColumnRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<AddConstraintColumnResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<AddConstraintColumnResponse>
     >(
       `/api/v1.0/constraints/${constraintId}/columns`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -140,11 +143,11 @@ export class ConstraintService {
   async removeConstraintColumn(
     constraintColumnId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/constraint-columns/${constraintColumnId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -165,12 +168,12 @@ export class ConstraintService {
     constraintColumnId: string,
     data: ChangeConstraintColumnPositionRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/constraint-columns/${constraintColumnId}/position`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/erd/erd.types.ts
+++ b/apps/bff/src/erd/erd.types.ts
@@ -1,6 +1,14 @@
+export type ErdOperation = {
+  opId: string;
+  clientOperationId: string | null;
+  committedRevision: number;
+  derivationKind: string;
+};
+
 export type MutationResponse<T = null> = {
   data: T;
   affectedTableIds: string[];
+  operation: ErdOperation;
 };
 
 export type JsonPrimitive = string | number | boolean | null;

--- a/apps/bff/src/erd/erd.types.ts
+++ b/apps/bff/src/erd/erd.types.ts
@@ -24,6 +24,7 @@ export type SchemaResponse = {
   name: string;
   charset: string;
   collation: string;
+  currentRevision?: number;
 };
 
 export type CreateSchemaRequest = {
@@ -330,4 +331,9 @@ export type TableSnapshotResponse = {
   constraints: ConstraintSnapshotResponse[];
   relationships: RelationshipSnapshotResponse[];
   indexes: IndexSnapshotResponse[];
+};
+
+export type SchemaSnapshotsResponse = {
+  currentRevision: number;
+  snapshots: Record<string, TableSnapshotResponse>;
 };

--- a/apps/bff/src/erd/index.controller.ts
+++ b/apps/bff/src/erd/index.controller.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/common';
 import { IndexService } from './index.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type {
   AddIndexColumnRequest,
   ChangeIndexColumnPositionRequest,
@@ -27,9 +28,14 @@ export class IndexController {
   async createIndex(
     @Body() data: CreateIndexRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.indexService.createIndex(data, authHeader, sessionId);
+    return this.indexService.createIndex(
+      data,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('indexes/:indexId')
@@ -53,13 +59,14 @@ export class IndexController {
     @Param('indexId') indexId: string,
     @Body() data: ChangeIndexNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.changeIndexName(
       indexId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -68,13 +75,14 @@ export class IndexController {
     @Param('indexId') indexId: string,
     @Body() data: ChangeIndexTypeRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.changeIndexType(
       indexId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -82,9 +90,14 @@ export class IndexController {
   async deleteIndex(
     @Param('indexId') indexId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.indexService.deleteIndex(indexId, authHeader, sessionId);
+    return this.indexService.deleteIndex(
+      indexId,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('indexes/:indexId/columns')
@@ -100,13 +113,14 @@ export class IndexController {
     @Param('indexId') indexId: string,
     @Body() data: AddIndexColumnRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.addIndexColumn(
       indexId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -114,12 +128,13 @@ export class IndexController {
   async removeIndexColumn(
     @Param('indexColumnId') indexColumnId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.removeIndexColumn(
       indexColumnId,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -136,13 +151,14 @@ export class IndexController {
     @Param('indexColumnId') indexColumnId: string,
     @Body() data: ChangeIndexColumnPositionRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.changeIndexColumnPosition(
       indexColumnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -151,13 +167,14 @@ export class IndexController {
     @Param('indexColumnId') indexColumnId: string,
     @Body() data: ChangeIndexColumnSortDirectionRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.indexService.changeIndexColumnSortDirection(
       indexColumnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 }

--- a/apps/bff/src/erd/index.service.ts
+++ b/apps/bff/src/erd/index.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   AddIndexColumnRequest,
   AddIndexColumnResponse,
@@ -20,14 +23,14 @@ export class IndexService {
   async createIndex(
     data: CreateIndexRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<IndexResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<IndexResponse>
     >(
       '/api/v1.0/indexes',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -55,12 +58,12 @@ export class IndexService {
     indexId: string,
     data: ChangeIndexNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/indexes/${indexId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -69,12 +72,12 @@ export class IndexService {
     indexId: string,
     data: ChangeIndexTypeRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/indexes/${indexId}/type`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -82,11 +85,11 @@ export class IndexService {
   async deleteIndex(
     indexId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/indexes/${indexId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -106,14 +109,14 @@ export class IndexService {
     indexId: string,
     data: AddIndexColumnRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<AddIndexColumnResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<AddIndexColumnResponse>
     >(
       `/api/v1.0/indexes/${indexId}/columns`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -121,11 +124,11 @@ export class IndexService {
   async removeIndexColumn(
     indexColumnId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -145,12 +148,12 @@ export class IndexService {
     indexColumnId: string,
     data: ChangeIndexColumnPositionRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}/position`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -159,12 +162,12 @@ export class IndexService {
     indexColumnId: string,
     data: ChangeIndexColumnSortDirectionRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/index-columns/${indexColumnId}/sort-direction`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/erd/relationship.controller.ts
+++ b/apps/bff/src/erd/relationship.controller.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/common';
 import { RelationshipService } from './relationship.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type {
   AddRelationshipColumnRequest,
   ChangeRelationshipCardinalityRequest,
@@ -28,12 +29,13 @@ export class RelationshipController {
   async createRelationship(
     @Body() data: CreateRelationshipRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.createRelationship(
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -61,13 +63,14 @@ export class RelationshipController {
     @Param('relationshipId') relationshipId: string,
     @Body() data: ChangeRelationshipNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.changeRelationshipName(
       relationshipId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -76,13 +79,14 @@ export class RelationshipController {
     @Param('relationshipId') relationshipId: string,
     @Body() data: ChangeRelationshipKindRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.changeRelationshipKind(
       relationshipId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -91,13 +95,14 @@ export class RelationshipController {
     @Param('relationshipId') relationshipId: string,
     @Body() data: ChangeRelationshipCardinalityRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.changeRelationshipCardinality(
       relationshipId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -106,13 +111,14 @@ export class RelationshipController {
     @Param('relationshipId') relationshipId: string,
     @Body() data: ChangeRelationshipExtraRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.changeRelationshipExtra(
       relationshipId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -120,12 +126,13 @@ export class RelationshipController {
   async deleteRelationship(
     @Param('relationshipId') relationshipId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.deleteRelationship(
       relationshipId,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -145,13 +152,14 @@ export class RelationshipController {
     @Param('relationshipId') relationshipId: string,
     @Body() data: AddRelationshipColumnRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.addRelationshipColumn(
       relationshipId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -159,12 +167,13 @@ export class RelationshipController {
   async removeRelationshipColumn(
     @Param('relationshipColumnId') relationshipColumnId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.removeRelationshipColumn(
       relationshipColumnId,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -184,13 +193,14 @@ export class RelationshipController {
     @Param('relationshipColumnId') relationshipColumnId: string,
     @Body() data: ChangeRelationshipColumnPositionRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.relationshipService.changeRelationshipColumnPosition(
       relationshipColumnId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 }

--- a/apps/bff/src/erd/relationship.service.ts
+++ b/apps/bff/src/erd/relationship.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   AddRelationshipColumnRequest,
   AddRelationshipColumnResponse,
@@ -21,14 +24,14 @@ export class RelationshipService {
   async createRelationship(
     data: CreateRelationshipRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<RelationshipResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<RelationshipResponse>
     >(
       '/api/v1.0/relationships',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -61,12 +64,12 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -75,12 +78,12 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipKindRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/kind`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -89,12 +92,12 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipCardinalityRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/cardinality`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -103,12 +106,12 @@ export class RelationshipService {
     relationshipId: string,
     data: ChangeRelationshipExtraRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}/extra`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -116,11 +119,11 @@ export class RelationshipService {
   async deleteRelationship(
     relationshipId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/relationships/${relationshipId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -142,14 +145,14 @@ export class RelationshipService {
     relationshipId: string,
     data: AddRelationshipColumnRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<AddRelationshipColumnResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<AddRelationshipColumnResponse>
     >(
       `/api/v1.0/relationships/${relationshipId}/columns`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -157,11 +160,11 @@ export class RelationshipService {
   async removeRelationshipColumn(
     relationshipColumnId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/relationship-columns/${relationshipColumnId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -182,12 +185,12 @@ export class RelationshipService {
     relationshipColumnId: string,
     data: ChangeRelationshipColumnPositionRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/relationship-columns/${relationshipColumnId}/position`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/erd/schema.controller.ts
+++ b/apps/bff/src/erd/schema.controller.ts
@@ -12,7 +12,11 @@ import { TableService } from './table.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
 import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
 import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
-import type { ChangeSchemaNameRequest, CreateSchemaRequest } from './erd.types';
+import type {
+  ChangeSchemaNameRequest,
+  CreateSchemaRequest,
+  SchemaSnapshotsResponse,
+} from './erd.types';
 
 @Controller('api/v1.0')
 export class SchemaController {
@@ -85,7 +89,15 @@ export class SchemaController {
   async getSchemaWithSnapshots(
     @Param('schemaId') schemaId: string,
     @AuthHeader() authHeader: string,
-  ) {
-    return this.tableService.getSchemaWithSnapshots(schemaId, authHeader);
+  ): Promise<SchemaSnapshotsResponse> {
+    const [schema, snapshots] = await Promise.all([
+      this.schemaService.getSchema(schemaId, authHeader),
+      this.tableService.getSchemaWithSnapshots(schemaId, authHeader),
+    ]);
+
+    return {
+      currentRevision: schema.currentRevision ?? 0,
+      snapshots,
+    };
   }
 }

--- a/apps/bff/src/erd/schema.controller.ts
+++ b/apps/bff/src/erd/schema.controller.ts
@@ -10,7 +10,8 @@ import {
 import { SchemaService } from './schema.service';
 import { TableService } from './table.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type { ChangeSchemaNameRequest, CreateSchemaRequest } from './erd.types';
 
 @Controller('api/v1.0')
@@ -24,9 +25,14 @@ export class SchemaController {
   async createSchema(
     @Body() data: CreateSchemaRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.schemaService.createSchema(data, authHeader, sessionId);
+    return this.schemaService.createSchema(
+      data,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('projects/:projectId/schemas')
@@ -50,13 +56,14 @@ export class SchemaController {
     @Param('schemaId') schemaId: string,
     @Body() data: ChangeSchemaNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.schemaService.changeSchemaName(
       schemaId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -64,9 +71,14 @@ export class SchemaController {
   async deleteSchema(
     @Param('schemaId') schemaId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.schemaService.deleteSchema(schemaId, authHeader, sessionId);
+    return this.schemaService.deleteSchema(
+      schemaId,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('schemas/:schemaId/snapshots')

--- a/apps/bff/src/erd/schema.service.ts
+++ b/apps/bff/src/erd/schema.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   ChangeSchemaNameRequest,
   CreateSchemaRequest,
@@ -14,14 +17,14 @@ export class SchemaService {
   async createSchema(
     data: CreateSchemaRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<SchemaResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<SchemaResponse>
     >(
       '/api/v1.0/schemas',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -52,12 +55,12 @@ export class SchemaService {
     schemaId: string,
     data: ChangeSchemaNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/schemas/${schemaId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -65,11 +68,11 @@ export class SchemaService {
   async deleteSchema(
     schemaId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/schemas/${schemaId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/erd/table.controller.ts
+++ b/apps/bff/src/erd/table.controller.ts
@@ -10,7 +10,8 @@ import {
 } from '@nestjs/common';
 import { TableService } from './table.service';
 import { AuthHeader } from '../common/decorators/auth-header.decorator';
-import { SessionId } from '../common/decorators/session-id.decorator';
+import { CollaborationHeaders } from '../common/decorators/collaboration-headers.decorator';
+import type { CollaborationRequestHeaders } from '../common/backend-client/backend-client.service';
 import type {
   ChangeTableExtraRequest,
   ChangeTableMetaRequest,
@@ -26,9 +27,14 @@ export class TableController {
   async createTable(
     @Body() data: CreateTableRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.tableService.createTable(data, authHeader, sessionId);
+    return this.tableService.createTable(
+      data,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 
   @Get('tables/snapshots')
@@ -68,13 +74,14 @@ export class TableController {
     @Param('tableId') tableId: string,
     @Body() data: ChangeTableNameRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.tableService.changeTableName(
       tableId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -83,13 +90,14 @@ export class TableController {
     @Param('tableId') tableId: string,
     @Body() data: ChangeTableMetaRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.tableService.changeTableMeta(
       tableId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -98,13 +106,14 @@ export class TableController {
     @Param('tableId') tableId: string,
     @Body() data: ChangeTableExtraRequest,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
     return this.tableService.changeTableExtra(
       tableId,
       data,
       authHeader,
-      sessionId,
+      collaborationHeaders,
     );
   }
 
@@ -112,8 +121,13 @@ export class TableController {
   async deleteTable(
     @Param('tableId') tableId: string,
     @AuthHeader() authHeader: string,
-    @SessionId() sessionId?: string,
+    @CollaborationHeaders()
+    collaborationHeaders?: CollaborationRequestHeaders,
   ) {
-    return this.tableService.deleteTable(tableId, authHeader, sessionId);
+    return this.tableService.deleteTable(
+      tableId,
+      authHeader,
+      collaborationHeaders,
+    );
   }
 }

--- a/apps/bff/src/erd/table.service.ts
+++ b/apps/bff/src/erd/table.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { BackendClientService } from '../common/backend-client/backend-client.service';
+import {
+  BackendClientService,
+  type CollaborationRequestHeaders,
+} from '../common/backend-client/backend-client.service';
 import type {
   ChangeTableExtraRequest,
   ChangeTableMetaRequest,
@@ -17,14 +20,14 @@ export class TableService {
   async createTable(
     data: CreateTableRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse<TableResponse>> {
     const response = await this.backendClient.client.post<
       MutationResponse<TableResponse>
     >(
       '/api/v1.0/tables',
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -76,12 +79,12 @@ export class TableService {
     tableId: string,
     data: ChangeTableNameRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/name`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -90,12 +93,12 @@ export class TableService {
     tableId: string,
     data: ChangeTableMetaRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/meta`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -104,12 +107,12 @@ export class TableService {
     tableId: string,
     data: ChangeTableExtraRequest,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.patch<MutationResponse>(
       `/api/v1.0/tables/${tableId}/extra`,
       data,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }
@@ -117,11 +120,11 @@ export class TableService {
   async deleteTable(
     tableId: string,
     authHeader: string,
-    sessionId?: string,
+    collaborationHeaders?: CollaborationRequestHeaders,
   ): Promise<MutationResponse> {
     const response = await this.backendClient.client.delete<MutationResponse>(
       `/api/v1.0/tables/${tableId}`,
-      this.backendClient.getAuthConfig(authHeader, sessionId),
+      this.backendClient.getAuthConfig(authHeader, collaborationHeaders),
     );
     return response.data;
   }

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -14,6 +14,14 @@ async function bootstrap() {
   app.enableCors({
     origin: process.env.FRONTEND_URL || 'http://localhost:3001',
     credentials: true,
+    allowedHeaders: [
+      'Content-Type',
+      'Accept',
+      'Authorization',
+      'X-Session-Id',
+      'X-Client-Op-Id',
+      'X-Base-Schema-Revision',
+    ],
   });
 
   app.useGlobalInterceptors(new LoggingInterceptor());

--- a/apps/frontend/src/features/collaboration/api/types.ts
+++ b/apps/frontend/src/features/collaboration/api/types.ts
@@ -1,3 +1,5 @@
+import type { ErdOperation } from '@/features/drawing/api/types';
+
 export type PostCursor = {
   type: 'CURSOR';
   cursor: {
@@ -68,8 +70,10 @@ export type ReceiveChat = {
 
 export type ReceiveErdMutated = {
   type: 'ERD_MUTATED';
+  sessionId?: string | null;
   schemaId: string;
   affectedTableIds: string[];
+  operation: ErdOperation;
   timestamp: number;
 };
 

--- a/apps/frontend/src/features/drawing/api/column.api.ts
+++ b/apps/frontend/src/features/drawing/api/column.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   ColumnResponse,
@@ -11,10 +12,12 @@ import type {
 
 export const createColumn = async (
   data: CreateColumnRequest,
+  schemaId: string,
 ): Promise<MutationResponse<ColumnResponse>> => {
   const { data: res } = await apiClient.post<MutationResponse<ColumnResponse>>(
     '/columns',
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -36,10 +39,12 @@ export const getColumnsByTableId = async (
 export const changeColumnName = async (
   columnId: string,
   data: ChangeColumnNameRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -47,10 +52,12 @@ export const changeColumnName = async (
 export const changeColumnType = async (
   columnId: string,
   data: ChangeColumnTypeRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/type`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -58,10 +65,12 @@ export const changeColumnType = async (
 export const changeColumnMeta = async (
   columnId: string,
   data: ChangeColumnMetaRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/meta`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -69,19 +78,23 @@ export const changeColumnMeta = async (
 export const changeColumnPosition = async (
   columnId: string,
   data: ChangeColumnPositionRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/columns/${columnId}/position`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
 
 export const deleteColumn = async (
   columnId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/columns/${columnId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/constraint.api.ts
+++ b/apps/frontend/src/features/drawing/api/constraint.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   ConstraintResponse,
@@ -14,10 +15,11 @@ import type {
 
 export const createConstraint = async (
   data: CreateConstraintRequest,
+  schemaId: string,
 ): Promise<MutationResponse<ConstraintResponse>> => {
   const { data: res } = await apiClient.post<
     MutationResponse<ConstraintResponse>
-  >('/constraints', data);
+  >('/constraints', data, createErdMutationConfig(schemaId));
   return res;
 };
 
@@ -42,10 +44,12 @@ export const getConstraintsByTableId = async (
 export const changeConstraintName = async (
   constraintId: string,
   data: ChangeConstraintNameRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -53,10 +57,12 @@ export const changeConstraintName = async (
 export const changeConstraintCheckExpr = async (
   constraintId: string,
   data: ChangeConstraintCheckExprRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/check-expr`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -64,19 +70,23 @@ export const changeConstraintCheckExpr = async (
 export const changeConstraintDefaultExpr = async (
   constraintId: string,
   data: ChangeConstraintDefaultExprRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraints/${constraintId}/default-expr`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
 
 export const deleteConstraint = async (
   constraintId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/constraints/${constraintId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -93,18 +103,25 @@ export const getConstraintColumns = async (
 export const addConstraintColumn = async (
   constraintId: string,
   data: AddConstraintColumnRequest,
+  schemaId: string,
 ): Promise<MutationResponse<AddConstraintColumnResponse>> => {
   const { data: res } = await apiClient.post<
     MutationResponse<AddConstraintColumnResponse>
-  >(`/constraints/${constraintId}/columns`, data);
+  >(
+    `/constraints/${constraintId}/columns`,
+    data,
+    createErdMutationConfig(schemaId),
+  );
   return res;
 };
 
 export const removeConstraintColumn = async (
   constraintColumnId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/constraint-columns/${constraintColumnId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -121,10 +138,12 @@ export const getConstraintColumn = async (
 export const changeConstraintColumnPosition = async (
   constraintColumnId: string,
   data: ChangeConstraintColumnPositionRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/constraint-columns/${constraintColumnId}/position`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/index-entity.api.ts
+++ b/apps/frontend/src/features/drawing/api/index-entity.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   IndexResponse,
@@ -14,10 +15,12 @@ import type {
 
 export const createIndex = async (
   data: CreateIndexRequest,
+  schemaId: string,
 ): Promise<MutationResponse<IndexResponse>> => {
   const { data: res } = await apiClient.post<MutationResponse<IndexResponse>>(
     '/indexes',
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -39,10 +42,12 @@ export const getIndexesByTableId = async (
 export const changeIndexName = async (
   indexId: string,
   data: ChangeIndexNameRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/indexes/${indexId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -50,19 +55,23 @@ export const changeIndexName = async (
 export const changeIndexType = async (
   indexId: string,
   data: ChangeIndexTypeRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/indexes/${indexId}/type`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
 
 export const deleteIndex = async (
   indexId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/indexes/${indexId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -79,18 +88,21 @@ export const getIndexColumns = async (
 export const addIndexColumn = async (
   indexId: string,
   data: AddIndexColumnRequest,
+  schemaId: string,
 ): Promise<MutationResponse<AddIndexColumnResponse>> => {
   const { data: res } = await apiClient.post<
     MutationResponse<AddIndexColumnResponse>
-  >(`/indexes/${indexId}/columns`, data);
+  >(`/indexes/${indexId}/columns`, data, createErdMutationConfig(schemaId));
   return res;
 };
 
 export const removeIndexColumn = async (
   indexColumnId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/index-columns/${indexColumnId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -107,10 +119,12 @@ export const getIndexColumn = async (
 export const changeIndexColumnPosition = async (
   indexColumnId: string,
   data: ChangeIndexColumnPositionRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/index-columns/${indexColumnId}/position`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -118,10 +132,12 @@ export const changeIndexColumnPosition = async (
 export const changeIndexColumnSortDirection = async (
   indexColumnId: string,
   data: ChangeIndexColumnSortDirectionRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/index-columns/${indexColumnId}/sort-direction`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/mutation-request.ts
+++ b/apps/frontend/src/features/drawing/api/mutation-request.ts
@@ -1,0 +1,32 @@
+import type { AxiosRequestConfig } from 'axios';
+
+import type { MutationResponse } from './types';
+import { collaborationStore } from '@/store/collaboration.store';
+
+export const createErdMutationConfig = (
+  schemaId?: string,
+): AxiosRequestConfig => {
+  const headers: Record<string, string> = {
+    'X-Client-Op-Id': crypto.randomUUID(),
+  };
+
+  if (schemaId) {
+    const baseSchemaRevision = collaborationStore.getSchemaRevision(schemaId);
+
+    if (baseSchemaRevision !== null) {
+      headers['X-Base-Schema-Revision'] = String(baseSchemaRevision);
+    }
+  }
+
+  return { headers };
+};
+
+export const syncCommittedRevision = (
+  schemaId: string,
+  result: Pick<MutationResponse, 'operation'>,
+) => {
+  collaborationStore.setSchemaRevision(
+    schemaId,
+    result.operation.committedRevision,
+  );
+};

--- a/apps/frontend/src/features/drawing/api/relationship.api.ts
+++ b/apps/frontend/src/features/drawing/api/relationship.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   RelationshipResponse,
@@ -15,10 +16,11 @@ import type {
 
 export const createRelationship = async (
   data: CreateRelationshipRequest,
+  schemaId: string,
 ): Promise<MutationResponse<RelationshipResponse>> => {
   const { data: res } = await apiClient.post<
     MutationResponse<RelationshipResponse>
-  >('/relationships', data);
+  >('/relationships', data, createErdMutationConfig(schemaId));
   return res;
 };
 
@@ -43,10 +45,12 @@ export const getRelationshipsByTableId = async (
 export const changeRelationshipName = async (
   relationshipId: string,
   data: ChangeRelationshipNameRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -54,10 +58,12 @@ export const changeRelationshipName = async (
 export const changeRelationshipKind = async (
   relationshipId: string,
   data: ChangeRelationshipKindRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/kind`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -65,10 +71,12 @@ export const changeRelationshipKind = async (
 export const changeRelationshipCardinality = async (
   relationshipId: string,
   data: ChangeRelationshipCardinalityRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/cardinality`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -76,19 +84,23 @@ export const changeRelationshipCardinality = async (
 export const changeRelationshipExtra = async (
   relationshipId: string,
   data: ChangeRelationshipExtraRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationships/${relationshipId}/extra`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
 
 export const deleteRelationship = async (
   relationshipId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/relationships/${relationshipId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -105,18 +117,25 @@ export const getRelationshipColumns = async (
 export const addRelationshipColumn = async (
   relationshipId: string,
   data: AddRelationshipColumnRequest,
+  schemaId: string,
 ): Promise<MutationResponse<AddRelationshipColumnResponse>> => {
   const { data: res } = await apiClient.post<
     MutationResponse<AddRelationshipColumnResponse>
-  >(`/relationships/${relationshipId}/columns`, data);
+  >(
+    `/relationships/${relationshipId}/columns`,
+    data,
+    createErdMutationConfig(schemaId),
+  );
   return res;
 };
 
 export const removeRelationshipColumn = async (
   relationshipColumnId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/relationship-columns/${relationshipColumnId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -133,10 +152,12 @@ export const getRelationshipColumn = async (
 export const changeRelationshipColumnPosition = async (
   relationshipColumnId: string,
   data: ChangeRelationshipColumnPositionRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/relationship-columns/${relationshipColumnId}/position`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/schema.api.ts
+++ b/apps/frontend/src/features/drawing/api/schema.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   SchemaResponse,
@@ -12,6 +13,7 @@ export const createSchema = async (
   const { data: res } = await apiClient.post<MutationResponse<SchemaResponse>>(
     '/schemas',
     data,
+    createErdMutationConfig(),
   );
   return res;
 };
@@ -37,6 +39,7 @@ export const changeSchemaName = async (
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/schemas/${schemaId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -46,6 +49,7 @@ export const deleteSchema = async (
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/schemas/${schemaId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/table.api.ts
+++ b/apps/frontend/src/features/drawing/api/table.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api';
+import { createErdMutationConfig } from './mutation-request';
 import type {
   MutationResponse,
   TableResponse,
@@ -15,6 +16,7 @@ export const createTable = async (
   const { data: res } = await apiClient.post<MutationResponse<TableResponse>>(
     '/tables',
     data,
+    createErdMutationConfig(data.schemaId),
   );
   return res;
 };
@@ -55,10 +57,12 @@ export const getTableSnapshots = async (
 export const changeTableName = async (
   tableId: string,
   data: ChangeTableNameRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/name`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -66,10 +70,12 @@ export const changeTableName = async (
 export const changeTableMeta = async (
   tableId: string,
   data: ChangeTableMetaRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/meta`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
@@ -77,19 +83,23 @@ export const changeTableMeta = async (
 export const changeTableExtra = async (
   tableId: string,
   data: ChangeTableExtraRequest,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.patch<MutationResponse>(
     `/tables/${tableId}/extra`,
     data,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };
 
 export const deleteTable = async (
   tableId: string,
+  schemaId: string,
 ): Promise<MutationResponse> => {
   const { data: res } = await apiClient.delete<MutationResponse>(
     `/tables/${tableId}`,
+    createErdMutationConfig(schemaId),
   );
   return res;
 };

--- a/apps/frontend/src/features/drawing/api/table.api.ts
+++ b/apps/frontend/src/features/drawing/api/table.api.ts
@@ -7,6 +7,7 @@ import type {
   ChangeTableNameRequest,
   ChangeTableMetaRequest,
   ChangeTableExtraRequest,
+  SchemaSnapshotsResponse,
   TableSnapshotResponse,
 } from './types';
 
@@ -106,8 +107,8 @@ export const deleteTable = async (
 
 export const getSchemaWithSnapshots = async (
   schemaId: string,
-): Promise<Record<string, TableSnapshotResponse>> => {
-  const { data } = await apiClient.get<Record<string, TableSnapshotResponse>>(
+): Promise<SchemaSnapshotsResponse> => {
+  const { data } = await apiClient.get<SchemaSnapshotsResponse>(
     `/schemas/${schemaId}/snapshots`,
   );
   return data;

--- a/apps/frontend/src/features/drawing/api/types.ts
+++ b/apps/frontend/src/features/drawing/api/types.ts
@@ -24,6 +24,7 @@ export type SchemaResponse = {
   name: string;
   charset: string;
   collation: string;
+  currentRevision?: number;
 };
 
 export type CreateSchemaRequest = {
@@ -332,6 +333,11 @@ export type TableSnapshotResponse = {
   constraints: ConstraintSnapshotResponse[];
   relationships: RelationshipSnapshotResponse[];
   indexes: IndexSnapshotResponse[];
+};
+
+export type SchemaSnapshotsResponse = {
+  currentRevision: number;
+  snapshots: Record<string, TableSnapshotResponse>;
 };
 
 export type DbVendorSummary = {

--- a/apps/frontend/src/features/drawing/api/types.ts
+++ b/apps/frontend/src/features/drawing/api/types.ts
@@ -1,6 +1,14 @@
+export type ErdOperation = {
+  opId: string;
+  clientOperationId: string | null;
+  committedRevision: number;
+  derivationKind: string;
+};
+
 export type MutationResponse<T = null> = {
   data: T;
   affectedTableIds: string[];
+  operation: ErdOperation;
 };
 
 export type JsonPrimitive = string | number | boolean | null;

--- a/apps/frontend/src/features/drawing/components/SearchEntitiesDialog.tsx
+++ b/apps/frontend/src/features/drawing/components/SearchEntitiesDialog.tsx
@@ -23,7 +23,8 @@ export const SearchEntitiesDialog = ({
   const [searchQuery, setSearchQuery] = useState('');
 
   const { selectedSchemaId } = useSelectedSchema();
-  const { data: snapshotsData } = useSchemaSnapshots(selectedSchemaId);
+  const { data: schemaSnapshots } = useSchemaSnapshots(selectedSchemaId);
+  const snapshotsData = schemaSnapshots.snapshots;
   const { fitView } = useReactFlow();
 
   const tables = Object.values(snapshotsData).map((snapshot) => ({

--- a/apps/frontend/src/features/drawing/hooks/useColumn.ts
+++ b/apps/frontend/src/features/drawing/hooks/useColumn.ts
@@ -75,7 +75,11 @@ export const useColumn = (
 
     if (isTextToNonText) {
       try {
-        await changeColumnMeta(columnId, { charset: '', collation: '' });
+        await changeColumnMeta(
+          columnId,
+          { charset: '', collation: '' },
+          schemaId,
+        );
       } catch {
         return;
       }
@@ -86,7 +90,7 @@ export const useColumn = (
         await changeColumnMeta(columnId, {
           charset: 'utf8mb4',
           collation: 'utf8mb4_general_ci',
-        });
+        }, schemaId);
       } catch {}
     } else {
       changeColumnTypeMutation.mutate(typePayload);

--- a/apps/frontend/src/features/drawing/hooks/useColumn.ts
+++ b/apps/frontend/src/features/drawing/hooks/useColumn.ts
@@ -1,7 +1,10 @@
 import { type ColumnType, CONSTRAINT_PREFIX_MAP } from '../types';
 import type { Constraint } from '@/types';
-import { useChangeColumnName, useChangeColumnType } from './useColumnMutations';
-import { changeColumnMeta } from '../api';
+import {
+  useChangeColumnMeta,
+  useChangeColumnName,
+  useChangeColumnType,
+} from './useColumnMutations';
 import {
   useCreateConstraint,
   useDeleteConstraint,
@@ -20,6 +23,7 @@ export const useColumn = (
   const debouncedChangeColumnName = useDebouncedMutation(
     changeColumnNameMutation,
   );
+  const changeColumnMetaMutation = useChangeColumnMeta(schemaId);
   const changeColumnTypeMutation = useChangeColumnType(schemaId);
   const createConstraintMutation = useCreateConstraint(schemaId);
   const deleteConstraintMutation = useDeleteConstraint(schemaId);
@@ -75,11 +79,10 @@ export const useColumn = (
 
     if (isTextToNonText) {
       try {
-        await changeColumnMeta(
+        await changeColumnMetaMutation.mutateAsync({
           columnId,
-          { charset: '', collation: '' },
-          schemaId,
-        );
+          data: { charset: '', collation: '' },
+        });
       } catch {
         return;
       }
@@ -87,10 +90,13 @@ export const useColumn = (
     } else if (isNonTextToText) {
       try {
         await changeColumnTypeMutation.mutateAsync(typePayload);
-        await changeColumnMeta(columnId, {
-          charset: 'utf8mb4',
-          collation: 'utf8mb4_general_ci',
-        }, schemaId);
+        await changeColumnMetaMutation.mutateAsync({
+          columnId,
+          data: {
+            charset: 'utf8mb4',
+            collation: 'utf8mb4_general_ci',
+          },
+        });
       } catch {}
     } else {
       changeColumnTypeMutation.mutate(typePayload);

--- a/apps/frontend/src/features/drawing/hooks/useColumnMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useColumnMutations.ts
@@ -14,13 +14,15 @@ import type {
   ChangeColumnMetaRequest,
   ChangeColumnPositionRequest,
 } from '../api';
+import { syncCommittedRevision } from '../api/mutation-request';
 import { useErdCache } from './useErdCache';
 
 export const useCreateColumn = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (data: CreateColumnRequest) => createColumn(data),
+    mutationFn: (data: CreateColumnRequest) => createColumn(data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -35,8 +37,9 @@ export const useChangeColumnName = (schemaId: string) => {
     }: {
       columnId: string;
       data: ChangeColumnNameRequest;
-    }) => changeColumnName(columnId, data),
+    }) => changeColumnName(columnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -51,8 +54,9 @@ export const useChangeColumnType = (schemaId: string) => {
     }: {
       columnId: string;
       data: ChangeColumnTypeRequest;
-    }) => changeColumnType(columnId, data),
+    }) => changeColumnType(columnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -67,8 +71,9 @@ export const useChangeColumnMeta = (schemaId: string) => {
     }: {
       columnId: string;
       data: ChangeColumnMetaRequest;
-    }) => changeColumnMeta(columnId, data),
+    }) => changeColumnMeta(columnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -83,8 +88,9 @@ export const useChangeColumnPosition = (schemaId: string) => {
     }: {
       columnId: string;
       data: ChangeColumnPositionRequest;
-    }) => changeColumnPosition(columnId, data),
+    }) => changeColumnPosition(columnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -93,8 +99,9 @@ export const useChangeColumnPosition = (schemaId: string) => {
 export const useDeleteColumn = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (columnId: string) => deleteColumn(columnId),
+    mutationFn: (columnId: string) => deleteColumn(columnId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });

--- a/apps/frontend/src/features/drawing/hooks/useConstraintMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useConstraintMutations.ts
@@ -17,13 +17,16 @@ import type {
   AddConstraintColumnRequest,
   ChangeConstraintColumnPositionRequest,
 } from '../api';
+import { syncCommittedRevision } from '../api/mutation-request';
 import { useErdCache } from './useErdCache';
 
 export const useCreateConstraint = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (data: CreateConstraintRequest) => createConstraint(data),
+    mutationFn: (data: CreateConstraintRequest) =>
+      createConstraint(data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -38,8 +41,9 @@ export const useChangeConstraintName = (schemaId: string) => {
     }: {
       constraintId: string;
       data: ChangeConstraintNameRequest;
-    }) => changeConstraintName(constraintId, data),
+    }) => changeConstraintName(constraintId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -54,8 +58,9 @@ export const useChangeConstraintCheckExpr = (schemaId: string) => {
     }: {
       constraintId: string;
       data: ChangeConstraintCheckExprRequest;
-    }) => changeConstraintCheckExpr(constraintId, data),
+    }) => changeConstraintCheckExpr(constraintId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -70,8 +75,9 @@ export const useChangeConstraintDefaultExpr = (schemaId: string) => {
     }: {
       constraintId: string;
       data: ChangeConstraintDefaultExprRequest;
-    }) => changeConstraintDefaultExpr(constraintId, data),
+    }) => changeConstraintDefaultExpr(constraintId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -80,8 +86,10 @@ export const useChangeConstraintDefaultExpr = (schemaId: string) => {
 export const useDeleteConstraint = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (constraintId: string) => deleteConstraint(constraintId),
+    mutationFn: (constraintId: string) =>
+      deleteConstraint(constraintId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -96,8 +104,9 @@ export const useAddConstraintColumn = (schemaId: string) => {
     }: {
       constraintId: string;
       data: AddConstraintColumnRequest;
-    }) => addConstraintColumn(constraintId, data),
+    }) => addConstraintColumn(constraintId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -107,8 +116,9 @@ export const useRemoveConstraintColumn = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
     mutationFn: (constraintColumnId: string) =>
-      removeConstraintColumn(constraintColumnId),
+      removeConstraintColumn(constraintColumnId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -123,8 +133,9 @@ export const useChangeConstraintColumnPosition = (schemaId: string) => {
     }: {
       constraintColumnId: string;
       data: ChangeConstraintColumnPositionRequest;
-    }) => changeConstraintColumnPosition(constraintColumnId, data),
+    }) => changeConstraintColumnPosition(constraintColumnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });

--- a/apps/frontend/src/features/drawing/hooks/useErdCache.ts
+++ b/apps/frontend/src/features/drawing/hooks/useErdCache.ts
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { getTableSnapshots } from '../api';
-import type { TableSnapshotResponse } from '../api';
+import type { SchemaSnapshotsResponse } from '../api';
 import { erdKeys } from './query-keys';
+import { collaborationStore } from '@/store/collaboration.store';
 
 export const useErdCache = (schemaId: string) => {
   const queryClient = useQueryClient();
@@ -17,13 +18,28 @@ export const useErdCache = (schemaId: string) => {
           (id) => !(id in snapshots),
         );
 
-        queryClient.setQueryData<Record<string, TableSnapshotResponse>>(
+        queryClient.setQueryData<SchemaSnapshotsResponse>(
           erdKeys.schemaSnapshots(schemaId),
           (old) => {
-            if (!old) return snapshots;
-            const updated = { ...old, ...snapshots };
+            const knownRevision = collaborationStore.getSchemaRevision(schemaId);
+
+            if (!old) {
+              return {
+                currentRevision: knownRevision ?? 0,
+                snapshots,
+              };
+            }
+
+            const updated = { ...old.snapshots, ...snapshots };
             deletedTableIds.forEach((id) => delete updated[id]);
-            return updated;
+
+            return {
+              currentRevision:
+                knownRevision === null
+                  ? old.currentRevision
+                  : Math.max(old.currentRevision, knownRevision),
+              snapshots: updated,
+            };
           },
         );
       } catch {
@@ -39,12 +55,16 @@ export const useErdCache = (schemaId: string) => {
     removedTableId: string,
     affectedTableIds: string[],
   ) => {
-    queryClient.setQueryData<Record<string, TableSnapshotResponse>>(
+    queryClient.setQueryData<SchemaSnapshotsResponse>(
       erdKeys.schemaSnapshots(schemaId),
       (old) => {
         if (!old) return old;
-        const { [removedTableId]: _, ...rest } = old;
-        return rest;
+        const { [removedTableId]: _, ...rest } = old.snapshots;
+
+        return {
+          ...old,
+          snapshots: rest,
+        };
       },
     );
     await updateAffectedTables(affectedTableIds);

--- a/apps/frontend/src/features/drawing/hooks/useErdCache.ts
+++ b/apps/frontend/src/features/drawing/hooks/useErdCache.ts
@@ -21,7 +21,8 @@ export const useErdCache = (schemaId: string) => {
         queryClient.setQueryData<SchemaSnapshotsResponse>(
           erdKeys.schemaSnapshots(schemaId),
           (old) => {
-            const knownRevision = collaborationStore.getSchemaRevision(schemaId);
+            const knownRevision =
+              collaborationStore.getSchemaRevision(schemaId);
 
             if (!old) {
               return {

--- a/apps/frontend/src/features/drawing/hooks/useIndexMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useIndexMutations.ts
@@ -17,13 +17,15 @@ import type {
   ChangeIndexColumnPositionRequest,
   ChangeIndexColumnSortDirectionRequest,
 } from '../api';
+import { syncCommittedRevision } from '../api/mutation-request';
 import { useErdCache } from './useErdCache';
 
 export const useCreateIndex = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (data: CreateIndexRequest) => createIndex(data),
+    mutationFn: (data: CreateIndexRequest) => createIndex(data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -38,8 +40,9 @@ export const useChangeIndexName = (schemaId: string) => {
     }: {
       indexId: string;
       data: ChangeIndexNameRequest;
-    }) => changeIndexName(indexId, data),
+    }) => changeIndexName(indexId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -54,8 +57,9 @@ export const useChangeIndexType = (schemaId: string) => {
     }: {
       indexId: string;
       data: ChangeIndexTypeRequest;
-    }) => changeIndexType(indexId, data),
+    }) => changeIndexType(indexId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -64,8 +68,9 @@ export const useChangeIndexType = (schemaId: string) => {
 export const useDeleteIndex = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (indexId: string) => deleteIndex(indexId),
+    mutationFn: (indexId: string) => deleteIndex(indexId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -80,8 +85,9 @@ export const useAddIndexColumn = (schemaId: string) => {
     }: {
       indexId: string;
       data: AddIndexColumnRequest;
-    }) => addIndexColumn(indexId, data),
+    }) => addIndexColumn(indexId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -90,8 +96,10 @@ export const useAddIndexColumn = (schemaId: string) => {
 export const useRemoveIndexColumn = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (indexColumnId: string) => removeIndexColumn(indexColumnId),
+    mutationFn: (indexColumnId: string) =>
+      removeIndexColumn(indexColumnId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -106,8 +114,9 @@ export const useChangeIndexColumnPosition = (schemaId: string) => {
     }: {
       indexColumnId: string;
       data: ChangeIndexColumnPositionRequest;
-    }) => changeIndexColumnPosition(indexColumnId, data),
+    }) => changeIndexColumnPosition(indexColumnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -122,8 +131,9 @@ export const useChangeIndexColumnSortDirection = (schemaId: string) => {
     }: {
       indexColumnId: string;
       data: ChangeIndexColumnSortDirectionRequest;
-    }) => changeIndexColumnSortDirection(indexColumnId, data),
+    }) => changeIndexColumnSortDirection(indexColumnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });

--- a/apps/frontend/src/features/drawing/hooks/useRelationshipMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useRelationshipMutations.ts
@@ -19,6 +19,7 @@ import type {
   AddRelationshipColumnRequest,
   ChangeRelationshipColumnPositionRequest,
 } from '../api';
+import { syncCommittedRevision } from '../api/mutation-request';
 import { useErdCache } from './useErdCache';
 
 export const useCreateRelationshipWithExtra = (schemaId: string) => {
@@ -27,8 +28,9 @@ export const useCreateRelationshipWithExtra = (schemaId: string) => {
     mutationFn: (data: {
       request: CreateRelationshipRequest;
       extra: NonNullable<CreateRelationshipRequest['extra']>;
-    }) => createRelationship({ ...data.request, extra: data.extra }),
+    }) => createRelationship({ ...data.request, extra: data.extra }, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -43,8 +45,9 @@ export const useChangeRelationshipName = (schemaId: string) => {
     }: {
       relationshipId: string;
       data: ChangeRelationshipNameRequest;
-    }) => changeRelationshipName(relationshipId, data),
+    }) => changeRelationshipName(relationshipId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -59,8 +62,9 @@ export const useChangeRelationshipKind = (schemaId: string) => {
     }: {
       relationshipId: string;
       data: ChangeRelationshipKindRequest;
-    }) => changeRelationshipKind(relationshipId, data),
+    }) => changeRelationshipKind(relationshipId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -75,8 +79,9 @@ export const useChangeRelationshipCardinality = (schemaId: string) => {
     }: {
       relationshipId: string;
       data: ChangeRelationshipCardinalityRequest;
-    }) => changeRelationshipCardinality(relationshipId, data),
+    }) => changeRelationshipCardinality(relationshipId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -91,8 +96,9 @@ export const useChangeRelationshipExtra = (schemaId: string) => {
     }: {
       relationshipId: string;
       data: ChangeRelationshipExtraRequest;
-    }) => changeRelationshipExtra(relationshipId, data),
+    }) => changeRelationshipExtra(relationshipId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -101,8 +107,10 @@ export const useChangeRelationshipExtra = (schemaId: string) => {
 export const useDeleteRelationship = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (relationshipId: string) => deleteRelationship(relationshipId),
+    mutationFn: (relationshipId: string) =>
+      deleteRelationship(relationshipId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -117,8 +125,9 @@ export const useAddRelationshipColumn = (schemaId: string) => {
     }: {
       relationshipId: string;
       data: AddRelationshipColumnRequest;
-    }) => addRelationshipColumn(relationshipId, data),
+    }) => addRelationshipColumn(relationshipId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -128,8 +137,9 @@ export const useRemoveRelationshipColumn = (schemaId: string) => {
   const { updateAffectedTables } = useErdCache(schemaId);
   return useMutation({
     mutationFn: (relationshipColumnId: string) =>
-      removeRelationshipColumn(relationshipColumnId),
+      removeRelationshipColumn(relationshipColumnId, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -144,8 +154,10 @@ export const useChangeRelationshipColumnPosition = (schemaId: string) => {
     }: {
       relationshipColumnId: string;
       data: ChangeRelationshipColumnPositionRequest;
-    }) => changeRelationshipColumnPosition(relationshipColumnId, data),
+    }) =>
+      changeRelationshipColumnPosition(relationshipColumnId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });

--- a/apps/frontend/src/features/drawing/hooks/useRelationships.ts
+++ b/apps/frontend/src/features/drawing/hooks/useRelationships.ts
@@ -22,7 +22,8 @@ import { RELATIONSHIP_TYPES } from '../types';
 
 export const useRelationships = (relationshipConfig: RelationshipConfig) => {
   const { selectedSchemaId } = useSelectedSchema();
-  const { data: snapshotsData } = useSchemaSnapshots(selectedSchemaId);
+  const { data: schemaSnapshots } = useSchemaSnapshots(selectedSchemaId);
+  const snapshotsData = schemaSnapshots.snapshots;
 
   const createRelationshipWithExtraMutation =
     useCreateRelationshipWithExtra(selectedSchemaId);

--- a/apps/frontend/src/features/drawing/hooks/useSchemaMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useSchemaMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createSchema, changeSchemaName, deleteSchema } from '../api';
 import type { CreateSchemaRequest, ChangeSchemaNameRequest } from '../api';
+import { collaborationStore } from '@/store/collaboration.store';
 import { erdKeys } from './query-keys';
 
 export const useCreateSchema = (projectId: string) => {
@@ -8,7 +9,11 @@ export const useCreateSchema = (projectId: string) => {
 
   return useMutation({
     mutationFn: (data: CreateSchemaRequest) => createSchema(data),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      collaborationStore.setSchemaRevision(
+        result.data.id,
+        result.operation.committedRevision,
+      );
       queryClient.invalidateQueries({
         queryKey: erdKeys.schemas(projectId),
       });
@@ -27,7 +32,11 @@ export const useChangeSchemaName = (projectId: string) => {
       schemaId: string;
       data: ChangeSchemaNameRequest;
     }) => changeSchemaName(schemaId, data),
-    onSuccess: () => {
+    onSuccess: (result, { schemaId }) => {
+      collaborationStore.setSchemaRevision(
+        schemaId,
+        result.operation.committedRevision,
+      );
       queryClient.invalidateQueries({
         queryKey: erdKeys.schemas(projectId),
       });
@@ -47,6 +56,7 @@ export const useDeleteSchema = (projectId: string) => {
       queryClient.invalidateQueries({
         queryKey: erdKeys.schemas(projectId),
       });
+      collaborationStore.clearSchemaRevision(deletedSchemaId);
     },
   });
 };

--- a/apps/frontend/src/features/drawing/hooks/useSchemaSnapshots.ts
+++ b/apps/frontend/src/features/drawing/hooks/useSchemaSnapshots.ts
@@ -1,11 +1,19 @@
+import { useLayoutEffect } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getSchemaWithSnapshots } from '../api';
 import { erdKeys } from './query-keys';
+import { collaborationStore } from '@/store/collaboration.store';
 
 export const useSchemaSnapshots = (schemaId: string) => {
-  return useSuspenseQuery({
+  const query = useSuspenseQuery({
     queryKey: erdKeys.schemaSnapshots(schemaId),
     queryFn: () => getSchemaWithSnapshots(schemaId),
     staleTime: Infinity,
   });
+
+  useLayoutEffect(() => {
+    collaborationStore.setSchemaRevision(schemaId, query.data.currentRevision);
+  }, [schemaId, query.data.currentRevision]);
+
+  return query;
 };

--- a/apps/frontend/src/features/drawing/hooks/useTableMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useTableMutations.ts
@@ -12,6 +12,7 @@ import type {
   ChangeTableMetaRequest,
   ChangeTableExtraRequest,
 } from '../api';
+import { syncCommittedRevision } from '../api/mutation-request';
 import { useErdCache } from './useErdCache';
 
 export const useCreateTableWithExtra = (schemaId: string) => {
@@ -22,6 +23,7 @@ export const useCreateTableWithExtra = (schemaId: string) => {
       extra: NonNullable<CreateTableRequest['extra']>;
     }) => createTable({ ...data.request, extra: data.extra }),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -36,8 +38,9 @@ export const useChangeTableName = (schemaId: string) => {
     }: {
       tableId: string;
       data: ChangeTableNameRequest;
-    }) => changeTableName(tableId, data),
+    }) => changeTableName(tableId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -52,8 +55,9 @@ export const useChangeTableMeta = (schemaId: string) => {
     }: {
       tableId: string;
       data: ChangeTableMetaRequest;
-    }) => changeTableMeta(tableId, data),
+    }) => changeTableMeta(tableId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -68,8 +72,9 @@ export const useChangeTableExtra = (schemaId: string) => {
     }: {
       tableId: string;
       data: ChangeTableExtraRequest;
-    }) => changeTableExtra(tableId, data),
+    }) => changeTableExtra(tableId, data, schemaId),
     onSuccess: (result) => {
+      syncCommittedRevision(schemaId, result);
       updateAffectedTables(result.affectedTableIds);
     },
   });
@@ -78,8 +83,9 @@ export const useChangeTableExtra = (schemaId: string) => {
 export const useDeleteTable = (schemaId: string) => {
   const { removeAndUpdate } = useErdCache(schemaId);
   return useMutation({
-    mutationFn: (tableId: string) => deleteTable(tableId),
+    mutationFn: (tableId: string) => deleteTable(tableId, schemaId),
     onSuccess: (result, tableId) => {
+      syncCommittedRevision(schemaId, result);
       removeAndUpdate(tableId, result.affectedTableIds);
     },
   });

--- a/apps/frontend/src/features/drawing/hooks/useTables.ts
+++ b/apps/frontend/src/features/drawing/hooks/useTables.ts
@@ -16,7 +16,8 @@ import {
 
 export const useTables = () => {
   const { selectedSchemaId } = useSelectedSchema();
-  const { data: snapshotsData } = useSchemaSnapshots(selectedSchemaId);
+  const { data: schemaSnapshots } = useSchemaSnapshots(selectedSchemaId);
+  const snapshotsData = schemaSnapshots.snapshots;
 
   const createTableWithExtraMutation =
     useCreateTableWithExtra(selectedSchemaId);

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -29,6 +29,7 @@ const MAX_RECONNECT_DELAY_MS = 60000;
 
 export class CollaborationStore {
   cursors: Map<string, CursorPosition> = new Map();
+  schemaRevisions: Map<string, number> = new Map();
   projectId: string | null = null;
   sessionId: string | null = null;
   private ws: WebSocket | null = null;
@@ -41,6 +42,7 @@ export class CollaborationStore {
   constructor() {
     makeObservable(this, {
       cursors: observable,
+      schemaRevisions: observable.shallow,
       projectId: observable,
       sessionId: observable,
       currentUser: computed,
@@ -48,11 +50,25 @@ export class CollaborationStore {
       disconnect: action,
       sendMessage: action,
       sendCursor: action,
+      setSchemaRevision: action,
+      clearSchemaRevision: action,
     });
   }
 
   get currentUser() {
     return authStore.user;
+  }
+
+  getSchemaRevision(schemaId: string): number | null {
+    return this.schemaRevisions.get(schemaId) ?? null;
+  }
+
+  setSchemaRevision(schemaId: string, revision: number) {
+    this.schemaRevisions.set(schemaId, revision);
+  }
+
+  clearSchemaRevision(schemaId: string) {
+    this.schemaRevisions.delete(schemaId);
   }
 
   connect(projectId: string, isReconnect = false) {
@@ -153,6 +169,7 @@ export class CollaborationStore {
     runInAction(() => {
       this.projectId = null;
       this.cursors.clear();
+      this.schemaRevisions.clear();
       this.sessionId = null;
     });
   }
@@ -268,6 +285,10 @@ export class CollaborationStore {
   }
 
   private handleErdMutatedMessage(message: ReceiveErdMutated) {
+    this.setSchemaRevision(
+      message.schemaId,
+      message.operation.committedRevision,
+    );
     this.erdMutatedListeners.forEach((listener) => listener(message));
   }
 

--- a/apps/frontend/src/store/collaboration.store.ts
+++ b/apps/frontend/src/store/collaboration.store.ts
@@ -64,7 +64,11 @@ export class CollaborationStore {
   }
 
   setSchemaRevision(schemaId: string, revision: number) {
-    this.schemaRevisions.set(schemaId, revision);
+    const currentRevision = this.schemaRevisions.get(schemaId);
+
+    if (currentRevision === undefined || revision > currentRevision) {
+      this.schemaRevisions.set(schemaId, revision);
+    }
   }
 
   clearSchemaRevision(schemaId: string) {


### PR DESCRIPTION
## 개요
- backend mutation response 및 collaboration event의 committed ERD operation metadata 노출
- BFF의 `X-Client-Op-Id`, `X-Base-Schema-Revision`, `X-Session-Id` 전달
- frontend의 schema revision 기반 mutation sync 및 cache 정합성 보강
- `currentRevision` 기반 schema 조회/응답 경로 및 API 문서 보강

## 참고
- `#295` 후속 작업으로서 ERD mutation HTTP/WS contract 확장 범위

## 테스트
- `./gradlew :api:compileJava`
- `./gradlew :core:test --tests com.schemafy.core.erd.schema.application.service.GetSchemaWithRevisionServiceTest`
- `./gradlew :api:test --tests com.schemafy.api.erd.controller.SchemaControllerTest`

## 이슈
- close #296
