### PR TITLE
refactor(#106): add annotation-based workspace/project access verification

### DIFF
--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -1,21 +1,95 @@
 {
+  ".github/pr-contexts/file-index.json": [
+    291,
+    335,
+    337,
+    346,
+    347,
+    352
+  ],
+  "apps/frontend/src/features/collaboration/components/ChatBubble.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/components/ChatInput.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/components/ChatOverlay.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/components/RemoteCursors.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/components/index.ts": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/hooks/useChatAnimation.ts": [
+    291
+  ],
+  "apps/frontend/src/features/collaboration/hooks/useInactivityTimer.ts": [
+    291
+  ],
+  "apps/frontend/src/features/drawing/components/FloatingButtons.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/drawing/components/ShortcutPanel.tsx": [
+    291
+  ],
+  "apps/frontend/src/features/drawing/components/Toolbar.tsx": [
+    331,
+    291
+  ],
+  "apps/frontend/src/features/drawing/components/index.ts": [
+    331,
+    291
+  ],
   ".github/workflows/cursor-pr-review.yml": [
     317,
     335
   ],
+  ".github/workflows/issue-automation.yml": [
+    353
+  ],
+  ".github/workflows/issue-project-intake.yml": [
+    353
+  ],
+  ".github/workflows/lint-and-format.yml": [
+    346
+  ],
   ".github/workflows/save-pr-context.yml": [
     317
   ],
-  ".github/pr-contexts/file-index.json": [
-    335,
-    337,
+  "apps/frontend/src/features/drawing/hooks/useCanvasController.ts": [
+    331,
+    291
+  ],
+  "apps/frontend/src/features/drawing/hooks/useCanvasKeyboard.ts": [
+    331,
+    291
+  ],
+  "apps/frontend/src/hooks/useChatMessages.ts": [
+    291
+  ],
+  "apps/frontend/src/pages/CanvasPage.tsx": [
+    331,
+    291
+  ],
+  "apps/frontend/src/store/collaboration.store.ts": [
+    291
+  ],
+  ".github/workflows/test.yml": [
+    346
+  ],
+  ".npmrc": [
     346
   ],
   "apps/backend/api/src/docs/asciidoc/api-guide.adoc": [
-    337
+    337,
+    357,
+    362
   ],
   "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java": [
-    337
+    337,
+    357
   ],
   "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEvent.java": [
     337
@@ -50,6 +124,18 @@
   "apps/backend/api/src/main/java/com/schemafy/api/erd/controller/dto/response/SchemaResponse.java": [
     337
   ],
+  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java": [
+    354
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectInvitationController.java": [
+    354
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceController.java": [
+    354
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceInvitationController.java": [
+    354
+  ],
   "apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/ErdMutatedEventTest.java": [
     337
   ],
@@ -58,6 +144,9 @@
   ],
   "apps/backend/api/src/test/java/com/schemafy/api/common/docs/RestDocsSnippets.java": [
     337
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/common/exception/DomainErrorCodeUniquenessTest.java": [
+    352
   ],
   "apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java": [
     337
@@ -83,14 +172,74 @@
   "apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java": [
     337
   ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectApiSnippets.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectInvitationApiSnippets.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ShareLinkApiSnippets.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceApiSnippets.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceInvitationApiSnippets.java": [
+    354
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/testsupport/project/ProjectHttpTestSupport.java": [
+    354
+  ],
   "apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java": [
     337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationLogRepository.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationPersistenceAdapter.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/port/out/GetErdOperationByIdPort.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/port/out/GetErdOperationsBySchemaIdPort.java": [
+    352
   ],
   "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java": [
     337
   ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultUndoRedoEligibilityService.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ResolvedUndoRedoEligibility.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/UndoRedoAction.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/UndoRedoEligibilityService.java": [
+    352
+  ],
   "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/CommittedErdOperation.java": [
     337
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/ErdOperationDerivationKind.java": [
+    352
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/exception/OperationErrorCode.java": [
+    352
   ],
   "apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/port/in/GetSchemaWithRevisionResult.java": [
     337
@@ -101,8 +250,18 @@
   "apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionService.java": [
     337
   ],
+  "apps/backend/core/src/test/java/com/schemafy/core/erd/operation/application/service/DefaultUndoRedoEligibilityServiceTest.java": [
+    352
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/UndoRedoEligibilityIntegrationTest.java": [
+    352
+  ],
   "apps/backend/core/src/test/java/com/schemafy/core/erd/schema/application/service/GetSchemaWithRevisionServiceTest.java": [
     337
+  ],
+  "apps/bff/package.json": [
+    346,
+    291
   ],
   "apps/bff/src/common/backend-client/backend-client.service.ts": [
     337
@@ -161,78 +320,6 @@
   "apps/frontend/src/features/drawing/api/constraint.api.ts": [
     337
   ],
-  ".github/workflows/lint-and-format.yml": [
-    346
-  ],
-  ".github/workflows/test.yml": [
-    346
-  ],
-  "apps/bff/package.json": [
-    346
-  ],
-  "package-lock.json": [
-    346
-  ],
-  "package.json": [
-    346
-  ],
-  "pnpm-lock.yaml": [
-    346
-  ],
-  "pnpm-workspace.yaml": [
-    346
-  ],
-  ".npmrc": [
-    346
-  ],
-  ".github/workflows/issue-automation.yml": [
-    353
-  ],
-  ".github/workflows/issue-project-intake.yml": [
-    353
-  ],
-  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java": [
-    354
-  ],
-  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectInvitationController.java": [
-    354
-  ],
-  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceController.java": [
-    354
-  ],
-  "apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceInvitationController.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectApiSnippets.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectInvitationApiSnippets.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/ShareLinkApiSnippets.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceApiSnippets.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceInvitationApiSnippets.java": [
-    354
-  ],
-  "apps/backend/api/src/test/java/com/schemafy/api/testsupport/project/ProjectHttpTestSupport.java": [
-    354
-  ],
   "apps/frontend/src/features/drawing/components/CustomSmoothStepEdge.tsx": [
     331
   ],
@@ -248,22 +335,10 @@
   "apps/frontend/src/features/drawing/components/TablePreview.tsx": [
     331
   ],
-  "apps/frontend/src/features/drawing/components/Toolbar.tsx": [
-    331
-  ],
-  "apps/frontend/src/features/drawing/components/index.ts": [
-    331
-  ],
   "apps/frontend/src/features/drawing/contexts/SelectedSchemaContext.tsx": [
     331
   ],
   "apps/frontend/src/features/drawing/hooks/index.ts": [
-    331
-  ],
-  "apps/frontend/src/features/drawing/hooks/useCanvasController.ts": [
-    331
-  ],
-  "apps/frontend/src/features/drawing/hooks/useCanvasKeyboard.ts": [
     331
   ],
   "apps/frontend/src/features/drawing/hooks/useCanvasNodes.ts": [
@@ -276,7 +351,8 @@
     331
   ],
   "apps/frontend/src/features/drawing/hooks/useRelationships.ts": [
-    331
+    331,
+    291
   ],
   "apps/frontend/src/features/drawing/hooks/useTables.ts": [
     331
@@ -287,7 +363,62 @@
   "apps/frontend/src/features/memo/hooks/useMemoStore.ts": [
     331
   ],
-  "apps/frontend/src/pages/CanvasPage.tsx": [
-    331
+  "package-lock.json": [
+    346
+  ],
+  "package.json": [
+    346
+  ],
+  "pnpm-lock.yaml": [
+    346,
+    291
+  ],
+  "pnpm-workspace.yaml": [
+    346
+  ],
+  ".npmrc": [
+    346
+  ],
+  ".env.example": [
+    347
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/CollaborationEventType.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/PreviewAction.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationInbound.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutbound.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/RelationshipExtraPreviewEvent.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/TablePositionPreviewEvent.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java": [
+    357
+  ],
+  "apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java": [
+    357
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/RelationshipExtraPreviewEventTest.java": [
+    357
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/TablePositionPreviewEventTest.java": [
+    357
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java": [
+    357
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandlerTest.java": [
+    357
+  ],
+  "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java": [
+    357
   ]
 }

--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -5,7 +5,8 @@
     337,
     346,
     347,
-    352
+    352,
+    364
   ],
   "apps/frontend/src/features/collaboration/components/ChatBubble.tsx": [
     291
@@ -376,9 +377,6 @@
   "pnpm-workspace.yaml": [
     346
   ],
-  ".npmrc": [
-    346
-  ],
   ".env.example": [
     347
   ],
@@ -420,5 +418,62 @@
   ],
   "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java": [
     357
+  ],
+  "apps/backend/core/build.gradle": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessAnnotationValidator.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerificationAspect.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerifier.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireProjectAccess.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireWorkspaceAccess.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectMembersService.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectService.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java": [
+    364
+  ],
+  "apps/backend/core/src/main/java/com/schemafy/core/project/domain/WorkspaceRole.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessAnnotationValidatorTest.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectSpringContextTest.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectTest.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerifierTest.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/domain/EnumDbContractTest.java": [
+    364
+  ],
+  "apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java": [
+    364
   ]
 }

--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -5,8 +5,7 @@
     337,
     346,
     347,
-    352,
-    364
+    352
   ],
   "apps/frontend/src/features/collaboration/components/ChatBubble.tsx": [
     291
@@ -377,6 +376,9 @@
   "pnpm-workspace.yaml": [
     346
   ],
+  ".npmrc": [
+    346
+  ],
   ".env.example": [
     347
   ],
@@ -418,62 +420,5 @@
   ],
   "apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java": [
     357
-  ],
-  "apps/backend/core/build.gradle": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessAnnotationValidator.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerificationAspect.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerifier.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireProjectAccess.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireWorkspaceAccess.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectMembersService.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectService.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java": [
-    364
-  ],
-  "apps/backend/core/src/main/java/com/schemafy/core/project/domain/WorkspaceRole.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessAnnotationValidatorTest.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectSpringContextTest.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectTest.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerifierTest.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/domain/EnumDbContractTest.java": [
-    364
-  ],
-  "apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java": [
-    364
   ]
 }

--- a/.github/pr-contexts/file-index.json
+++ b/.github/pr-contexts/file-index.json
@@ -190,6 +190,7 @@
   ],
   ".github/workflows/issue-project-intake.yml": [
     353
+  ],
   "apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java": [
     354
   ],

--- a/apps/backend/core/build.gradle
+++ b/apps/backend/core/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework:spring-web'

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessAnnotationValidator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessAnnotationValidator.java
@@ -1,0 +1,95 @@
+package com.schemafy.core.project.application.access;
+
+import java.lang.reflect.Method;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+class AccessAnnotationValidator implements SmartInitializingSingleton {
+
+  private final ApplicationContext applicationContext;
+
+  @Override
+  public void afterSingletonsInstantiated() {
+    applicationContext.getBeansOfType(Object.class, false, false)
+        .values()
+        .forEach(this::validateBean);
+  }
+
+  private void validateBean(Object bean) {
+    Class<?> targetClass = AopUtils.getTargetClass(bean);
+    for (Method method : targetClass.getDeclaredMethods()) {
+      validateMethod(targetClass, method);
+    }
+  }
+
+  private void validateMethod(Class<?> targetClass, Method method) {
+    RequireProjectAccess projectAccess = method.getAnnotation(RequireProjectAccess.class);
+    RequireWorkspaceAccess workspaceAccess = method.getAnnotation(RequireWorkspaceAccess.class);
+    if (projectAccess == null && workspaceAccess == null) {
+      return;
+    }
+
+    if (projectAccess != null && workspaceAccess != null) {
+      throw new IllegalStateException(
+          "Only one access annotation can be declared on "
+              + targetClass.getSimpleName() + "#" + method.getName());
+    }
+
+    if (!Mono.class.isAssignableFrom(method.getReturnType())
+        && !Flux.class.isAssignableFrom(method.getReturnType())) {
+      throw new IllegalStateException(
+          "Access annotations are only supported on Mono/Flux methods: "
+              + targetClass.getSimpleName() + "#" + method.getName());
+    }
+
+    if (method.getParameterCount() != 1) {
+      throw new IllegalStateException(
+          "Access annotations require exactly one request parameter on "
+              + targetClass.getSimpleName() + "#" + method.getName());
+    }
+
+    Class<?> requestType = method.getParameterTypes()[0];
+    if (projectAccess != null) {
+      validateStringAccessor(targetClass, method, requestType, projectAccess.projectId(), "projectId");
+      validateStringAccessor(targetClass, method, requestType, projectAccess.requesterId(), "requesterId");
+    }
+    if (workspaceAccess != null) {
+      validateStringAccessor(targetClass, method, requestType, workspaceAccess.workspaceId(), "workspaceId");
+      validateStringAccessor(targetClass, method, requestType, workspaceAccess.requesterId(), "requesterId");
+    }
+  }
+
+  private void validateStringAccessor(
+      Class<?> targetClass,
+      Method method,
+      Class<?> requestType,
+      String accessorName,
+      String label) {
+    Method accessor;
+    try {
+      accessor = requestType.getMethod(accessorName);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(
+          "Access annotation requires " + label + " accessor " + accessorName + "() on "
+              + requestType.getSimpleName() + " for "
+              + targetClass.getSimpleName() + "#" + method.getName(),
+          e);
+    }
+    if (!String.class.equals(accessor.getReturnType())) {
+      throw new IllegalStateException(
+          "Access annotation requires " + label + " accessor " + accessorName
+              + " to return String on "
+              + targetClass.getSimpleName() + "#" + method.getName());
+    }
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerificationAspect.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerificationAspect.java
@@ -1,0 +1,164 @@
+package com.schemafy.core.project.application.access;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class AccessVerificationAspect {
+
+  private final AccessVerifier accessVerifier;
+
+  @Around("@annotation(com.schemafy.core.project.application.access.RequireProjectAccess) || "
+      + "@annotation(com.schemafy.core.project.application.access.RequireWorkspaceAccess)")
+  public Object verifyAccess(ProceedingJoinPoint joinPoint) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    Method method = AopUtils.getMostSpecificMethod(
+        signature.getMethod(),
+        joinPoint.getTarget().getClass());
+
+    RequireProjectAccess projectAccess = method.getAnnotation(RequireProjectAccess.class);
+    RequireWorkspaceAccess workspaceAccess = method.getAnnotation(RequireWorkspaceAccess.class);
+    if (projectAccess != null && workspaceAccess != null) {
+      throw new IllegalStateException(
+          "Only one access annotation can be declared on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName());
+    }
+    if (projectAccess == null && workspaceAccess == null) {
+      throw new IllegalStateException(
+          "Access annotation is missing on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName());
+    }
+
+    Class<?> returnType = method.getReturnType();
+    if (Mono.class.isAssignableFrom(returnType)) {
+      return Mono.defer(() -> buildVerificationChain(
+          method,
+          joinPoint.getArgs(),
+          projectAccess,
+          workspaceAccess)
+          .then(Mono.defer(() -> proceedMono(joinPoint, method))));
+    }
+    if (Flux.class.isAssignableFrom(returnType)) {
+      return Flux.defer(() -> buildVerificationChain(
+          method,
+          joinPoint.getArgs(),
+          projectAccess,
+          workspaceAccess)
+          .thenMany(Flux.defer(() -> proceedFlux(joinPoint, method))));
+    }
+    throw new IllegalStateException(
+        "Access annotations are only supported on Mono/Flux methods: "
+            + method.getDeclaringClass().getSimpleName() + "#" + method.getName());
+  }
+
+  private Mono<Void> buildVerificationChain(
+      Method method,
+      Object[] args,
+      RequireProjectAccess projectAccess,
+      RequireWorkspaceAccess workspaceAccess) {
+    return projectAccess != null
+        ? accessVerifier.requireProjectAccess(
+            extractStringValue(method, args, projectAccess.projectId(), "projectId"),
+            extractStringValue(method, args, projectAccess.requesterId(), "requesterId"),
+            projectAccess.role())
+        : accessVerifier.requireWorkspaceAccess(
+            extractStringValue(method, args, workspaceAccess.workspaceId(), "workspaceId"),
+            extractStringValue(method, args, workspaceAccess.requesterId(), "requesterId"),
+            workspaceAccess.role());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Mono<Object> proceedMono(ProceedingJoinPoint joinPoint, Method method) {
+    try {
+      Object result = joinPoint.proceed();
+      if (result instanceof Mono<?> mono) {
+        return (Mono<Object>) mono;
+      }
+      return Mono.error(new IllegalStateException(
+          "Access annotation target did not return Mono: "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName()));
+    } catch (Throwable t) {
+      return Mono.error(t);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Flux<Object> proceedFlux(ProceedingJoinPoint joinPoint, Method method) {
+    try {
+      Object result = joinPoint.proceed();
+      if (result instanceof Flux<?> flux) {
+        return (Flux<Object>) flux;
+      }
+      return Flux.error(new IllegalStateException(
+          "Access annotation target did not return Flux: "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName()));
+    } catch (Throwable t) {
+      return Flux.error(t);
+    }
+  }
+
+  private String extractStringValue(Method method, Object[] args, String accessorName, String label) {
+    Object request = extractRequestArgument(method, args);
+    Method accessor = findAccessor(method, request.getClass(), accessorName, label);
+    Object value;
+    try {
+      value = accessor.invoke(request);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(
+          "Access annotation cannot read " + label + " accessor " + accessorName + " on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName(),
+          e);
+    } catch (InvocationTargetException e) {
+      throw new IllegalStateException(
+          "Access annotation accessor " + accessorName + " failed on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName(),
+          e.getTargetException());
+    }
+    if (!(value instanceof String stringValue)) {
+      throw new IllegalStateException(
+          "Access annotation requires " + label + " accessor " + accessorName
+              + " to return String on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName());
+    }
+    return stringValue;
+  }
+
+  private Object extractRequestArgument(Method method, Object[] args) {
+    if (args.length != 1 || args[0] == null) {
+      throw new IllegalStateException(
+          "Access annotations require exactly one non-null request argument on "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName());
+    }
+    return args[0];
+  }
+
+  private Method findAccessor(Method method, Class<?> requestType, String accessorName, String label) {
+    try {
+      return requestType.getMethod(accessorName);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(
+          "Access annotation requires " + label + " accessor " + accessorName + "() on "
+              + requestType.getSimpleName() + " for "
+              + method.getDeclaringClass().getSimpleName() + "#" + method.getName(),
+          e);
+    }
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerifier.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/AccessVerifier.java
@@ -1,0 +1,65 @@
+package com.schemafy.core.project.application.access;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class AccessVerifier {
+
+  private final WorkspaceMemberPort workspaceMemberPort;
+  private final ProjectMemberPort projectMemberPort;
+
+  public Mono<Void> requireProjectAccess(
+      String projectId,
+      String requesterId,
+      ProjectRole requiredRole) {
+    return projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(projectId, requesterId)
+        .switchIfEmpty(Mono.error(new DomainException(ProjectErrorCode.ACCESS_DENIED)))
+        .flatMap(member -> verifyProjectRole(member, requiredRole));
+  }
+
+  public Mono<Void> requireWorkspaceAccess(
+      String workspaceId,
+      String requesterId,
+      WorkspaceRole requiredRole) {
+    return workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, requesterId)
+        .switchIfEmpty(Mono.error(new DomainException(WorkspaceErrorCode.ACCESS_DENIED)))
+        .flatMap(member -> verifyWorkspaceRole(member, requiredRole));
+  }
+
+  private Mono<Void> verifyProjectRole(ProjectMember member, ProjectRole requiredRole) {
+    ProjectRole currentRole = member.getRoleAsEnum();
+    if (currentRole.isHigherOrEqualThan(requiredRole)) {
+      return Mono.empty();
+    }
+    if (requiredRole == ProjectRole.ADMIN) {
+      return Mono.error(new DomainException(ProjectErrorCode.ADMIN_REQUIRED));
+    }
+    return Mono.error(new DomainException(ProjectErrorCode.ACCESS_DENIED));
+  }
+
+  private Mono<Void> verifyWorkspaceRole(WorkspaceMember member, WorkspaceRole requiredRole) {
+    WorkspaceRole currentRole = member.getRoleAsEnum();
+    if (currentRole.isHigherOrEqualThan(requiredRole)) {
+      return Mono.empty();
+    }
+    if (requiredRole == WorkspaceRole.ADMIN) {
+      return Mono.error(new DomainException(WorkspaceErrorCode.ADMIN_REQUIRED));
+    }
+    return Mono.error(new DomainException(WorkspaceErrorCode.ACCESS_DENIED));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireProjectAccess.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireProjectAccess.java
@@ -1,0 +1,20 @@
+package com.schemafy.core.project.application.access;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.schemafy.core.project.domain.ProjectRole;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireProjectAccess {
+
+  ProjectRole role() default ProjectRole.VIEWER;
+
+  String projectId() default "projectId";
+
+  String requesterId() default "requesterId";
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireWorkspaceAccess.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/access/RequireWorkspaceAccess.java
@@ -1,0 +1,20 @@
+package com.schemafy.core.project.application.access;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.schemafy.core.project.domain.WorkspaceRole;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireWorkspaceAccess {
+
+  WorkspaceRole role() default WorkspaceRole.MEMBER;
+
+  String workspaceId() default "workspaceId";
+
+  String requesterId() default "requesterId";
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
@@ -3,8 +3,10 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
+import com.schemafy.core.project.domain.ProjectRole;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -18,10 +20,9 @@ class DeleteProjectService implements DeleteProjectUseCase {
   private final ProjectCascadeHelper projectCascadeHelper;
 
   @Override
+  @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<Void> deleteProject(DeleteProjectCommand command) {
-    return projectAccessHelper.validateProjectAdmin(command.projectId(),
-        command.requesterId())
-        .then(projectAccessHelper.findProjectById(command.projectId()))
+    return projectAccessHelper.findProjectById(command.projectId())
         .flatMap(projectCascadeHelper::softDeleteProjectCascade)
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectMembersService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectMembersService.java
@@ -3,10 +3,12 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.GetProjectMembersQuery;
 import com.schemafy.core.project.application.port.in.GetProjectMembersUseCase;
 import com.schemafy.core.project.application.port.out.ProjectMemberPort;
 import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -19,11 +21,10 @@ class GetProjectMembersService implements GetProjectMembersUseCase {
   private final ProjectAccessHelper projectAccessHelper;
 
   @Override
+  @RequireProjectAccess(role = ProjectRole.VIEWER)
   public Mono<PageResult<ProjectMember>> getProjectMembers(
       GetProjectMembersQuery query) {
-    return projectAccessHelper.validateProjectMember(query.projectId(),
-        query.requesterId())
-        .then(projectMemberPort.countByProjectIdAndNotDeleted(query.projectId()))
+    return projectMemberPort.countByProjectIdAndNotDeleted(query.projectId())
         .flatMap(totalElements -> projectMemberPort
             .findByProjectIdAndNotDeleted(query.projectId(), query.size(),
                 query.page() * query.size())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectService.java
@@ -2,9 +2,11 @@ package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
 
+import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.GetProjectQuery;
 import com.schemafy.core.project.application.port.in.GetProjectUseCase;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
+import com.schemafy.core.project.domain.ProjectRole;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -16,10 +18,9 @@ class GetProjectService implements GetProjectUseCase {
   private final ProjectAccessHelper projectAccessHelper;
 
   @Override
+  @RequireProjectAccess(role = ProjectRole.VIEWER)
   public Mono<ProjectDetail> getProject(GetProjectQuery query) {
-    return projectAccessHelper.validateProjectMember(query.projectId(),
-        query.requesterId())
-        .then(projectAccessHelper.findProjectById(query.projectId()))
+    return projectAccessHelper.findProjectById(query.projectId())
         .flatMap(project -> projectAccessHelper.buildProjectDetail(project,
             query.requesterId()));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
@@ -3,6 +3,7 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Component;
 
 import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.access.AccessVerifier;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
 import com.schemafy.core.project.application.port.out.ProjectMemberPort;
 import com.schemafy.core.project.application.port.out.ProjectPort;
@@ -11,6 +12,7 @@ import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 
@@ -21,6 +23,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class ProjectAccessHelper {
 
+  private final AccessVerifier accessVerifier;
   private final ProjectPort projectPort;
   private final ProjectMemberPort projectMemberPort;
   private final WorkspaceMemberPort workspaceMemberPort;
@@ -52,39 +55,22 @@ class ProjectAccessHelper {
   }
 
   Mono<Void> validateWorkspaceAdmin(String workspaceId, String userId) {
-    return workspaceMemberPort
-        .findByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, userId)
-        .filter(WorkspaceMember::isAdmin)
-        .switchIfEmpty(Mono.error(
-            new DomainException(WorkspaceErrorCode.ACCESS_DENIED)))
+    return accessVerifier.requireWorkspaceAccess(workspaceId, userId, WorkspaceRole.ADMIN)
+        .onErrorMap(DomainException.hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED),
+            error -> new DomainException(WorkspaceErrorCode.ACCESS_DENIED))
         .then();
   }
 
   Mono<Void> validateWorkspaceMember(String workspaceId, String userId) {
-    return workspaceMemberPort
-        .findByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, userId)
-        .switchIfEmpty(Mono.error(new DomainException(
-            WorkspaceErrorCode.ACCESS_DENIED)))
-        .then();
+    return accessVerifier.requireWorkspaceAccess(workspaceId, userId, WorkspaceRole.MEMBER);
   }
 
   Mono<Void> validateProjectMember(String projectId, String userId) {
-    return projectMemberPort
-        .findByProjectIdAndUserIdAndNotDeleted(projectId, userId)
-        .switchIfEmpty(Mono.error(
-            new DomainException(ProjectErrorCode.ACCESS_DENIED)))
-        .then();
+    return accessVerifier.requireProjectAccess(projectId, userId, ProjectRole.VIEWER);
   }
 
   Mono<Void> validateProjectAdmin(String projectId, String userId) {
-    return projectMemberPort
-        .findByProjectIdAndUserIdAndNotDeleted(projectId, userId)
-        .switchIfEmpty(Mono.error(
-            new DomainException(ProjectErrorCode.ACCESS_DENIED)))
-        .filter(ProjectMember::isAdmin)
-        .switchIfEmpty(Mono.error(
-            new DomainException(ProjectErrorCode.ADMIN_REQUIRED)))
-        .then();
+    return accessVerifier.requireProjectAccess(projectId, userId, ProjectRole.ADMIN);
   }
 
   Mono<Void> validateWorkspaceAdminGuard(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
@@ -3,10 +3,12 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
 import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
 import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.domain.ProjectRole;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -20,10 +22,9 @@ class UpdateProjectService implements UpdateProjectUseCase {
   private final ProjectAccessHelper projectAccessHelper;
 
   @Override
+  @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ProjectDetail> updateProject(UpdateProjectCommand command) {
-    return projectAccessHelper.validateProjectAdmin(command.projectId(),
-        command.requesterId())
-        .then(projectAccessHelper.findProjectById(command.projectId()))
+    return projectAccessHelper.findProjectById(command.projectId())
         .flatMap(project -> {
           project.update(command.name(), command.description());
           return projectPort.save(project);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import org.springframework.stereotype.Component;
 
 import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.access.AccessVerifier;
 import com.schemafy.core.project.application.port.in.WorkspaceDetail;
 import com.schemafy.core.project.application.port.out.ProjectPort;
 import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
@@ -25,6 +26,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class WorkspaceAccessHelper {
 
+  private final AccessVerifier accessVerifier;
   private final WorkspacePort workspacePort;
   private final WorkspaceMemberPort workspaceMemberPort;
   private final ProjectPort projectPort;
@@ -50,26 +52,11 @@ class WorkspaceAccessHelper {
   }
 
   Mono<Void> validateMemberAccess(String workspaceId, String userId) {
-    return workspaceMemberPort
-        .existsByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, userId)
-        .flatMap(exists -> {
-          if (!exists) {
-            return Mono.error(new DomainException(
-                WorkspaceErrorCode.ACCESS_DENIED));
-          }
-          return Mono.empty();
-        });
+    return accessVerifier.requireWorkspaceAccess(workspaceId, userId, WorkspaceRole.MEMBER);
   }
 
   Mono<Void> validateAdminAccess(String workspaceId, String userId) {
-    return findWorkspaceMember(userId, workspaceId)
-        .flatMap(member -> {
-          if (!member.isAdmin()) {
-            return Mono.error(new DomainException(
-                WorkspaceErrorCode.ADMIN_REQUIRED));
-          }
-          return Mono.empty();
-        });
+    return accessVerifier.requireWorkspaceAccess(workspaceId, userId, WorkspaceRole.ADMIN);
   }
 
   Mono<Workspace> findWorkspaceOrThrow(String workspaceId) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/domain/WorkspaceRole.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/domain/WorkspaceRole.java
@@ -2,8 +2,14 @@ package com.schemafy.core.project.domain;
 
 public enum WorkspaceRole {
 
-  ADMIN,
-  MEMBER;
+  ADMIN(2),
+  MEMBER(1);
+
+  private final int level;
+
+  WorkspaceRole(int level) {
+    this.level = level;
+  }
 
   public static WorkspaceRole fromString(String value) {
     for (WorkspaceRole role : WorkspaceRole.values()) {
@@ -14,10 +20,16 @@ public enum WorkspaceRole {
     throw new IllegalArgumentException("Unknown role: " + value);
   }
 
-  public boolean isAdmin() { return this == ADMIN; }
+  public int getLevel() { return level; }
+
+  public boolean isAdmin() { return this.level >= ADMIN.level; }
+
+  public boolean isHigherOrEqualThan(WorkspaceRole other) {
+    return this.level >= other.level;
+  }
 
   public ProjectRole toProjectRole() {
-    return this == ADMIN ? ProjectRole.ADMIN : ProjectRole.VIEWER;
+    return isAdmin() ? ProjectRole.ADMIN : ProjectRole.VIEWER;
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessAnnotationValidatorTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessAnnotationValidatorTest.java
@@ -1,0 +1,186 @@
+package com.schemafy.core.project.application.access;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AccessAnnotationValidator")
+class AccessAnnotationValidatorTest {
+
+  @Test
+  @DisplayName("정상적인 access annotation은 context startup을 통과한다")
+  void validAccessAnnotations_passValidation() {
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ValidConfig.class)) {
+      assertThat(context.getBean(ValidService.class)).isNotNull();
+    }
+  }
+
+  @Test
+  @DisplayName("프로젝트와 워크스페이스 access annotation이 함께 붙으면 실패한다")
+  void dualAnnotations_failValidation() {
+    assertThatThrownBy(() -> new AnnotationConfigApplicationContext(DualAnnotationConfig.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Only one access annotation can be declared on"
+            + " DualAnnotatedService#invalid");
+  }
+
+  @Test
+  @DisplayName("Mono/Flux가 아닌 반환 타입은 실패한다")
+  void nonReactiveReturnType_failValidation() {
+    assertThatThrownBy(() -> new AnnotationConfigApplicationContext(NonReactiveReturnConfig.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Access annotations are only supported on Mono/Flux methods:"
+            + " NonReactiveService#invalid");
+  }
+
+  @Test
+  @DisplayName("프로젝트 access accessor가 없으면 실패한다")
+  void projectAccessorMismatch_failValidation() {
+    assertThatThrownBy(() -> new AnnotationConfigApplicationContext(ProjectMismatchConfig.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Access annotation requires projectId accessor targetProjectId() on"
+            + " ProjectRequest for ProjectMismatchService#invalid");
+  }
+
+  @Test
+  @DisplayName("워크스페이스 access accessor가 없으면 실패한다")
+  void workspaceAccessorMismatch_failValidation() {
+    assertThatThrownBy(() -> new AnnotationConfigApplicationContext(WorkspaceMismatchConfig.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Access annotation requires workspaceId accessor targetWorkspaceId() on"
+            + " WorkspaceRequest for WorkspaceMismatchService#invalid");
+  }
+
+  @Configuration
+  static class ValidatorBeanConfig {
+
+    @Bean
+    AccessAnnotationValidator accessAnnotationValidator(
+        org.springframework.context.ApplicationContext applicationContext) {
+      return new AccessAnnotationValidator(applicationContext);
+    }
+
+  }
+
+  @Configuration
+  @org.springframework.context.annotation.Import(ValidatorBeanConfig.class)
+  static class ValidConfig {
+
+    @Bean
+    ValidService validService() {
+      return new ValidService();
+    }
+
+  }
+
+  @Configuration
+  @org.springframework.context.annotation.Import(ValidatorBeanConfig.class)
+  static class DualAnnotationConfig {
+
+    @Bean
+    DualAnnotatedService dualAnnotatedService() {
+      return new DualAnnotatedService();
+    }
+
+  }
+
+  @Configuration
+  @org.springframework.context.annotation.Import(ValidatorBeanConfig.class)
+  static class NonReactiveReturnConfig {
+
+    @Bean
+    NonReactiveService nonReactiveService() {
+      return new NonReactiveService();
+    }
+
+  }
+
+  @Configuration
+  @org.springframework.context.annotation.Import(ValidatorBeanConfig.class)
+  static class ProjectMismatchConfig {
+
+    @Bean
+    ProjectMismatchService projectMismatchService() {
+      return new ProjectMismatchService();
+    }
+
+  }
+
+  @Configuration
+  @org.springframework.context.annotation.Import(ValidatorBeanConfig.class)
+  static class WorkspaceMismatchConfig {
+
+    @Bean
+    WorkspaceMismatchService workspaceMismatchService() {
+      return new WorkspaceMismatchService();
+    }
+
+  }
+
+  static class ValidService {
+
+    @RequireProjectAccess
+    public Mono<String> project(ProjectRequest request) {
+      return Mono.just("ok");
+    }
+
+    @RequireWorkspaceAccess
+    public Flux<String> workspace(WorkspaceRequest request) {
+      return Flux.just("ok");
+    }
+
+  }
+
+  static class DualAnnotatedService {
+
+    @RequireProjectAccess
+    @RequireWorkspaceAccess
+    public Mono<String> invalid(ProjectRequest request) {
+      return Mono.just("invalid");
+    }
+
+  }
+
+  static class NonReactiveService {
+
+    @RequireProjectAccess
+    public String invalid(ProjectRequest request) {
+      return "invalid";
+    }
+
+  }
+
+  static class ProjectMismatchService {
+
+    @RequireProjectAccess(projectId = "targetProjectId")
+    public Mono<String> invalid(ProjectRequest request) {
+      return Mono.just("invalid");
+    }
+
+  }
+
+  static class WorkspaceMismatchService {
+
+    @RequireWorkspaceAccess(workspaceId = "targetWorkspaceId")
+    public Mono<String> invalid(WorkspaceRequest request) {
+      return Mono.just("invalid");
+    }
+
+  }
+
+  record ProjectRequest(String projectId, String requesterId) {
+  }
+
+  record WorkspaceRequest(String workspaceId, String requesterId) {
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectSpringContextTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectSpringContextTest.java
@@ -1,0 +1,133 @@
+package com.schemafy.core.project.application.access;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringJUnitConfig(classes = AccessVerificationAspectSpringContextTest.TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("AccessVerificationAspect Spring context")
+class AccessVerificationAspectSpringContextTest {
+
+  @jakarta.annotation.Resource
+  private AnnotatedService annotatedService;
+
+  @jakarta.annotation.Resource
+  private AccessVerifier accessVerifier;
+
+  @Test
+  @DisplayName("프로젝트 어노테이션은 Spring 프록시 경유 호출에서도 동작한다")
+  void projectAccess_worksThroughSpringProxy() {
+    reset(accessVerifier);
+    annotatedService.reset();
+    when(accessVerifier.requireProjectAccess(
+        eq("project-id"), eq("requester-id"), eq(ProjectRole.EDITOR)))
+        .thenReturn(Mono.empty());
+
+    StepVerifier.create(
+        annotatedService.project(new ProjectCommand("project-id", "requester-id")))
+        .expectNext("project-ok")
+        .verifyComplete();
+
+    verify(accessVerifier).requireProjectAccess(
+        eq("project-id"), eq("requester-id"), eq(ProjectRole.EDITOR));
+    assertThat(annotatedService.invocationCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 어노테이션은 Spring 프록시 경유 호출에서 차단을 적용한다")
+  void workspaceAccess_blocksThroughSpringProxy() {
+    reset(accessVerifier);
+    annotatedService.reset();
+    when(accessVerifier.requireWorkspaceAccess(
+        eq("workspace-id"), eq("requester-id"), eq(WorkspaceRole.MEMBER)))
+        .thenReturn(Mono.error(new DomainException(
+            WorkspaceErrorCode.ACCESS_DENIED)));
+
+    StepVerifier.create(
+        annotatedService.workspace(new WorkspaceCommand("workspace-id", "requester-id")))
+        .expectErrorMatches(
+            DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+
+    verify(accessVerifier).requireWorkspaceAccess(
+        eq("workspace-id"), eq("requester-id"), eq(WorkspaceRole.MEMBER));
+    assertThat(annotatedService.invocationCount()).isZero();
+  }
+
+  @Configuration
+  @EnableAspectJAutoProxy(proxyTargetClass = true)
+  static class TestConfig {
+
+    @Bean
+    AccessVerifier accessVerifier() {
+      return mock(AccessVerifier.class);
+    }
+
+    @Bean
+    AccessVerificationAspect accessVerificationAspect(AccessVerifier accessVerifier) {
+      return new AccessVerificationAspect(accessVerifier);
+    }
+
+    @Bean
+    AnnotatedService annotatedService() {
+      return new AnnotatedService();
+    }
+
+  }
+
+  static class AnnotatedService {
+
+    private final AtomicInteger invocations = new AtomicInteger();
+
+    @RequireProjectAccess(role = ProjectRole.EDITOR)
+    public Mono<String> project(ProjectCommand command) {
+      invocations.incrementAndGet();
+      return Mono.just("project-ok");
+    }
+
+    @RequireWorkspaceAccess
+    public Mono<String> workspace(WorkspaceCommand command) {
+      invocations.incrementAndGet();
+      return Mono.just("workspace-ok");
+    }
+
+    public void reset() {
+      invocations.set(0);
+    }
+
+    public int invocationCount() {
+      return invocations.get();
+    }
+
+  }
+
+  record ProjectCommand(String projectId, String requesterId) {
+  }
+
+  record WorkspaceCommand(String workspaceId, String requesterId) {
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerificationAspectTest.java
@@ -1,0 +1,158 @@
+package com.schemafy.core.project.application.access;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AccessVerificationAspect")
+class AccessVerificationAspectTest {
+
+  private TestService createProxy(AccessVerifier accessVerifier, TestService target) {
+    AspectJProxyFactory factory = new AspectJProxyFactory(target);
+    factory.setProxyTargetClass(true);
+    factory.addAspect(new AccessVerificationAspect(accessVerifier));
+    return factory.getProxy();
+  }
+
+  @Test
+  @DisplayName("프로젝트 어노테이션은 기본 accessor로 requesterId와 projectId를 추출한다")
+  void projectAccess_extractsDefaultAccessors() {
+    AccessVerifier verifier = mock(AccessVerifier.class);
+    when(verifier.requireProjectAccess(anyString(), anyString(), any(ProjectRole.class)))
+        .thenReturn(Mono.empty());
+    TestService proxy = createProxy(verifier, new TestService());
+
+    StepVerifier.create(proxy.loadProject(new ProjectCommand("project-id", "requester-id")))
+        .expectNext("project")
+        .verifyComplete();
+
+    verify(verifier)
+        .requireProjectAccess(eq("project-id"), eq("requester-id"), eq(ProjectRole.VIEWER));
+  }
+
+  @Test
+  @DisplayName("프로젝트 어노테이션은 지정한 accessor 이름을 사용할 수 있다")
+  void projectAccess_supportsCustomAccessors() {
+    AccessVerifier verifier = mock(AccessVerifier.class);
+    when(verifier.requireProjectAccess(anyString(), anyString(), any(ProjectRole.class)))
+        .thenReturn(Mono.empty());
+    TestService proxy = createProxy(verifier, new TestService());
+
+    StepVerifier.create(proxy.loadAlternateProject(
+        new AlternateProjectCommand("project-id", "requester-id")))
+        .expectNext("alternate-project")
+        .verifyComplete();
+
+    verify(verifier)
+        .requireProjectAccess(eq("project-id"), eq("requester-id"), eq(ProjectRole.VIEWER));
+  }
+
+  @Test
+  @DisplayName("워크스페이스 어노테이션은 Flux 반환도 검증 후 통과시킨다")
+  void workspaceAccess_supportsFlux() {
+    AccessVerifier verifier = mock(AccessVerifier.class);
+    when(verifier.requireWorkspaceAccess(anyString(), anyString(), any(WorkspaceRole.class)))
+        .thenReturn(Mono.empty());
+    TestService proxy = createProxy(verifier, new TestService());
+
+    StepVerifier.create(proxy.workspaceStream(new WorkspaceCommand("workspace-id", "requester-id")))
+        .expectNext("workspace-1", "workspace-2")
+        .verifyComplete();
+
+    verify(verifier)
+        .requireWorkspaceAccess(eq("workspace-id"), eq("requester-id"), eq(WorkspaceRole.MEMBER));
+  }
+
+  @Test
+  @DisplayName("검증 실패 시 대상 메서드는 실행되지 않는다")
+  void verificationFailure_preventsMethodExecution() {
+    AccessVerifier verifier = mock(AccessVerifier.class);
+    when(verifier.requireProjectAccess(eq("project-id"), eq("requester-id"), eq(ProjectRole.ADMIN)))
+        .thenReturn(Mono.error(new DomainException(ProjectErrorCode.ACCESS_DENIED)));
+    TestService target = new TestService();
+    TestService proxy = createProxy(verifier, target);
+
+    StepVerifier.create(proxy.updateProject(new ProjectCommand("project-id", "requester-id")))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+        .verify();
+
+    assertThat(target.invocations.get()).isZero();
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 시그니처는 IllegalStateException으로 실패한다")
+  void unsupportedSignature_fails() {
+    AccessVerifier verifier = mock(AccessVerifier.class);
+    TestService proxy = createProxy(verifier, new TestService());
+
+    StepVerifier.create(proxy.invalid("project-id", "requester-id"))
+        .expectError(IllegalStateException.class)
+        .verify();
+  }
+
+  static class TestService {
+
+    private final AtomicInteger invocations = new AtomicInteger();
+
+    @RequireProjectAccess
+    public Mono<String> loadProject(ProjectCommand command) {
+      invocations.incrementAndGet();
+      return Mono.just("project");
+    }
+
+    @RequireProjectAccess(role = ProjectRole.ADMIN)
+    public Mono<String> updateProject(ProjectCommand command) {
+      invocations.incrementAndGet();
+      return Mono.just("updated");
+    }
+
+    @RequireProjectAccess(projectId = "targetProjectId", requesterId = "actorId")
+    public Mono<String> loadAlternateProject(AlternateProjectCommand command) {
+      invocations.incrementAndGet();
+      return Mono.just("alternate-project");
+    }
+
+    @RequireWorkspaceAccess
+    public Flux<String> workspaceStream(WorkspaceCommand command) {
+      invocations.incrementAndGet();
+      return Flux.just("workspace-1", "workspace-2");
+    }
+
+    @RequireProjectAccess
+    public Mono<String> invalid(String projectId, String requesterId) {
+      invocations.incrementAndGet();
+      return Mono.just("invalid");
+    }
+
+  }
+
+  record ProjectCommand(String projectId, String requesterId) {
+  }
+
+  record AlternateProjectCommand(String targetProjectId, String actorId) {
+  }
+
+  record WorkspaceCommand(String workspaceId, String requesterId) {
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerifierTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/access/AccessVerifierTest.java
@@ -1,0 +1,214 @@
+package com.schemafy.core.project.application.access;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AccessVerifier")
+class AccessVerifierTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String PROJECT_ID = "project-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  private WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  private ProjectMemberPort projectMemberPort;
+
+  @InjectMocks
+  private AccessVerifier accessVerifier;
+
+  @Nested
+  @DisplayName("requireProjectAccess")
+  class RequireProjectAccessTest {
+
+    @Test
+    @DisplayName("VIEWER 권한은 프로젝트 멤버면 허용한다")
+    void viewerAccess_allowsMember() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+              ProjectRole.VIEWER)));
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.VIEWER))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("VIEWER 권한은 비회원이면 ACCESS_DENIED를 반환한다")
+    void viewerAccess_deniesNonMember() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.VIEWER))
+          .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("EDITOR 권한은 VIEWER를 거부한다")
+    void editorAccess_deniesViewer() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+              ProjectRole.VIEWER)));
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.EDITOR))
+          .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("EDITOR 권한은 EDITOR를 허용한다")
+    void editorAccess_allowsEditor() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+              ProjectRole.EDITOR)));
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.EDITOR))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 비회원이면 ACCESS_DENIED를 반환한다")
+    void adminAccess_deniesNonMember() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.ADMIN))
+          .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 비관리자 멤버면 ADMIN_REQUIRED를 반환한다")
+    void adminAccess_requiresAdmin() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+              ProjectRole.EDITOR)));
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.ADMIN))
+          .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 관리자면 허용한다")
+    void adminAccess_allowsAdmin() {
+      when(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(PROJECT_ID, USER_ID))
+          .thenReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+              ProjectRole.ADMIN)));
+
+      StepVerifier.create(
+          accessVerifier.requireProjectAccess(PROJECT_ID, USER_ID, ProjectRole.ADMIN))
+          .verifyComplete();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("requireWorkspaceAccess")
+  class RequireWorkspaceAccessTest {
+
+    @Test
+    @DisplayName("MEMBER 권한은 워크스페이스 멤버면 허용한다")
+    void memberAccess_allowsMember() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.just(WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+              WorkspaceRole.MEMBER)));
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("MEMBER 권한은 상위 권한 멤버도 허용한다")
+    void memberAccess_allowsAdmin() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.just(WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+              WorkspaceRole.ADMIN)));
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("MEMBER 권한은 비회원이면 ACCESS_DENIED를 반환한다")
+    void memberAccess_deniesNonMember() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER))
+          .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 비회원이면 ACCESS_DENIED를 반환한다")
+    void adminAccess_deniesNonMember() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.ADMIN))
+          .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 비관리자면 ADMIN_REQUIRED를 반환한다")
+    void adminAccess_requiresAdmin() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.just(WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+              WorkspaceRole.MEMBER)));
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.ADMIN))
+          .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
+          .verify();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 관리자면 허용한다")
+    void adminAccess_allowsAdmin() {
+      when(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+          .thenReturn(Mono.just(WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+              WorkspaceRole.ADMIN)));
+
+      StepVerifier.create(
+          accessVerifier.requireWorkspaceAccess(WORKSPACE_ID, USER_ID, WorkspaceRole.ADMIN))
+          .verifyComplete();
+    }
+
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/domain/EnumDbContractTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/domain/EnumDbContractTest.java
@@ -24,6 +24,15 @@ class EnumDbContractTest {
   }
 
   @Test
+  @DisplayName("WorkspaceRole 비교 규칙은 level 기반으로 고정된다")
+  void workspaceRoleComparison_isLevelBased() {
+    assertThat(WorkspaceRole.ADMIN.getLevel()).isEqualTo(2);
+    assertThat(WorkspaceRole.MEMBER.getLevel()).isEqualTo(1);
+    assertThat(WorkspaceRole.ADMIN.isHigherOrEqualThan(WorkspaceRole.MEMBER)).isTrue();
+    assertThat(WorkspaceRole.MEMBER.isHigherOrEqualThan(WorkspaceRole.ADMIN)).isFalse();
+  }
+
+  @Test
   @DisplayName("InvitationStatus name은 DB 저장 값으로 고정된다")
   void invitationStatusNames_areFixed() {
     assertThat(InvitationStatus.PENDING.name()).isEqualTo("PENDING");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -12,18 +12,25 @@ import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
 import com.schemafy.core.project.application.port.in.GetMySharedProjectsQuery;
 import com.schemafy.core.project.application.port.in.GetMySharedProjectsUseCase;
+import com.schemafy.core.project.application.port.in.GetProjectMembersQuery;
+import com.schemafy.core.project.application.port.in.GetProjectMembersUseCase;
+import com.schemafy.core.project.application.port.in.GetProjectQuery;
+import com.schemafy.core.project.application.port.in.GetProjectUseCase;
 import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
 import com.schemafy.core.project.application.port.in.LeaveProjectUseCase;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
 import com.schemafy.core.project.application.port.in.RemoveProjectMemberCommand;
 import com.schemafy.core.project.application.port.in.RemoveProjectMemberUseCase;
+import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleUseCase;
+import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.Workspace;
 import com.schemafy.core.project.domain.WorkspaceRole;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 import com.schemafy.core.user.domain.User;
 
 import reactor.test.StepVerifier;
@@ -41,6 +48,15 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
   @Autowired
   private DeleteProjectUseCase deleteProjectUseCase;
+
+  @Autowired
+  private GetProjectUseCase getProjectUseCase;
+
+  @Autowired
+  private UpdateProjectUseCase updateProjectUseCase;
+
+  @Autowired
+  private GetProjectMembersUseCase getProjectMembersUseCase;
 
   @Autowired
   private RemoveProjectMemberUseCase removeProjectMemberUseCase;
@@ -84,6 +100,89 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     assertThat(creatorMember.getRoleAsEnum()).isEqualTo(ProjectRole.ADMIN);
     assertThat(memberProjectMember.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
     assertThat(deletedProjectMember).isNull();
+  }
+
+  @Test
+  @DisplayName("프로젝트 생성은 워크스페이스 관리자만 허용한다")
+  void createProject_requiresWorkspaceAdmin() {
+    User member = signUpUser("member-create-denied@test.com", "Member");
+    Workspace workspace = saveWorkspace("Create Denied WS", "Description");
+    saveWorkspaceMember(workspace, member, WorkspaceRole.MEMBER);
+
+    StepVerifier.create(createProjectUseCase.createProject(new CreateProjectCommand(
+        workspace.getId(),
+        "Denied Project",
+        "Description",
+        member.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("프로젝트 조회는 프로젝트 멤버에게 허용된다")
+  void getProject_allowsMember() {
+    User member = signUpUser("member-get@test.com", "Member");
+    Workspace workspace = saveWorkspace("Get WS", "Description");
+    var project = saveProject(workspace, "Get Project");
+    saveProjectMember(project, member, ProjectRole.EDITOR);
+
+    ProjectDetail detail = getProjectUseCase.getProject(new GetProjectQuery(
+        project.getId(),
+        member.id())).block();
+
+    assertThat(detail).isNotNull();
+    assertThat(detail.project().getId()).isEqualTo(project.getId());
+    assertThat(detail.currentUserRole()).isEqualTo(ProjectRole.EDITOR.name());
+  }
+
+  @Test
+  @DisplayName("프로젝트 조회는 비회원이면 거부된다")
+  void getProject_deniesNonMember() {
+    User requester = signUpUser("non-member-get@test.com", "Requester");
+    Workspace workspace = saveWorkspace("Get Denied WS", "Description");
+    var project = saveProject(workspace, "Get Denied Project");
+
+    StepVerifier.create(getProjectUseCase.getProject(new GetProjectQuery(project.getId(),
+        requester.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("프로젝트 수정은 관리자에게 허용된다")
+  void updateProject_allowsAdmin() {
+    User admin = signUpUser("admin-update-project@test.com", "Admin");
+    Workspace workspace = saveWorkspace("Update Project WS", "Description");
+    var project = saveProject(workspace, "Old Name");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+
+    ProjectDetail updated = updateProjectUseCase.updateProject(new UpdateProjectCommand(
+        project.getId(),
+        "New Name",
+        "New Description",
+        admin.id()))
+        .block();
+
+    assertThat(updated).isNotNull();
+    assertThat(updated.project().getName()).isEqualTo("New Name");
+    assertThat(updated.currentUserRole()).isEqualTo(ProjectRole.ADMIN.name());
+  }
+
+  @Test
+  @DisplayName("프로젝트 수정은 비관리자면 거부된다")
+  void updateProject_deniesNonAdmin() {
+    User editor = signUpUser("editor-update-project@test.com", "Editor");
+    Workspace workspace = saveWorkspace("Update Denied WS", "Description");
+    var project = saveProject(workspace, "Update Denied Project");
+    saveProjectMember(project, editor, ProjectRole.EDITOR);
+
+    StepVerifier.create(updateProjectUseCase.updateProject(new UpdateProjectCommand(
+        project.getId(),
+        "Forbidden",
+        "Forbidden",
+        editor.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
+        .verify();
   }
 
   @Test
@@ -185,6 +284,57 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
     assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
     assertThat(findSchemasByProjectId(project.getId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("프로젝트 삭제는 비관리자면 거부된다")
+  void deleteProject_deniesNonAdmin() {
+    User editor = signUpUser("editor-delete-project@test.com", "Editor");
+    Workspace workspace = saveWorkspace("Delete Denied WS", "Description");
+    var project = saveProject(workspace, "Delete Denied Project");
+    saveProjectMember(project, editor, ProjectRole.EDITOR);
+
+    StepVerifier.create(deleteProjectUseCase.deleteProject(
+        new DeleteProjectCommand(project.getId(), editor.id())))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 조회는 프로젝트 멤버에게 허용된다")
+  void getProjectMembers_allowsMember() {
+    User requester = signUpUser("member-get-members@test.com", "Requester");
+    User another = signUpUser("another-get-members@test.com", "Another");
+    Workspace workspace = saveWorkspace("Members WS", "Description");
+    var project = saveProject(workspace, "Members Project");
+    saveProjectMember(project, requester, ProjectRole.VIEWER);
+    saveProjectMember(project, another, ProjectRole.EDITOR);
+
+    var result = getProjectMembersUseCase.getProjectMembers(new GetProjectMembersQuery(
+        project.getId(),
+        requester.id(),
+        0,
+        10)).block();
+
+    assertThat(result).isNotNull();
+    assertThat(result.content()).hasSize(2);
+    assertThat(result.totalElements()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 조회는 비회원이면 거부된다")
+  void getProjectMembers_deniesNonMember() {
+    User requester = signUpUser("non-member-get-members@test.com", "Requester");
+    Workspace workspace = saveWorkspace("Members Denied WS", "Description");
+    var project = saveProject(workspace, "Members Denied Project");
+
+    StepVerifier.create(getProjectMembersUseCase.getProjectMembers(new GetProjectMembersQuery(
+        project.getId(),
+        requester.id(),
+        0,
+        10)))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+        .verify();
   }
 
   @Test


### PR DESCRIPTION
## 개요
프로젝트/워크스페이스 접근 검증을 어노테이션 기반으로 처리할 수 있도록 변경했습니다.

- `@RequireProjectAccess`, `@RequireWorkspaceAccess` 추가
- `AccessVerifier`로 프로젝트/워크스페이스 권한 검증 로직 통합
- AOP를 통해 annotated use case 실행 전에 접근 권한 검증
- 해당 어노테이션 오사용을 애플리케이션 시작 시점에 잡는 validator 추가
- 일부 프로젝트 use case만 annotation 방식으로 전환 나머지 전환 작업은 다른 이슈(`#365` ,`#366`)로 작업 예정
- `WorkspaceRole`을 `ProjectRole`처럼 level 기반 비교 모델로 정리

## 이슈


- close #106