### PR TITLE
chore: clean up api guide snippets

### DIFF
--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -28,7 +28,8 @@
     346
   ],
   "apps/backend/api/src/docs/asciidoc/api-guide.adoc": [
-    337
+    337,
+    362
   ],
   "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java": [
     337

--- a/apps/backend/api/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/api/src/docs/asciidoc/api-guide.adoc
@@ -7,6 +7,7 @@
 :highlightjs-theme: github
 :icons: font
 :imagesdir: images
+ifndef::snippets[:snippets: ../../../build/generated-snippets]
 
 == 개요
 
@@ -1358,14 +1359,8 @@ include::{snippets}/memo-delete/curl-request.adoc[]
 [discrete]
 ==== 응답
 
-include::{snippets}/memo-delete/response-headers.adoc[]
 include::{snippets}/memo-delete/response-body.adoc[]
 include::{snippets}/memo-delete/http-response.adoc[]
-
-[discrete]
-==== 응답 필드
-
-include::{snippets}/memo-delete/response-fields.adoc[]
 
 ---
 
@@ -1484,14 +1479,8 @@ include::{snippets}/memo-comment-delete/curl-request.adoc[]
 [discrete]
 ==== 응답
 
-include::{snippets}/memo-comment-delete/response-headers.adoc[]
 include::{snippets}/memo-comment-delete/response-body.adoc[]
 include::{snippets}/memo-comment-delete/http-response.adoc[]
-
-[discrete]
-==== 응답 필드
-
-include::{snippets}/memo-comment-delete/response-fields.adoc[]
 
 ---
 
@@ -3637,7 +3626,6 @@ include::{snippets}/user-refresh/curl-request.adoc[]
 include::{snippets}/user-refresh/response-headers.adoc[]
 include::{snippets}/user-refresh/response-body.adoc[]
 include::{snippets}/user-refresh/http-response.adoc[]
-include::{snippets}/user-refresh/response-fields.adoc[]
 
 ---
 


### PR DESCRIPTION
## 개요
- `api-guide.adoc`에 `snippets` attribute 기본 경로를 추가해 로컬/빌드 환경 모두에서 스니펫 include 경로가 해석되도록 정리
- `memo-delete`, `memo-comment-delete` 문서에서 불필요한 `response-headers`, `response-fields` include를 제거
- `user-refresh` 문서에서 존재하지 않는 `response-fields` include를 제거

## 테스트
- `./gradlew :api:asciidoctor`