### PR TITLE
feat(#301): support ERD undo redo for simple property changes

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/MutationResult.java
@@ -3,12 +3,14 @@ package com.schemafy.core.common;
 import java.util.Collections;
 import java.util.Set;
 
+import com.schemafy.core.erd.operation.application.inverse.InversePayload;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public record MutationResult<T>(
     T result,
     Set<String> affectedTableIds,
-    CommittedErdOperation operation) {
+    CommittedErdOperation operation,
+    InversePayload inversePayload) {
 
   public MutationResult {
     affectedTableIds = affectedTableIds == null
@@ -17,22 +19,26 @@ public record MutationResult<T>(
   }
 
   public static <T> MutationResult<T> empty(T result) {
-    return new MutationResult<>(result, Collections.emptySet(), null);
+    return new MutationResult<>(result, Collections.emptySet(), null, null);
   }
 
   public static <T> MutationResult<T> of(T result, String tableId) {
     if (tableId == null) {
-      return new MutationResult<>(result, Collections.emptySet(), null);
+      return new MutationResult<>(result, Collections.emptySet(), null, null);
     }
-    return new MutationResult<>(result, Set.of(tableId), null);
+    return new MutationResult<>(result, Set.of(tableId), null, null);
   }
 
   public static <T> MutationResult<T> of(T result, Set<String> tableIds) {
-    return new MutationResult<>(result, tableIds, null);
+    return new MutationResult<>(result, tableIds, null, null);
   }
 
   public MutationResult<T> withOperation(CommittedErdOperation operation) {
-    return new MutationResult<>(result, affectedTableIds, operation);
+    return new MutationResult<>(result, affectedTableIds, operation, inversePayload);
+  }
+
+  public MutationResult<T> withInverse(InversePayload inversePayload) {
+    return new MutationResult<>(result, affectedTableIds, operation, inversePayload);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/json/JsonCodec.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/json/JsonCodec.java
@@ -90,6 +90,7 @@ public final class JsonCodec {
       throw new IllegalArgumentException("Failed to serialize JSON", e);
     }
   }
+
   public String serialize(Object value, Class<?> type) {
     requireNonNull(value, "value");
     requireNonNull(type, "type");

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/json/JsonCodec.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/json/JsonCodec.java
@@ -90,6 +90,15 @@ public final class JsonCodec {
       throw new IllegalArgumentException("Failed to serialize JSON", e);
     }
   }
+  public String serialize(Object value, Class<?> type) {
+    requireNonNull(value, "value");
+    requireNonNull(type, "type");
+    try {
+      return objectMapper.writerFor(type).writeValueAsString(value);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to serialize JSON", e);
+    }
+  }
 
   public byte[] serializeBytes(Object value) {
     requireNonNull(value, "value");

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnNameService.java
@@ -16,6 +16,7 @@ import com.schemafy.core.erd.column.application.port.out.GetColumnsByTableIdPort
 import com.schemafy.core.erd.column.domain.Column;
 import com.schemafy.core.erd.column.domain.exception.ColumnErrorCode;
 import com.schemafy.core.erd.column.domain.validator.ColumnValidator;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnNameInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
@@ -53,7 +54,8 @@ public class ChangeColumnNameService implements ChangeColumnNameUseCase {
             .switchIfEmpty(Mono.error(new DomainException(ColumnErrorCode.NOT_FOUND, "Column not found")))
             .flatMap(column -> fetchTableSchemaAndColumns(column)
                 .flatMap(tuple -> applyChange(column, tuple, command.newName()))
-                .thenReturn(MutationResult.<Void>of(null, column.tableId()))))
+                .thenReturn(MutationResult.<Void>of(null, column.tableId())
+                    .withInverse(new ChangeColumnNameInverse(column.id(), column.name())))))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnTypeService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnTypeService.java
@@ -1,9 +1,9 @@
 package com.schemafy.core.erd.column.application.service;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -24,6 +24,8 @@ import com.schemafy.core.erd.column.domain.validator.ColumnValidator;
 import com.schemafy.core.erd.constraint.application.port.out.GetConstraintByIdPort;
 import com.schemafy.core.erd.constraint.application.port.out.GetConstraintColumnsByColumnIdPort;
 import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnTypeInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnTypeInverse.FkColumnTypeRevert;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipColumnsByColumnIdPort;
@@ -62,24 +64,33 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
         command.precision(),
         command.scale(),
         command.values());
-    Set<String> affectedTableIds = ConcurrentHashMap.newKeySet();
+    Set<String> affectedTableIds = new HashSet<>();
+    Set<String> capturedFkColumnIds = new HashSet<>();
+    List<FkColumnTypeRevert> fkRevertList = new ArrayList<>();
 
     return erdMutationCoordinator.coordinate(ErdOperationType.CHANGE_COLUMN_TYPE, command,
-        () -> rejectIfForeignKeyColumn(command.columnId())
-            .then(getColumnByIdPort.findColumnById(command.columnId()))
-            .switchIfEmpty(Mono.error(new DomainException(ColumnErrorCode.NOT_FOUND, "Column not found")))
-            .flatMap(column -> {
-              affectedTableIds.add(column.tableId());
-              return getColumnsByTableIdPort.findColumnsByTableId(column.tableId())
-                  .defaultIfEmpty(List.of())
-                  .flatMap(columns -> applyChange(
-                      column,
-                      columns,
-                      command.dataType(),
-                      typeArguments,
-                      affectedTableIds));
-            })
-            .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds))))
+            () -> rejectIfForeignKeyColumn(command.columnId())
+                .then(getColumnByIdPort.findColumnById(command.columnId()))
+                .switchIfEmpty(Mono.error(new DomainException(ColumnErrorCode.NOT_FOUND, "Column not found")))
+                .flatMap(column -> {
+                  affectedTableIds.add(column.tableId());
+                  return getColumnsByTableIdPort.findColumnsByTableId(column.tableId())
+                      .defaultIfEmpty(List.of())
+                      .flatMap(columns -> applyChange(
+                          column,
+                          columns,
+                          command.dataType(),
+                          typeArguments,
+                          affectedTableIds,
+                          fkRevertList,
+                          capturedFkColumnIds)
+                          .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)
+                              .withInverse(new ChangeColumnTypeInverse(
+                                  column.id(),
+                                  column.dataType(),
+                                  column.typeArguments(),
+                                  fkRevertList)))));
+                }))
         .as(transactionalOperator::transactional);
   }
 
@@ -101,7 +112,9 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
       List<Column> columns,
       String dataType,
       ColumnTypeArguments typeArguments,
-      Set<String> affectedTableIds) {
+      Set<String> affectedTableIds,
+      List<FkColumnTypeRevert> fkRevertList,
+      Set<String> capturedFkColumnIds) {
     String normalizedDataType = ColumnValidator.normalizeDataType(dataType);
     ColumnValidator.validateDataType(normalizedDataType);
     ColumnValidator.validateTypeArguments(normalizedDataType, typeArguments);
@@ -121,7 +134,9 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
             normalizedDataType,
             typeArguments,
             new HashSet<>(),
-            affectedTableIds));
+            affectedTableIds,
+            fkRevertList,
+            capturedFkColumnIds));
   }
 
   private Mono<Void> cascadeTypeToFkColumns(
@@ -129,14 +144,16 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
       String dataType,
       ColumnTypeArguments typeArguments,
       Set<String> visited,
-      Set<String> affectedTableIds) {
+      Set<String> affectedTableIds,
+      List<FkColumnTypeRevert> fkRevertList,
+      Set<String> capturedFkColumnIds) {
     if (!visited.add(pkColumn.id())) {
       return Mono.empty();
     }
     return getConstraintColumnsByColumnIdPort.findConstraintColumnsByColumnId(pkColumn.id())
         .defaultIfEmpty(List.of())
         .flatMap(constraintColumns -> Flux.fromIterable(constraintColumns)
-            .flatMap(cc -> getConstraintByIdPort.findConstraintById(cc.constraintId()))
+            .concatMap(cc -> getConstraintByIdPort.findConstraintById(cc.constraintId()))
             .filter(constraint -> constraint.kind() == ConstraintKind.PRIMARY_KEY)
             .next()
             .flatMap(pk -> propagateTypeToFkColumns(
@@ -144,7 +161,9 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
                 dataType,
                 typeArguments,
                 visited,
-                affectedTableIds)));
+                affectedTableIds,
+                fkRevertList,
+                capturedFkColumnIds)));
   }
 
   private Mono<Void> propagateTypeToFkColumns(
@@ -152,39 +171,54 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
       String dataType,
       ColumnTypeArguments typeArguments,
       Set<String> visited,
-      Set<String> affectedTableIds) {
+      Set<String> affectedTableIds,
+      List<FkColumnTypeRevert> fkRevertList,
+      Set<String> capturedFkColumnIds) {
     return getRelationshipsByPkTableIdPort.findRelationshipsByPkTableId(pkColumn.tableId())
         .defaultIfEmpty(List.of())
         .flatMapMany(Flux::fromIterable)
-        .flatMap(relationship -> {
+        .concatMap(relationship -> {
           affectedTableIds.add(relationship.fkTableId());
           return getRelationshipColumnsByRelationshipIdPort
               .findRelationshipColumnsByRelationshipId(relationship.id())
               .defaultIfEmpty(List.of())
               .flatMapMany(Flux::fromIterable)
               .filter(rc -> rc.pkColumnId().equals(pkColumn.id()))
-              .flatMap(rc -> {
-                Mono<Void> changeType = changeColumnTypePort.changeColumnType(
-                    rc.fkColumnId(), dataType, typeArguments);
-                Mono<Void> clearCharsetCollation = ColumnValidator.isTextType(dataType)
-                    ? Mono.empty()
-                    : changeColumnMetaPort.changeColumnMeta(
-                        rc.fkColumnId(),
-                        null,
-                        "",
-                        "",
-                        null);
+              .concatMap(rc -> getColumnByIdPort.findColumnById(rc.fkColumnId())
+                  .switchIfEmpty(Mono.error(new DomainException(
+                      ColumnErrorCode.NOT_FOUND,
+                      "Column not found: " + rc.fkColumnId())))
+                  .flatMap(fkCol -> {
+                    if (capturedFkColumnIds.add(fkCol.id())) {
+                      fkRevertList.add(new FkColumnTypeRevert(
+                          fkCol.id(),
+                          fkCol.dataType(),
+                          fkCol.typeArguments(),
+                          fkCol.charset(),
+                          fkCol.collation()));
+                    }
+                    Mono<Void> changeType = changeColumnTypePort.changeColumnType(
+                        rc.fkColumnId(), dataType, typeArguments);
+                    Mono<Void> clearCharsetCollation = ColumnValidator.isTextType(dataType)
+                        ? Mono.empty()
+                        : changeColumnMetaPort.changeColumnMeta(
+                            rc.fkColumnId(),
+                            null,
+                            "",
+                            "",
+                            null);
 
-                return changeType
-                    .then(clearCharsetCollation)
-                    .then(getColumnByIdPort.findColumnById(rc.fkColumnId())
-                        .flatMap(fkCol -> cascadeTypeToFkColumns(
+                    return changeType
+                        .then(clearCharsetCollation)
+                        .then(cascadeTypeToFkColumns(
                             fkCol,
                             dataType,
                             typeArguments,
                             visited,
-                            affectedTableIds)));
-              });
+                            affectedTableIds,
+                            fkRevertList,
+                            capturedFkColumnIds));
+                  }));
         })
         .then();
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnTypeService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/column/application/service/ChangeColumnTypeService.java
@@ -69,28 +69,28 @@ public class ChangeColumnTypeService implements ChangeColumnTypeUseCase {
     List<FkColumnTypeRevert> fkRevertList = new ArrayList<>();
 
     return erdMutationCoordinator.coordinate(ErdOperationType.CHANGE_COLUMN_TYPE, command,
-            () -> rejectIfForeignKeyColumn(command.columnId())
-                .then(getColumnByIdPort.findColumnById(command.columnId()))
-                .switchIfEmpty(Mono.error(new DomainException(ColumnErrorCode.NOT_FOUND, "Column not found")))
-                .flatMap(column -> {
-                  affectedTableIds.add(column.tableId());
-                  return getColumnsByTableIdPort.findColumnsByTableId(column.tableId())
-                      .defaultIfEmpty(List.of())
-                      .flatMap(columns -> applyChange(
-                          column,
-                          columns,
-                          command.dataType(),
-                          typeArguments,
-                          affectedTableIds,
-                          fkRevertList,
-                          capturedFkColumnIds)
-                          .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)
-                              .withInverse(new ChangeColumnTypeInverse(
-                                  column.id(),
-                                  column.dataType(),
-                                  column.typeArguments(),
-                                  fkRevertList)))));
-                }))
+        () -> rejectIfForeignKeyColumn(command.columnId())
+            .then(getColumnByIdPort.findColumnById(command.columnId()))
+            .switchIfEmpty(Mono.error(new DomainException(ColumnErrorCode.NOT_FOUND, "Column not found")))
+            .flatMap(column -> {
+              affectedTableIds.add(column.tableId());
+              return getColumnsByTableIdPort.findColumnsByTableId(column.tableId())
+                  .defaultIfEmpty(List.of())
+                  .flatMap(columns -> applyChange(
+                      column,
+                      columns,
+                      command.dataType(),
+                      typeArguments,
+                      affectedTableIds,
+                      fkRevertList,
+                      capturedFkColumnIds)
+                      .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)
+                          .withInverse(new ChangeColumnTypeInverse(
+                              column.id(),
+                              column.dataType(),
+                              column.typeArguments(),
+                              fkRevertList)))));
+            }))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/ChangeConstraintNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/ChangeConstraintNameService.java
@@ -47,9 +47,9 @@ public class ChangeConstraintNameService implements ChangeConstraintNameUseCase 
               .flatMap(constraint -> getTableByIdPort.findTableById(constraint.tableId())
                   .switchIfEmpty(Mono.error(new DomainException(TableErrorCode.NOT_FOUND, "Table not found")))
                   .flatMap(table -> constraintExistsPort.existsBySchemaIdAndNameExcludingId(
-                          table.schemaId(),
-                          normalizedName,
-                          constraint.id())
+                      table.schemaId(),
+                      normalizedName,
+                      constraint.id())
                       .flatMap(exists -> {
                         if (exists) {
                           return Mono.error(new DomainException(ConstraintErrorCode.NAME_DUPLICATE,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/ChangeConstraintNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/ChangeConstraintNameService.java
@@ -12,6 +12,7 @@ import com.schemafy.core.erd.constraint.application.port.out.ConstraintExistsPor
 import com.schemafy.core.erd.constraint.application.port.out.GetConstraintByIdPort;
 import com.schemafy.core.erd.constraint.domain.exception.ConstraintErrorCode;
 import com.schemafy.core.erd.constraint.domain.validator.ConstraintValidator;
+import com.schemafy.core.erd.operation.application.inverse.ChangeConstraintNameInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;
@@ -46,9 +47,9 @@ public class ChangeConstraintNameService implements ChangeConstraintNameUseCase 
               .flatMap(constraint -> getTableByIdPort.findTableById(constraint.tableId())
                   .switchIfEmpty(Mono.error(new DomainException(TableErrorCode.NOT_FOUND, "Table not found")))
                   .flatMap(table -> constraintExistsPort.existsBySchemaIdAndNameExcludingId(
-                      table.schemaId(),
-                      normalizedName,
-                      constraint.id())
+                          table.schemaId(),
+                          normalizedName,
+                          constraint.id())
                       .flatMap(exists -> {
                         if (exists) {
                           return Mono.error(new DomainException(ConstraintErrorCode.NAME_DUPLICATE,
@@ -56,7 +57,10 @@ public class ChangeConstraintNameService implements ChangeConstraintNameUseCase 
                         }
                         return changeConstraintNamePort
                             .changeConstraintName(constraint.id(), normalizedName)
-                            .thenReturn(MutationResult.<Void>of(null, constraint.tableId()));
+                            .thenReturn(MutationResult.<Void>of(null, constraint.tableId())
+                                .withInverse(new ChangeConstraintNameInverse(
+                                    constraint.id(),
+                                    constraint.name())));
                       })));
         }));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/index/application/service/ChangeIndexNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/index/application/service/ChangeIndexNameService.java
@@ -12,6 +12,7 @@ import com.schemafy.core.erd.index.application.port.out.GetIndexByIdPort;
 import com.schemafy.core.erd.index.application.port.out.IndexExistsPort;
 import com.schemafy.core.erd.index.domain.exception.IndexErrorCode;
 import com.schemafy.core.erd.index.domain.validator.IndexValidator;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexNameInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 
@@ -51,7 +52,8 @@ public class ChangeIndexNameService implements ChangeIndexNameUseCase {
                 }
                 return changeIndexNamePort
                     .changeIndexName(index.id(), normalizedName)
-                    .thenReturn(MutationResult.<Void>of(null, index.tableId()));
+                    .thenReturn(MutationResult.<Void>of(null, index.tableId())
+                        .withInverse(new ChangeIndexNameInverse(index.id(), index.name())));
               }));
     }));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/index/application/service/ChangeIndexTypeService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/index/application/service/ChangeIndexTypeService.java
@@ -18,6 +18,7 @@ import com.schemafy.core.erd.index.domain.Index;
 import com.schemafy.core.erd.index.domain.IndexColumn;
 import com.schemafy.core.erd.index.domain.exception.IndexErrorCode;
 import com.schemafy.core.erd.index.domain.validator.IndexValidator;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexTypeInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 
@@ -62,7 +63,8 @@ public class ChangeIndexTypeService implements ChangeIndexTypeUseCase {
                             index.id());
                         return changeIndexTypePort
                             .changeIndexType(index.id(), command.type())
-                            .thenReturn(MutationResult.<Void>of(null, index.tableId()));
+                            .thenReturn(MutationResult.<Void>of(null, index.tableId())
+                                .withInverse(new ChangeIndexTypeInverse(index.id(), index.type())));
                       }))));
     }));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationContexts.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationContexts.java
@@ -13,8 +13,7 @@ public final class ErdOperationContexts {
   private static final Object METADATA_CONTEXT_KEY = new Object();
   private static final Object SUPPRESS_NESTED_MUTATION_CONTEXT_KEY = new Object();
 
-  private ErdOperationContexts() {
-  }
+  private ErdOperationContexts() {}
 
   public static ErdOperationMetadata metadata(ContextView contextView) {
     Object typedValue = contextView.getOrDefault(METADATA_CONTEXT_KEY, null);

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationContexts.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationContexts.java
@@ -3,6 +3,8 @@ package com.schemafy.core.erd.operation;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+
 import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 
@@ -12,7 +14,6 @@ public final class ErdOperationContexts {
   private static final Object SUPPRESS_NESTED_MUTATION_CONTEXT_KEY = new Object();
 
   private ErdOperationContexts() {
-    // utility class
   }
 
   public static ErdOperationMetadata metadata(ContextView contextView) {
@@ -37,6 +38,12 @@ public final class ErdOperationContexts {
 
   public static Function<Context, Context> withActorUserId(String actorUserId) {
     return updateMetadata(metadata -> metadata.withActorUserId(actorUserId));
+  }
+
+  public static Function<Context, Context> withDerivation(
+      ErdOperationDerivationKind derivationKind,
+      String derivedFromOpId) {
+    return updateMetadata(metadata -> metadata.withDerivation(derivationKind, derivedFromOpId));
   }
 
   public static Function<Context, Context> suppressNestedMutation() {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationMetadata.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/ErdOperationMetadata.java
@@ -1,33 +1,59 @@
 package com.schemafy.core.erd.operation;
 
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+
 public record ErdOperationMetadata(
     String sessionId,
     String clientOperationId,
     Long baseSchemaRevision,
-    String actorUserId) {
+    String actorUserId,
+    ErdOperationDerivationKind derivationKind,
+    String derivedFromOpId) {
 
   public static ErdOperationMetadata empty() {
-    return new ErdOperationMetadata(null, null, null, null);
+    return new ErdOperationMetadata(null, null, null, null, null, null);
+  }
+
+  public ErdOperationMetadata(
+      String sessionId,
+      String clientOperationId,
+      Long baseSchemaRevision,
+      String actorUserId) {
+    this(sessionId, clientOperationId, baseSchemaRevision, actorUserId, null, null);
   }
 
   public ErdOperationMetadata withSessionId(String sessionId) {
-    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId);
+    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId,
+        derivationKind, derivedFromOpId);
   }
 
   public ErdOperationMetadata withClientOperationId(String clientOperationId) {
-    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId);
+    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId,
+        derivationKind, derivedFromOpId);
   }
 
   public ErdOperationMetadata withBaseSchemaRevision(Long baseSchemaRevision) {
-    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId);
+    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId,
+        derivationKind, derivedFromOpId);
   }
 
   public ErdOperationMetadata withActorUserId(String actorUserId) {
-    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId);
+    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId,
+        derivationKind, derivedFromOpId);
+  }
+
+  public ErdOperationMetadata withDerivation(
+      ErdOperationDerivationKind derivationKind, String derivedFromOpId) {
+    return new ErdOperationMetadata(sessionId, clientOperationId, baseSchemaRevision, actorUserId,
+        derivationKind, derivedFromOpId);
   }
 
   public String actorUserIdOr(String defaultValue) {
     return actorUserId != null ? actorUserId : defaultValue;
+  }
+
+  public ErdOperationDerivationKind derivationKindOrDefault() {
+    return derivationKind != null ? derivationKind : ErdOperationDerivationKind.ORIGINAL;
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationPersistenceAdapter.java
@@ -73,6 +73,24 @@ class ErdOperationPersistenceAdapter implements
   }
 
   @Override
+  public Mono<SchemaCollaborationState> incrementIfCurrentRevision(String schemaId, long expectedRevision) {
+    return schemaCollaborationStateRepository.incrementRevisionIfCurrentRevision(schemaId, expectedRevision)
+        .flatMap(rowsUpdated -> {
+          if (rowsUpdated == 0) {
+            return Mono.empty();
+          }
+          if (rowsUpdated != 1) {
+            return Mono.error(new IllegalStateException(
+                "Schema collaboration state guarded increment failed: schemaId=" + schemaId));
+          }
+          return schemaCollaborationStateRepository.findById(schemaId)
+              .switchIfEmpty(Mono.error(new IllegalStateException(
+                  "Schema collaboration state missing after guarded increment: schemaId=" + schemaId)));
+        })
+        .map(schemaCollaborationStateMapper::toDomain);
+  }
+
+  @Override
   public Mono<ErdOperationLog> append(ErdOperationLog erdOperationLog) {
     return erdOperationLogRepository.save(erdOperationLogMapper.toEntity(erdOperationLog))
         .map(erdOperationLogMapper::toDomain);

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateRepository.java
@@ -18,4 +18,14 @@ interface SchemaCollaborationStateRepository
       """)
   Mono<Long> incrementRevision(String schemaId);
 
+  @Modifying
+  @Query("""
+      UPDATE schema_collaboration_state
+      SET current_revision = current_revision + 1,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE schema_id = :schemaId
+        AND current_revision = :expectedRevision
+      """)
+  Mono<Long> incrementRevisionIfCurrentRevision(String schemaId, long expectedRevision);
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeColumnNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeColumnNameInverse.java
@@ -1,0 +1,7 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+public record ChangeColumnNameInverse(
+    String columnId,
+    String oldName) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeColumnTypeInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeColumnTypeInverse.java
@@ -1,0 +1,28 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+import java.util.List;
+
+import com.schemafy.core.erd.column.domain.ColumnTypeArguments;
+
+public record ChangeColumnTypeInverse(
+    String columnId,
+    String oldDataType,
+    ColumnTypeArguments oldTypeArguments,
+    List<FkColumnTypeRevert> fkRevertList) implements InversePayload {
+
+  public ChangeColumnTypeInverse {
+    fkRevertList = fkRevertList == null
+        ? List.of()
+        : List.copyOf(fkRevertList);
+  }
+
+  public record FkColumnTypeRevert(
+      String columnId,
+      String oldDataType,
+      ColumnTypeArguments oldTypeArguments,
+      String oldCharset,
+      String oldCollation) {
+
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeConstraintNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeConstraintNameInverse.java
@@ -1,0 +1,7 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+public record ChangeConstraintNameInverse(
+    String constraintId,
+    String oldName) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeIndexNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeIndexNameInverse.java
@@ -1,0 +1,7 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+public record ChangeIndexNameInverse(
+    String indexId,
+    String oldName) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeIndexTypeInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeIndexTypeInverse.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+import com.schemafy.core.erd.index.domain.type.IndexType;
+
+public record ChangeIndexTypeInverse(
+    String indexId,
+    IndexType oldType) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeRelationshipCardinalityInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeRelationshipCardinalityInverse.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+import com.schemafy.core.erd.relationship.domain.type.Cardinality;
+
+public record ChangeRelationshipCardinalityInverse(
+    String relationshipId,
+    Cardinality oldCardinality) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeRelationshipNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeRelationshipNameInverse.java
@@ -1,0 +1,7 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+public record ChangeRelationshipNameInverse(
+    String relationshipId,
+    String oldName) implements InversePayload {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
@@ -5,32 +5,16 @@ import java.util.List;
 public record ChangeTableNameInverse(
     String tableId,
     String oldName,
-    String oldPkConstraintId,
-    String oldPkConstraintName,
     List<ConstraintRename> constraintRenames,
     List<RelationshipRename> relationshipRenames) implements InversePayload {
 
   public ChangeTableNameInverse {
-    constraintRenames = normalizeConstraintRenames(
-        constraintRenames,
-        oldPkConstraintId,
-        oldPkConstraintName);
+    constraintRenames = constraintRenames == null
+        ? List.of()
+        : List.copyOf(constraintRenames);
     relationshipRenames = relationshipRenames == null
         ? List.of()
         : List.copyOf(relationshipRenames);
-  }
-
-  private static List<ConstraintRename> normalizeConstraintRenames(
-      List<ConstraintRename> constraintRenames,
-      String oldPkConstraintId,
-      String oldPkConstraintName) {
-    if (constraintRenames != null) {
-      return List.copyOf(constraintRenames);
-    }
-    if (oldPkConstraintId == null || oldPkConstraintName == null) {
-      return List.of();
-    }
-    return List.of(new ConstraintRename(oldPkConstraintId, oldPkConstraintName));
   }
 
   public record ConstraintRename(String constraintId, String oldName) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
@@ -27,10 +27,6 @@ public record ChangeTableNameInverse(
       String fkTableId,
       String pkTableId) {
 
-    public RelationshipRename(String relationshipId, String oldName) {
-      this(relationshipId, oldName, null, null);
-    }
-
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
@@ -20,21 +20,6 @@ public record ChangeTableNameInverse(
         : List.copyOf(relationshipRenames);
   }
 
-  public ChangeTableNameInverse(
-      String tableId,
-      String oldName,
-      String oldPkConstraintId,
-      String oldPkConstraintName,
-      List<RelationshipRename> relationshipRenames) {
-    this(
-        tableId,
-        oldName,
-        oldPkConstraintId,
-        oldPkConstraintName,
-        null,
-        relationshipRenames);
-  }
-
   private static List<ConstraintRename> normalizeConstraintRenames(
       List<ConstraintRename> constraintRenames,
       String oldPkConstraintId,
@@ -52,7 +37,15 @@ public record ChangeTableNameInverse(
 
   }
 
-  public record RelationshipRename(String relationshipId, String oldName) {
+  public record RelationshipRename(
+      String relationshipId,
+      String oldName,
+      String fkTableId,
+      String pkTableId) {
+
+    public RelationshipRename(String relationshipId, String oldName) {
+      this(relationshipId, oldName, null, null);
+    }
 
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/ChangeTableNameInverse.java
@@ -1,0 +1,59 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+import java.util.List;
+
+public record ChangeTableNameInverse(
+    String tableId,
+    String oldName,
+    String oldPkConstraintId,
+    String oldPkConstraintName,
+    List<ConstraintRename> constraintRenames,
+    List<RelationshipRename> relationshipRenames) implements InversePayload {
+
+  public ChangeTableNameInverse {
+    constraintRenames = normalizeConstraintRenames(
+        constraintRenames,
+        oldPkConstraintId,
+        oldPkConstraintName);
+    relationshipRenames = relationshipRenames == null
+        ? List.of()
+        : List.copyOf(relationshipRenames);
+  }
+
+  public ChangeTableNameInverse(
+      String tableId,
+      String oldName,
+      String oldPkConstraintId,
+      String oldPkConstraintName,
+      List<RelationshipRename> relationshipRenames) {
+    this(
+        tableId,
+        oldName,
+        oldPkConstraintId,
+        oldPkConstraintName,
+        null,
+        relationshipRenames);
+  }
+
+  private static List<ConstraintRename> normalizeConstraintRenames(
+      List<ConstraintRename> constraintRenames,
+      String oldPkConstraintId,
+      String oldPkConstraintName) {
+    if (constraintRenames != null) {
+      return List.copyOf(constraintRenames);
+    }
+    if (oldPkConstraintId == null || oldPkConstraintName == null) {
+      return List.of();
+    }
+    return List.of(new ConstraintRename(oldPkConstraintId, oldPkConstraintName));
+  }
+
+  public record ConstraintRename(String constraintId, String oldName) {
+
+  }
+
+  public record RelationshipRename(String relationshipId, String oldName) {
+
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/InversePayload.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/InversePayload.java
@@ -1,0 +1,27 @@
+package com.schemafy.core.erd.operation.application.inverse;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ChangeTableNameInverse.class, name = "CHANGE_TABLE_NAME"),
+    @JsonSubTypes.Type(value = ChangeColumnNameInverse.class, name = "CHANGE_COLUMN_NAME"),
+    @JsonSubTypes.Type(value = ChangeColumnTypeInverse.class, name = "CHANGE_COLUMN_TYPE"),
+    @JsonSubTypes.Type(value = ChangeRelationshipNameInverse.class, name = "CHANGE_RELATIONSHIP_NAME"),
+    @JsonSubTypes.Type(value = ChangeRelationshipCardinalityInverse.class, name = "CHANGE_RELATIONSHIP_CARDINALITY"),
+    @JsonSubTypes.Type(value = ChangeConstraintNameInverse.class, name = "CHANGE_CONSTRAINT_NAME"),
+    @JsonSubTypes.Type(value = ChangeIndexNameInverse.class, name = "CHANGE_INDEX_NAME"),
+    @JsonSubTypes.Type(value = ChangeIndexTypeInverse.class, name = "CHANGE_INDEX_TYPE")
+})
+public sealed interface InversePayload permits
+    ChangeTableNameInverse,
+    ChangeColumnNameInverse,
+    ChangeColumnTypeInverse,
+    ChangeRelationshipNameInverse,
+    ChangeRelationshipCardinalityInverse,
+    ChangeConstraintNameInverse,
+    ChangeIndexNameInverse,
+    ChangeIndexTypeInverse {
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/InversePayload.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/inverse/InversePayload.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = ChangeTableNameInverse.class, name = "CHANGE_TABLE_NAME"),
-    @JsonSubTypes.Type(value = ChangeColumnNameInverse.class, name = "CHANGE_COLUMN_NAME"),
-    @JsonSubTypes.Type(value = ChangeColumnTypeInverse.class, name = "CHANGE_COLUMN_TYPE"),
-    @JsonSubTypes.Type(value = ChangeRelationshipNameInverse.class, name = "CHANGE_RELATIONSHIP_NAME"),
-    @JsonSubTypes.Type(value = ChangeRelationshipCardinalityInverse.class, name = "CHANGE_RELATIONSHIP_CARDINALITY"),
-    @JsonSubTypes.Type(value = ChangeConstraintNameInverse.class, name = "CHANGE_CONSTRAINT_NAME"),
-    @JsonSubTypes.Type(value = ChangeIndexNameInverse.class, name = "CHANGE_INDEX_NAME"),
-    @JsonSubTypes.Type(value = ChangeIndexTypeInverse.class, name = "CHANGE_INDEX_TYPE")
+  @JsonSubTypes.Type(value = ChangeTableNameInverse.class, name = "CHANGE_TABLE_NAME"),
+  @JsonSubTypes.Type(value = ChangeColumnNameInverse.class, name = "CHANGE_COLUMN_NAME"),
+  @JsonSubTypes.Type(value = ChangeColumnTypeInverse.class, name = "CHANGE_COLUMN_TYPE"),
+  @JsonSubTypes.Type(value = ChangeRelationshipNameInverse.class, name = "CHANGE_RELATIONSHIP_NAME"),
+  @JsonSubTypes.Type(value = ChangeRelationshipCardinalityInverse.class, name = "CHANGE_RELATIONSHIP_CARDINALITY"),
+  @JsonSubTypes.Type(value = ChangeConstraintNameInverse.class, name = "CHANGE_CONSTRAINT_NAME"),
+  @JsonSubTypes.Type(value = ChangeIndexNameInverse.class, name = "CHANGE_INDEX_NAME"),
+  @JsonSubTypes.Type(value = ChangeIndexTypeInverse.class, name = "CHANGE_INDEX_TYPE")
 })
 public sealed interface InversePayload permits
     ChangeTableNameInverse,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/port/out/IncrementSchemaCollaborationRevisionPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/port/out/IncrementSchemaCollaborationRevisionPort.java
@@ -8,4 +8,6 @@ public interface IncrementSchemaCollaborationRevisionPort {
 
   Mono<SchemaCollaborationState> increment(String schemaId);
 
+  Mono<SchemaCollaborationState> incrementIfCurrentRevision(String schemaId, long expectedRevision);
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/AbstractUndoRedoErdOperationHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/AbstractUndoRedoErdOperationHandler.java
@@ -1,0 +1,98 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.springframework.util.StringUtils;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.inverse.InversePayload;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+import com.schemafy.core.erd.operation.domain.ErdOperationLog;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+import com.schemafy.core.erd.operation.domain.exception.OperationErrorCode;
+
+import reactor.core.publisher.Mono;
+
+abstract class AbstractUndoRedoErdOperationHandler<T extends InversePayload>
+    implements UndoRedoErdOperationHandler {
+
+  private final ErdOperationType operationType;
+  private final Class<T> inverseType;
+  private final JsonCodec jsonCodec;
+  private final ErdMutationCoordinator erdMutationCoordinator;
+
+  AbstractUndoRedoErdOperationHandler(
+      ErdOperationType operationType,
+      Class<T> inverseType,
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator) {
+    this.operationType = Objects.requireNonNull(operationType, "operationType");
+    this.inverseType = Objects.requireNonNull(inverseType, "inverseType");
+    this.jsonCodec = Objects.requireNonNull(jsonCodec, "jsonCodec");
+    this.erdMutationCoordinator = Objects.requireNonNull(erdMutationCoordinator, "erdMutationCoordinator");
+  }
+
+  @Override
+  public final boolean supports(ErdOperationType rootOriginalOpType) {
+    return operationType == rootOriginalOpType;
+  }
+
+  @Override
+  public final Mono<MutationResult<Void>> undo(ResolvedUndoRedoEligibility resolved) {
+    return execute(resolved);
+  }
+
+  @Override
+  public final Mono<MutationResult<Void>> redo(ResolvedUndoRedoEligibility resolved) {
+    return execute(resolved);
+  }
+
+  protected final ErdOperationType operationType() {
+    return operationType;
+  }
+
+  protected final Mono<MutationResult<Void>> coordinate(
+      ResolvedUndoRedoEligibility resolved,
+      T inversePayload,
+      Supplier<Mono<MutationResult<Void>>> mutationSupplier) {
+    ErdOperationLog executionBase = resolved.executionBaseOperation();
+    ErdOperationDerivationKind derivationKind = resolved.action() == UndoRedoAction.UNDO
+        ? ErdOperationDerivationKind.UNDO
+        : ErdOperationDerivationKind.REDO;
+    return erdMutationCoordinator.coordinate(operationType, inversePayload, mutationSupplier)
+        .contextWrite(ErdOperationContexts.withDerivation(derivationKind, executionBase.opId()));
+  }
+
+  protected abstract Mono<MutationResult<Void>> applyInverse(
+      T inversePayload,
+      ResolvedUndoRedoEligibility resolved);
+
+  private Mono<MutationResult<Void>> execute(ResolvedUndoRedoEligibility resolved) {
+    return Mono.defer(() -> {
+      T inversePayload = deserialize(resolved.executionBaseOperation());
+      return applyInverse(inversePayload, resolved);
+    });
+  }
+
+  private T deserialize(ErdOperationLog executionBase) {
+    String inversePayloadJson = executionBase.inversePayloadJson();
+    if (!StringUtils.hasText(inversePayloadJson)) {
+      throw new DomainException(
+          OperationErrorCode.INVERSE_PAYLOAD_MISSING,
+          "Inverse payload is missing for operation: " + executionBase.opId());
+    }
+
+    InversePayload payload = jsonCodec.parse(
+        jsonCodec.normalizePersistedJson(inversePayloadJson), InversePayload.class);
+    if (!inverseType.isInstance(payload)) {
+      throw new IllegalStateException(
+          "Unexpected inverse payload type for %s: %s".formatted(operationType, payload.getClass().getName()));
+    }
+    return inverseType.cast(payload);
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/AbstractUndoRedoErdOperationHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/AbstractUndoRedoErdOperationHandler.java
@@ -64,7 +64,8 @@ abstract class AbstractUndoRedoErdOperationHandler<T extends InversePayload>
         ? ErdOperationDerivationKind.UNDO
         : ErdOperationDerivationKind.REDO;
     return erdMutationCoordinator.coordinate(operationType, inversePayload, mutationSupplier)
-        .contextWrite(ErdOperationContexts.withDerivation(derivationKind, executionBase.opId()));
+        .contextWrite(ErdOperationContexts.withDerivation(derivationKind, executionBase.opId())
+            .andThen(ErdOperationContexts.withBaseSchemaRevision(resolved.schemaCurrentRevision())));
   }
 
   protected abstract Mono<MutationResult<Void>> applyInverse(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnNameUndoRedoHandler.java
@@ -1,0 +1,47 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.column.application.port.out.ChangeColumnNamePort;
+import com.schemafy.core.erd.column.application.port.out.GetColumnByIdPort;
+import com.schemafy.core.erd.column.domain.exception.ColumnErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnNameInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeColumnNameUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeColumnNameInverse> {
+
+  private final ChangeColumnNamePort changeColumnNamePort;
+  private final GetColumnByIdPort getColumnByIdPort;
+
+  ChangeColumnNameUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeColumnNamePort changeColumnNamePort,
+      GetColumnByIdPort getColumnByIdPort) {
+    super(ErdOperationType.CHANGE_COLUMN_NAME, ChangeColumnNameInverse.class, jsonCodec, erdMutationCoordinator);
+    this.changeColumnNamePort = changeColumnNamePort;
+    this.getColumnByIdPort = getColumnByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeColumnNameInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getColumnByIdPort.findColumnById(inversePayload.columnId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            ColumnErrorCode.NOT_FOUND,
+            "Column not found: " + inversePayload.columnId())))
+        .flatMap(column -> coordinate(resolved, inversePayload,
+            () -> changeColumnNamePort.changeColumnName(inversePayload.columnId(), inversePayload.oldName())
+                .thenReturn(MutationResult.<Void>of(null, column.tableId())
+                    .withInverse(new ChangeColumnNameInverse(column.id(), column.name())))));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnTypeUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnTypeUndoRedoHandler.java
@@ -84,9 +84,9 @@ class ChangeColumnTypeUndoRedoHandler
 
   private Mono<Void> applyColumnTypeInverse(ChangeColumnTypeInverse inversePayload) {
     return changeColumnTypePort.changeColumnType(
-            inversePayload.columnId(),
-            inversePayload.oldDataType(),
-            inversePayload.oldTypeArguments())
+        inversePayload.columnId(),
+        inversePayload.oldDataType(),
+        inversePayload.oldTypeArguments())
         .then(Flux.fromIterable(inversePayload.fkRevertList())
             .concatMap(this::applyFkColumnTypeInverse)
             .then());
@@ -94,9 +94,9 @@ class ChangeColumnTypeUndoRedoHandler
 
   private Mono<Void> applyFkColumnTypeInverse(FkColumnTypeRevert revert) {
     return changeColumnTypePort.changeColumnType(
-            revert.columnId(),
-            revert.oldDataType(),
-            revert.oldTypeArguments())
+        revert.columnId(),
+        revert.oldDataType(),
+        revert.oldTypeArguments())
         .then(changeColumnMetaPort.changeColumnMeta(
             revert.columnId(),
             null,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnTypeUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeColumnTypeUndoRedoHandler.java
@@ -1,0 +1,127 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.column.application.port.out.ChangeColumnMetaPort;
+import com.schemafy.core.erd.column.application.port.out.ChangeColumnTypePort;
+import com.schemafy.core.erd.column.application.port.out.GetColumnByIdPort;
+import com.schemafy.core.erd.column.domain.Column;
+import com.schemafy.core.erd.column.domain.exception.ColumnErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnTypeInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnTypeInverse.FkColumnTypeRevert;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeColumnTypeUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeColumnTypeInverse> {
+
+  private final ChangeColumnTypePort changeColumnTypePort;
+  private final ChangeColumnMetaPort changeColumnMetaPort;
+  private final GetColumnByIdPort getColumnByIdPort;
+
+  ChangeColumnTypeUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeColumnTypePort changeColumnTypePort,
+      ChangeColumnMetaPort changeColumnMetaPort,
+      GetColumnByIdPort getColumnByIdPort) {
+    super(ErdOperationType.CHANGE_COLUMN_TYPE, ChangeColumnTypeInverse.class, jsonCodec, erdMutationCoordinator);
+    this.changeColumnTypePort = changeColumnTypePort;
+    this.changeColumnMetaPort = changeColumnMetaPort;
+    this.getColumnByIdPort = getColumnByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeColumnTypeInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getColumnByIdPort.findColumnById(inversePayload.columnId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            ColumnErrorCode.NOT_FOUND,
+            "Column not found: " + inversePayload.columnId())))
+        .flatMap(column -> captureFkForwardSnapshot(inversePayload)
+            .flatMap(fkSnapshot -> {
+              ChangeColumnTypeInverse forwardSnapshot = new ChangeColumnTypeInverse(
+                  column.id(),
+                  column.dataType(),
+                  column.typeArguments(),
+                  fkSnapshot.revertList());
+              Set<String> affectedTableIds = new HashSet<>(fkSnapshot.affectedTableIds());
+              affectedTableIds.add(column.tableId());
+              return coordinate(resolved, inversePayload,
+                  () -> applyColumnTypeInverse(inversePayload)
+                      .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
+                          .withInverse(forwardSnapshot)));
+            }));
+  }
+
+  private Mono<FkForwardSnapshot> captureFkForwardSnapshot(ChangeColumnTypeInverse inversePayload) {
+    return Flux.fromIterable(inversePayload.fkRevertList())
+        .concatMap(revert -> getColumnByIdPort.findColumnById(revert.columnId())
+            .switchIfEmpty(Mono.error(new DomainException(
+                ColumnErrorCode.NOT_FOUND,
+                "Column not found: " + revert.columnId()))))
+        .collectList()
+        .map(columns -> new FkForwardSnapshot(
+            columns.stream()
+                .map(this::toFkColumnTypeRevert)
+                .toList(),
+            columns.stream()
+                .map(Column::tableId)
+                .collect(Collectors.toSet())));
+  }
+
+  private Mono<Void> applyColumnTypeInverse(ChangeColumnTypeInverse inversePayload) {
+    return changeColumnTypePort.changeColumnType(
+            inversePayload.columnId(),
+            inversePayload.oldDataType(),
+            inversePayload.oldTypeArguments())
+        .then(Flux.fromIterable(inversePayload.fkRevertList())
+            .concatMap(this::applyFkColumnTypeInverse)
+            .then());
+  }
+
+  private Mono<Void> applyFkColumnTypeInverse(FkColumnTypeRevert revert) {
+    return changeColumnTypePort.changeColumnType(
+            revert.columnId(),
+            revert.oldDataType(),
+            revert.oldTypeArguments())
+        .then(changeColumnMetaPort.changeColumnMeta(
+            revert.columnId(),
+            null,
+            nullableMetaValue(revert.oldCharset()),
+            nullableMetaValue(revert.oldCollation()),
+            null));
+  }
+
+  private FkColumnTypeRevert toFkColumnTypeRevert(Column column) {
+    return new FkColumnTypeRevert(
+        column.id(),
+        column.dataType(),
+        column.typeArguments(),
+        column.charset(),
+        column.collation());
+  }
+
+  private static String nullableMetaValue(String value) {
+    return value == null ? "" : value;
+  }
+
+  private record FkForwardSnapshot(
+      List<FkColumnTypeRevert> revertList,
+      Set<String> affectedTableIds) {
+
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeConstraintNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeConstraintNameUndoRedoHandler.java
@@ -1,0 +1,52 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.constraint.application.port.out.ChangeConstraintNamePort;
+import com.schemafy.core.erd.constraint.application.port.out.GetConstraintByIdPort;
+import com.schemafy.core.erd.constraint.domain.exception.ConstraintErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeConstraintNameInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeConstraintNameUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeConstraintNameInverse> {
+
+  private final ChangeConstraintNamePort changeConstraintNamePort;
+  private final GetConstraintByIdPort getConstraintByIdPort;
+
+  ChangeConstraintNameUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeConstraintNamePort changeConstraintNamePort,
+      GetConstraintByIdPort getConstraintByIdPort) {
+    super(ErdOperationType.CHANGE_CONSTRAINT_NAME, ChangeConstraintNameInverse.class, jsonCodec,
+        erdMutationCoordinator);
+    this.changeConstraintNamePort = changeConstraintNamePort;
+    this.getConstraintByIdPort = getConstraintByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeConstraintNameInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getConstraintByIdPort.findConstraintById(inversePayload.constraintId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            ConstraintErrorCode.NOT_FOUND,
+            "Constraint not found: " + inversePayload.constraintId())))
+        .flatMap(constraint -> coordinate(resolved, inversePayload,
+            () -> changeConstraintNamePort.changeConstraintName(
+                    inversePayload.constraintId(),
+                    inversePayload.oldName())
+                .thenReturn(MutationResult.<Void>of(null, constraint.tableId())
+                    .withInverse(new ChangeConstraintNameInverse(
+                        constraint.id(),
+                        constraint.name())))));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeConstraintNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeConstraintNameUndoRedoHandler.java
@@ -41,8 +41,8 @@ class ChangeConstraintNameUndoRedoHandler
             "Constraint not found: " + inversePayload.constraintId())))
         .flatMap(constraint -> coordinate(resolved, inversePayload,
             () -> changeConstraintNamePort.changeConstraintName(
-                    inversePayload.constraintId(),
-                    inversePayload.oldName())
+                inversePayload.constraintId(),
+                inversePayload.oldName())
                 .thenReturn(MutationResult.<Void>of(null, constraint.tableId())
                     .withInverse(new ChangeConstraintNameInverse(
                         constraint.id(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeIndexNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeIndexNameUndoRedoHandler.java
@@ -1,0 +1,47 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.index.application.port.out.ChangeIndexNamePort;
+import com.schemafy.core.erd.index.application.port.out.GetIndexByIdPort;
+import com.schemafy.core.erd.index.domain.exception.IndexErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexNameInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeIndexNameUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeIndexNameInverse> {
+
+  private final ChangeIndexNamePort changeIndexNamePort;
+  private final GetIndexByIdPort getIndexByIdPort;
+
+  ChangeIndexNameUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeIndexNamePort changeIndexNamePort,
+      GetIndexByIdPort getIndexByIdPort) {
+    super(ErdOperationType.CHANGE_INDEX_NAME, ChangeIndexNameInverse.class, jsonCodec, erdMutationCoordinator);
+    this.changeIndexNamePort = changeIndexNamePort;
+    this.getIndexByIdPort = getIndexByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeIndexNameInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getIndexByIdPort.findIndexById(inversePayload.indexId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            IndexErrorCode.NOT_FOUND,
+            "Index not found: " + inversePayload.indexId())))
+        .flatMap(index -> coordinate(resolved, inversePayload,
+            () -> changeIndexNamePort.changeIndexName(inversePayload.indexId(), inversePayload.oldName())
+                .thenReturn(MutationResult.<Void>of(null, index.tableId())
+                    .withInverse(new ChangeIndexNameInverse(index.id(), index.name())))));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeIndexTypeUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeIndexTypeUndoRedoHandler.java
@@ -1,0 +1,47 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.index.application.port.out.ChangeIndexTypePort;
+import com.schemafy.core.erd.index.application.port.out.GetIndexByIdPort;
+import com.schemafy.core.erd.index.domain.exception.IndexErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexTypeInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeIndexTypeUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeIndexTypeInverse> {
+
+  private final ChangeIndexTypePort changeIndexTypePort;
+  private final GetIndexByIdPort getIndexByIdPort;
+
+  ChangeIndexTypeUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeIndexTypePort changeIndexTypePort,
+      GetIndexByIdPort getIndexByIdPort) {
+    super(ErdOperationType.CHANGE_INDEX_TYPE, ChangeIndexTypeInverse.class, jsonCodec, erdMutationCoordinator);
+    this.changeIndexTypePort = changeIndexTypePort;
+    this.getIndexByIdPort = getIndexByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeIndexTypeInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getIndexByIdPort.findIndexById(inversePayload.indexId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            IndexErrorCode.NOT_FOUND,
+            "Index not found: " + inversePayload.indexId())))
+        .flatMap(index -> coordinate(resolved, inversePayload,
+            () -> changeIndexTypePort.changeIndexType(inversePayload.indexId(), inversePayload.oldType())
+                .thenReturn(MutationResult.<Void>of(null, index.tableId())
+                    .withInverse(new ChangeIndexTypeInverse(index.id(), index.type())))));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipCardinalityUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipCardinalityUndoRedoHandler.java
@@ -15,6 +15,7 @@ import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipBy
 import com.schemafy.core.erd.relationship.domain.exception.RelationshipErrorCode;
 
 import reactor.core.publisher.Mono;
+
 @Component
 class ChangeRelationshipCardinalityUndoRedoHandler
     extends AbstractUndoRedoErdOperationHandler<ChangeRelationshipCardinalityInverse> {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipCardinalityUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipCardinalityUndoRedoHandler.java
@@ -1,0 +1,59 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipCardinalityInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+import com.schemafy.core.erd.relationship.application.port.out.ChangeRelationshipCardinalityPort;
+import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipByIdPort;
+import com.schemafy.core.erd.relationship.domain.exception.RelationshipErrorCode;
+
+import reactor.core.publisher.Mono;
+@Component
+class ChangeRelationshipCardinalityUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeRelationshipCardinalityInverse> {
+
+  private final ChangeRelationshipCardinalityPort changeRelationshipCardinalityPort;
+  private final GetRelationshipByIdPort getRelationshipByIdPort;
+
+  ChangeRelationshipCardinalityUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeRelationshipCardinalityPort changeRelationshipCardinalityPort,
+      GetRelationshipByIdPort getRelationshipByIdPort) {
+    super(ErdOperationType.CHANGE_RELATIONSHIP_CARDINALITY, ChangeRelationshipCardinalityInverse.class, jsonCodec,
+        erdMutationCoordinator);
+    this.changeRelationshipCardinalityPort = changeRelationshipCardinalityPort;
+    this.getRelationshipByIdPort = getRelationshipByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeRelationshipCardinalityInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getRelationshipByIdPort.findRelationshipById(inversePayload.relationshipId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            RelationshipErrorCode.NOT_FOUND,
+            "Relationship not found: " + inversePayload.relationshipId())))
+        .flatMap(relationship -> coordinate(resolved, inversePayload,
+            () -> {
+              Set<String> affectedTableIds = new HashSet<>();
+              affectedTableIds.add(relationship.fkTableId());
+              affectedTableIds.add(relationship.pkTableId());
+              return changeRelationshipCardinalityPort.changeRelationshipCardinality(
+                  inversePayload.relationshipId(),
+                  inversePayload.oldCardinality())
+                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
+                      .withInverse(new ChangeRelationshipCardinalityInverse(
+                          relationship.id(),
+                          relationship.cardinality())));
+            }));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipNameUndoRedoHandler.java
@@ -48,8 +48,8 @@ class ChangeRelationshipNameUndoRedoHandler
               affectedTableIds.add(relationship.fkTableId());
               affectedTableIds.add(relationship.pkTableId());
               return changeRelationshipNamePort.changeRelationshipName(
-                      inversePayload.relationshipId(),
-                      inversePayload.oldName())
+                  inversePayload.relationshipId(),
+                  inversePayload.oldName())
                   .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
                       .withInverse(new ChangeRelationshipNameInverse(
                           relationship.id(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeRelationshipNameUndoRedoHandler.java
@@ -1,0 +1,60 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipNameInverse;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+import com.schemafy.core.erd.relationship.application.port.out.ChangeRelationshipNamePort;
+import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipByIdPort;
+import com.schemafy.core.erd.relationship.domain.exception.RelationshipErrorCode;
+
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeRelationshipNameUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeRelationshipNameInverse> {
+
+  private final ChangeRelationshipNamePort changeRelationshipNamePort;
+  private final GetRelationshipByIdPort getRelationshipByIdPort;
+
+  ChangeRelationshipNameUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeRelationshipNamePort changeRelationshipNamePort,
+      GetRelationshipByIdPort getRelationshipByIdPort) {
+    super(ErdOperationType.CHANGE_RELATIONSHIP_NAME, ChangeRelationshipNameInverse.class, jsonCodec,
+        erdMutationCoordinator);
+    this.changeRelationshipNamePort = changeRelationshipNamePort;
+    this.getRelationshipByIdPort = getRelationshipByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeRelationshipNameInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getRelationshipByIdPort.findRelationshipById(inversePayload.relationshipId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            RelationshipErrorCode.NOT_FOUND,
+            "Relationship not found: " + inversePayload.relationshipId())))
+        .flatMap(relationship -> coordinate(resolved, inversePayload,
+            () -> {
+              Set<String> affectedTableIds = new HashSet<>();
+              affectedTableIds.add(relationship.fkTableId());
+              affectedTableIds.add(relationship.pkTableId());
+              return changeRelationshipNamePort.changeRelationshipName(
+                      inversePayload.relationshipId(),
+                      inversePayload.oldName())
+                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
+                      .withInverse(new ChangeRelationshipNameInverse(
+                          relationship.id(),
+                          relationship.name())));
+            }));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
@@ -1,0 +1,140 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.constraint.application.port.out.ChangeConstraintNamePort;
+import com.schemafy.core.erd.constraint.application.port.out.GetConstraintByIdPort;
+import com.schemafy.core.erd.constraint.domain.Constraint;
+import com.schemafy.core.erd.constraint.domain.exception.ConstraintErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse.ConstraintRename;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse.RelationshipRename;
+import com.schemafy.core.erd.operation.domain.ErdOperationType;
+import com.schemafy.core.erd.relationship.application.port.out.ChangeRelationshipNamePort;
+import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipByIdPort;
+import com.schemafy.core.erd.relationship.domain.exception.RelationshipErrorCode;
+import com.schemafy.core.erd.table.application.port.out.ChangeTableNamePort;
+import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;
+import com.schemafy.core.erd.table.domain.Table;
+import com.schemafy.core.erd.table.domain.exception.TableErrorCode;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+class ChangeTableNameUndoRedoHandler
+    extends AbstractUndoRedoErdOperationHandler<ChangeTableNameInverse> {
+
+  private final ChangeTableNamePort changeTableNamePort;
+  private final GetTableByIdPort getTableByIdPort;
+  private final ChangeConstraintNamePort changeConstraintNamePort;
+  private final GetConstraintByIdPort getConstraintByIdPort;
+  private final ChangeRelationshipNamePort changeRelationshipNamePort;
+  private final GetRelationshipByIdPort getRelationshipByIdPort;
+
+  ChangeTableNameUndoRedoHandler(
+      JsonCodec jsonCodec,
+      ErdMutationCoordinator erdMutationCoordinator,
+      ChangeTableNamePort changeTableNamePort,
+      GetTableByIdPort getTableByIdPort,
+      ChangeConstraintNamePort changeConstraintNamePort,
+      GetConstraintByIdPort getConstraintByIdPort,
+      ChangeRelationshipNamePort changeRelationshipNamePort,
+      GetRelationshipByIdPort getRelationshipByIdPort) {
+    super(ErdOperationType.CHANGE_TABLE_NAME, ChangeTableNameInverse.class, jsonCodec, erdMutationCoordinator);
+    this.changeTableNamePort = changeTableNamePort;
+    this.getTableByIdPort = getTableByIdPort;
+    this.changeConstraintNamePort = changeConstraintNamePort;
+    this.getConstraintByIdPort = getConstraintByIdPort;
+    this.changeRelationshipNamePort = changeRelationshipNamePort;
+    this.getRelationshipByIdPort = getRelationshipByIdPort;
+  }
+
+  @Override
+  protected Mono<MutationResult<Void>> applyInverse(
+      ChangeTableNameInverse inversePayload,
+      ResolvedUndoRedoEligibility resolved) {
+    return getTableByIdPort.findTableById(inversePayload.tableId())
+        .switchIfEmpty(Mono.error(new DomainException(
+            TableErrorCode.NOT_FOUND,
+            "Table not found: " + inversePayload.tableId())))
+        .flatMap(table -> captureForwardSnapshot(table, inversePayload)
+            .flatMap(forwardSnapshot -> coordinate(resolved, inversePayload,
+                () -> applyTableInverse(inversePayload)
+                    .thenReturn(MutationResult.<Void>of(null, table.id())
+                        .withInverse(forwardSnapshot)))));
+  }
+
+  private Mono<ChangeTableNameInverse> captureForwardSnapshot(
+      Table table,
+      ChangeTableNameInverse inversePayload) {
+    Mono<List<ConstraintRename>> constraintRenames = Flux.fromIterable(inversePayload.constraintRenames())
+        .concatMap(rename -> findConstraint(rename.constraintId())
+            .map(constraint -> new ConstraintRename(constraint.id(), constraint.name())))
+        .collectList();
+    Mono<List<RelationshipRename>> relationshipRenames = Flux.fromIterable(inversePayload.relationshipRenames())
+        .concatMap(rename -> getRelationshipByIdPort.findRelationshipById(rename.relationshipId())
+            .switchIfEmpty(Mono.error(new DomainException(
+                RelationshipErrorCode.NOT_FOUND,
+                "Relationship not found: " + rename.relationshipId())))
+            .map(relationship -> new RelationshipRename(relationship.id(), relationship.name())))
+        .collectList();
+
+    return Mono.zip(constraintRenames, relationshipRenames)
+        .map(tuple -> new ChangeTableNameInverse(
+            table.id(),
+            table.name(),
+            inversePayload.oldPkConstraintId(),
+            firstLegacyPkName(tuple.getT1(), inversePayload.oldPkConstraintId()),
+            tuple.getT1(),
+            tuple.getT2()));
+  }
+
+  private Mono<Constraint> findConstraint(String constraintId) {
+    return getConstraintByIdPort.findConstraintById(constraintId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ConstraintErrorCode.NOT_FOUND,
+            "Constraint not found: " + constraintId)));
+  }
+
+  private static String firstLegacyPkName(
+      List<ConstraintRename> constraintRenames,
+      String legacyPkConstraintId) {
+    if (legacyPkConstraintId == null) {
+      return null;
+    }
+    return constraintRenames.stream()
+        .filter(rename -> legacyPkConstraintId.equals(rename.constraintId()))
+        .map(ConstraintRename::oldName)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Mono<Void> applyTableInverse(ChangeTableNameInverse inversePayload) {
+    return changeTableNamePort.changeTableName(inversePayload.tableId(), inversePayload.oldName())
+        .then(applyConstraintInverse(inversePayload.constraintRenames()))
+        .then(applyRelationshipInverse(inversePayload.relationshipRenames()));
+  }
+
+  private Mono<Void> applyConstraintInverse(List<ConstraintRename> constraintRenames) {
+    return Flux.fromIterable(constraintRenames)
+        .concatMap(rename -> changeConstraintNamePort.changeConstraintName(
+            rename.constraintId(),
+            rename.oldName()))
+        .then();
+  }
+
+  private Mono<Void> applyRelationshipInverse(List<RelationshipRename> relationshipRenames) {
+    return Flux.fromIterable(relationshipRenames)
+        .concatMap(rename -> changeRelationshipNamePort.changeRelationshipName(
+            rename.relationshipId(),
+            rename.oldName()))
+        .then();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
@@ -1,6 +1,9 @@
 package com.schemafy.core.erd.operation.application.service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Component;
 
@@ -66,7 +69,7 @@ class ChangeTableNameUndoRedoHandler
         .flatMap(table -> captureForwardSnapshot(table, inversePayload)
             .flatMap(forwardSnapshot -> coordinate(resolved, inversePayload,
                 () -> applyTableInverse(inversePayload)
-                    .thenReturn(MutationResult.<Void>of(null, table.id())
+                    .thenReturn(MutationResult.<Void>of(null, affectedTableIds(table.id(), forwardSnapshot))
                         .withInverse(forwardSnapshot)))));
   }
 
@@ -82,7 +85,11 @@ class ChangeTableNameUndoRedoHandler
             .switchIfEmpty(Mono.error(new DomainException(
                 RelationshipErrorCode.NOT_FOUND,
                 "Relationship not found: " + rename.relationshipId())))
-            .map(relationship -> new RelationshipRename(relationship.id(), relationship.name())))
+            .map(relationship -> new RelationshipRename(
+                relationship.id(),
+                relationship.name(),
+                relationship.fkTableId(),
+                relationship.pkTableId())))
         .collectList();
 
     return Mono.zip(constraintRenames, relationshipRenames)
@@ -113,6 +120,16 @@ class ChangeTableNameUndoRedoHandler
         .map(ConstraintRename::oldName)
         .findFirst()
         .orElse(null);
+  }
+
+  private static Set<String> affectedTableIds(
+      String tableId,
+      ChangeTableNameInverse forwardSnapshot) {
+    return Stream.concat(
+        Stream.of(tableId),
+        forwardSnapshot.relationshipRenames().stream()
+            .flatMap(rename -> Stream.of(rename.fkTableId(), rename.pkTableId())))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   private Mono<Void> applyTableInverse(ChangeTableNameInverse inversePayload) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ChangeTableNameUndoRedoHandler.java
@@ -96,8 +96,6 @@ class ChangeTableNameUndoRedoHandler
         .map(tuple -> new ChangeTableNameInverse(
             table.id(),
             table.name(),
-            inversePayload.oldPkConstraintId(),
-            firstLegacyPkName(tuple.getT1(), inversePayload.oldPkConstraintId()),
             tuple.getT1(),
             tuple.getT2()));
   }
@@ -107,19 +105,6 @@ class ChangeTableNameUndoRedoHandler
         .switchIfEmpty(Mono.error(new DomainException(
             ConstraintErrorCode.NOT_FOUND,
             "Constraint not found: " + constraintId)));
-  }
-
-  private static String firstLegacyPkName(
-      List<ConstraintRename> constraintRenames,
-      String legacyPkConstraintId) {
-    if (legacyPkConstraintId == null) {
-      return null;
-    }
-    return constraintRenames.stream()
-        .filter(rename -> legacyPkConstraintId.equals(rename.constraintId()))
-        .map(ConstraintRename::oldName)
-        .findFirst()
-        .orElse(null);
   }
 
   private static Set<String> affectedTableIds(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.ErdOperationMetadata;
@@ -20,6 +21,7 @@ import com.schemafy.core.erd.operation.application.port.out.SaveSchemaCollaborat
 import com.schemafy.core.erd.operation.application.service.ErdMutationTargetResolver.FinalizedErdMutationTarget;
 import com.schemafy.core.erd.operation.application.service.ErdMutationTargetResolver.ResolvedErdMutationTarget;
 import com.schemafy.core.erd.operation.domain.*;
+import com.schemafy.core.erd.operation.domain.exception.OperationErrorCode;
 import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
 
 import lombok.RequiredArgsConstructor;
@@ -120,7 +122,7 @@ class DefaultErdMutationCoordinator implements ErdMutationCoordinator {
         mutationResult);
 
     return resolveSchemaState(operationType, resolvedTarget, finalizedTarget, preloadedState)
-        .flatMap(schemaState -> incrementSchemaCollaborationRevisionPort.increment(schemaState.schemaId())
+        .flatMap(schemaState -> incrementRevision(schemaState.schemaId(), metadata)
             .flatMap(updatedState -> appendErdOperationLogPort.append(buildOperationLog(
                 operationType,
                 payload,
@@ -130,6 +132,36 @@ class DefaultErdMutationCoordinator implements ErdMutationCoordinator {
                 metadata)))
             .map(operationLog -> mutationResult.withOperation(
                 CommittedErdOperation.from(operationLog))));
+  }
+
+  private Mono<SchemaCollaborationState> incrementRevision(
+      String schemaId,
+      ErdOperationMetadata metadata) {
+    Long expectedRevision = metadata.baseSchemaRevision();
+    if (isDerivedMutation(metadata)) {
+      if (expectedRevision == null) {
+        return Mono.error(new IllegalStateException("Derived operation requires base schema revision"));
+      }
+      return incrementSchemaCollaborationRevisionPort
+          .incrementIfCurrentRevision(schemaId, expectedRevision)
+          .switchIfEmpty(Mono.error(new DomainException(
+              staleDerivedOperationErrorCode(metadata),
+              "Schema revision changed before undo/redo commit: schemaId=" + schemaId)));
+    }
+    return incrementSchemaCollaborationRevisionPort.increment(schemaId);
+  }
+
+  private boolean isDerivedMutation(ErdOperationMetadata metadata) {
+    ErdOperationDerivationKind derivationKind = metadata.derivationKind();
+    return derivationKind == ErdOperationDerivationKind.UNDO
+        || derivationKind == ErdOperationDerivationKind.REDO;
+  }
+
+  private OperationErrorCode staleDerivedOperationErrorCode(ErdOperationMetadata metadata) {
+    if (metadata.derivationKind() == ErdOperationDerivationKind.REDO) {
+      return OperationErrorCode.REDO_NOT_ELIGIBLE;
+    }
+    return OperationErrorCode.SUPERSEDED;
   }
 
   private Mono<SchemaCollaborationState> resolveSchemaState(

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
@@ -12,6 +12,7 @@ import com.schemafy.core.common.MutationResult;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.ErdOperationMetadata;
+import com.schemafy.core.erd.operation.application.inverse.InversePayload;
 import com.schemafy.core.erd.operation.application.port.out.AppendErdOperationLogPort;
 import com.schemafy.core.erd.operation.application.port.out.FindSchemaCollaborationStatePort;
 import com.schemafy.core.erd.operation.application.port.out.IncrementSchemaCollaborationRevisionPort;
@@ -23,7 +24,6 @@ import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
-
 @Component
 @RequiredArgsConstructor
 class DefaultErdMutationCoordinator implements ErdMutationCoordinator {
@@ -167,15 +167,24 @@ class DefaultErdMutationCoordinator implements ErdMutationCoordinator {
         metadata.clientOperationId(),
         metadata.sessionId(),
         metadata.actorUserIdOr(SYSTEM_ACTOR_USER_ID),
-        ErdOperationDerivationKind.ORIGINAL,
-        null,
+        metadata.derivationKindOrDefault(),
+        metadata.derivedFromOpId(),
         ErdOperationLifecycleState.COMMITTED,
-        jsonCodec.serialize(payload),
-        null,
+        serializePayload(payload),
+        mutationResult.inversePayload() == null
+            ? null
+            : jsonCodec.serialize(mutationResult.inversePayload(), InversePayload.class),
         jsonCodec.serialize(finalizedTarget.touchedEntity() == null
             ? List.of()
             : List.of(finalizedTarget.touchedEntity())),
         jsonCodec.serialize(affectedTableIds));
+  }
+
+  private String serializePayload(Object payload) {
+    if (payload instanceof InversePayload inversePayload) {
+      return jsonCodec.serialize(inversePayload, InversePayload.class);
+    }
+    return jsonCodec.serialize(payload);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/DefaultErdMutationCoordinator.java
@@ -26,6 +26,7 @@ import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
+
 @Component
 @RequiredArgsConstructor
 class DefaultErdMutationCoordinator implements ErdMutationCoordinator {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ErdMutationTargetResolver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ErdMutationTargetResolver.java
@@ -41,6 +41,14 @@ import com.schemafy.core.erd.index.application.port.in.RemoveIndexColumnCommand;
 import com.schemafy.core.erd.index.application.port.out.GetIndexByIdPort;
 import com.schemafy.core.erd.index.application.port.out.GetIndexColumnByIdPort;
 import com.schemafy.core.erd.index.domain.exception.IndexErrorCode;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeColumnTypeInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeConstraintNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeIndexTypeInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipCardinalityInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.operation.domain.ErdTouchedEntity;
 import com.schemafy.core.erd.relationship.application.port.in.AddRelationshipColumnCommand;
@@ -91,168 +99,208 @@ class ErdMutationTargetResolver {
 
   Mono<ResolvedErdMutationTarget> resolveBefore(ErdOperationType operationType, Object payload) {
     return switch (operationType) {
-    case CREATE_SCHEMA -> {
-      CreateSchemaCommand command = requirePayload(payload, CreateSchemaCommand.class);
-      yield Mono.just(new ResolvedErdMutationTarget(command.projectId(), null, null));
-    }
-    case CHANGE_SCHEMA_NAME -> {
-      ChangeSchemaNameCommand command = requirePayload(payload, ChangeSchemaNameCommand.class);
-      yield resolveBySchemaId(command.schemaId(), command.schemaId());
-    }
-    case DELETE_SCHEMA -> {
-      DeleteSchemaCommand command = requirePayload(payload, DeleteSchemaCommand.class);
-      yield resolveBySchemaId(command.schemaId(), command.schemaId());
-    }
-    case CREATE_TABLE -> {
-      CreateTableCommand command = requirePayload(payload, CreateTableCommand.class);
-      yield resolveSchemaContext(command.schemaId());
-    }
-    case CHANGE_TABLE_NAME -> {
-      ChangeTableNameCommand command = requirePayload(payload, ChangeTableNameCommand.class);
-      yield resolveByTableId(command.tableId(), command.tableId());
-    }
-    case CHANGE_TABLE_META -> {
-      ChangeTableMetaCommand command = requirePayload(payload, ChangeTableMetaCommand.class);
-      yield resolveByTableId(command.tableId(), command.tableId());
-    }
-    case CHANGE_TABLE_EXTRA -> {
-      ChangeTableExtraCommand command = requirePayload(payload, ChangeTableExtraCommand.class);
-      yield resolveByTableId(command.tableId(), command.tableId());
-    }
-    case DELETE_TABLE -> {
-      DeleteTableCommand command = requirePayload(payload, DeleteTableCommand.class);
-      yield resolveByTableId(command.tableId(), command.tableId());
-    }
-    case CREATE_COLUMN -> {
-      CreateColumnCommand command = requirePayload(payload, CreateColumnCommand.class);
-      yield resolveTableContext(command.tableId());
-    }
-    case CHANGE_COLUMN_NAME -> {
-      ChangeColumnNameCommand command = requirePayload(payload, ChangeColumnNameCommand.class);
-      yield resolveByColumnId(command.columnId(), command.columnId());
-    }
-    case CHANGE_COLUMN_TYPE -> {
-      ChangeColumnTypeCommand command = requirePayload(payload, ChangeColumnTypeCommand.class);
-      yield resolveByColumnId(command.columnId(), command.columnId());
-    }
-    case CHANGE_COLUMN_META -> {
-      ChangeColumnMetaCommand command = requirePayload(payload, ChangeColumnMetaCommand.class);
-      yield resolveByColumnId(command.columnId(), command.columnId());
-    }
-    case CHANGE_COLUMN_POSITION -> {
-      ChangeColumnPositionCommand command = requirePayload(payload, ChangeColumnPositionCommand.class);
-      yield resolveByColumnId(command.columnId(), command.columnId());
-    }
-    case DELETE_COLUMN -> {
-      DeleteColumnCommand command = requirePayload(payload, DeleteColumnCommand.class);
-      yield resolveByColumnId(command.columnId(), command.columnId());
-    }
-    case CREATE_CONSTRAINT -> {
-      CreateConstraintCommand command = requirePayload(payload, CreateConstraintCommand.class);
-      yield resolveTableContext(command.tableId());
-    }
-    case CHANGE_CONSTRAINT_NAME -> {
-      ChangeConstraintNameCommand command = requirePayload(payload, ChangeConstraintNameCommand.class);
-      yield resolveByConstraintId(command.constraintId(), command.constraintId());
-    }
-    case CHANGE_CONSTRAINT_CHECK_EXPR -> {
-      ChangeConstraintCheckExprCommand command = requirePayload(payload, ChangeConstraintCheckExprCommand.class);
-      yield resolveByConstraintId(command.constraintId(), command.constraintId());
-    }
-    case CHANGE_CONSTRAINT_DEFAULT_EXPR -> {
-      ChangeConstraintDefaultExprCommand command = requirePayload(payload, ChangeConstraintDefaultExprCommand.class);
-      yield resolveByConstraintId(command.constraintId(), command.constraintId());
-    }
-    case DELETE_CONSTRAINT -> {
-      DeleteConstraintCommand command = requirePayload(payload, DeleteConstraintCommand.class);
-      yield resolveByConstraintId(command.constraintId(), command.constraintId());
-    }
-    case ADD_CONSTRAINT_COLUMN -> {
-      AddConstraintColumnCommand command = requirePayload(payload, AddConstraintColumnCommand.class);
-      yield resolveByConstraintId(command.constraintId(), null);
-    }
-    case REMOVE_CONSTRAINT_COLUMN -> {
-      RemoveConstraintColumnCommand command = requirePayload(payload, RemoveConstraintColumnCommand.class);
-      yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
-    }
-    case CHANGE_CONSTRAINT_COLUMN_POSITION -> {
-      ChangeConstraintColumnPositionCommand command = requirePayload(payload,
-          ChangeConstraintColumnPositionCommand.class);
-      yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
-    }
-    case CREATE_INDEX -> {
-      CreateIndexCommand command = requirePayload(payload, CreateIndexCommand.class);
-      yield resolveTableContext(command.tableId());
-    }
-    case CHANGE_INDEX_NAME -> {
-      ChangeIndexNameCommand command = requirePayload(payload, ChangeIndexNameCommand.class);
-      yield resolveByIndexId(command.indexId(), command.indexId());
-    }
-    case CHANGE_INDEX_TYPE -> {
-      ChangeIndexTypeCommand command = requirePayload(payload, ChangeIndexTypeCommand.class);
-      yield resolveByIndexId(command.indexId(), command.indexId());
-    }
-    case DELETE_INDEX -> {
-      DeleteIndexCommand command = requirePayload(payload, DeleteIndexCommand.class);
-      yield resolveByIndexId(command.indexId(), command.indexId());
-    }
-    case ADD_INDEX_COLUMN -> {
-      AddIndexColumnCommand command = requirePayload(payload, AddIndexColumnCommand.class);
-      yield resolveByIndexId(command.indexId(), null);
-    }
-    case REMOVE_INDEX_COLUMN -> {
-      RemoveIndexColumnCommand command = requirePayload(payload, RemoveIndexColumnCommand.class);
-      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-    }
-    case CHANGE_INDEX_COLUMN_POSITION -> {
-      ChangeIndexColumnPositionCommand command = requirePayload(payload,
-          ChangeIndexColumnPositionCommand.class);
-      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-    }
-    case CHANGE_INDEX_COLUMN_SORT_DIRECTION -> {
-      ChangeIndexColumnSortDirectionCommand command = requirePayload(payload,
-          ChangeIndexColumnSortDirectionCommand.class);
-      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-    }
-    case CREATE_RELATIONSHIP -> {
-      CreateRelationshipCommand command = requirePayload(payload, CreateRelationshipCommand.class);
-      yield resolveTableContext(command.fkTableId());
-    }
-    case CHANGE_RELATIONSHIP_NAME -> {
-      ChangeRelationshipNameCommand command = requirePayload(payload, ChangeRelationshipNameCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-    }
-    case CHANGE_RELATIONSHIP_KIND -> {
-      ChangeRelationshipKindCommand command = requirePayload(payload, ChangeRelationshipKindCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-    }
-    case CHANGE_RELATIONSHIP_CARDINALITY -> {
-      ChangeRelationshipCardinalityCommand command = requirePayload(payload,
-          ChangeRelationshipCardinalityCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-    }
-    case CHANGE_RELATIONSHIP_EXTRA -> {
-      ChangeRelationshipExtraCommand command = requirePayload(payload, ChangeRelationshipExtraCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-    }
-    case DELETE_RELATIONSHIP -> {
-      DeleteRelationshipCommand command = requirePayload(payload, DeleteRelationshipCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-    }
-    case ADD_RELATIONSHIP_COLUMN -> {
-      AddRelationshipColumnCommand command = requirePayload(payload, AddRelationshipColumnCommand.class);
-      yield resolveByRelationshipId(command.relationshipId(), null);
-    }
-    case REMOVE_RELATIONSHIP_COLUMN -> {
-      RemoveRelationshipColumnCommand command = requirePayload(payload, RemoveRelationshipColumnCommand.class);
-      yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
-    }
-    case CHANGE_RELATIONSHIP_COLUMN_POSITION -> {
-      ChangeRelationshipColumnPositionCommand command = requirePayload(payload,
-          ChangeRelationshipColumnPositionCommand.class);
-      yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
-    }
+      case CREATE_SCHEMA -> {
+        CreateSchemaCommand command = requirePayload(payload, CreateSchemaCommand.class);
+        yield Mono.just(new ResolvedErdMutationTarget(command.projectId(), null, null));
+      }
+      case CHANGE_SCHEMA_NAME -> {
+        ChangeSchemaNameCommand command = requirePayload(payload, ChangeSchemaNameCommand.class);
+        yield resolveBySchemaId(command.schemaId(), command.schemaId());
+      }
+      case DELETE_SCHEMA -> {
+        DeleteSchemaCommand command = requirePayload(payload, DeleteSchemaCommand.class);
+        yield resolveBySchemaId(command.schemaId(), command.schemaId());
+      }
+      case CREATE_TABLE -> {
+        CreateTableCommand command = requirePayload(payload, CreateTableCommand.class);
+        yield resolveSchemaContext(command.schemaId());
+      }
+      case CHANGE_TABLE_NAME -> resolveChangeTableName(payload);
+      case CHANGE_TABLE_META -> {
+        ChangeTableMetaCommand command = requirePayload(payload, ChangeTableMetaCommand.class);
+        yield resolveByTableId(command.tableId(), command.tableId());
+      }
+      case CHANGE_TABLE_EXTRA -> {
+        ChangeTableExtraCommand command = requirePayload(payload, ChangeTableExtraCommand.class);
+        yield resolveByTableId(command.tableId(), command.tableId());
+      }
+      case DELETE_TABLE -> {
+        DeleteTableCommand command = requirePayload(payload, DeleteTableCommand.class);
+        yield resolveByTableId(command.tableId(), command.tableId());
+      }
+      case CREATE_COLUMN -> {
+        CreateColumnCommand command = requirePayload(payload, CreateColumnCommand.class);
+        yield resolveTableContext(command.tableId());
+      }
+      case CHANGE_COLUMN_NAME -> resolveChangeColumnName(payload);
+      case CHANGE_COLUMN_TYPE -> resolveChangeColumnType(payload);
+      case CHANGE_COLUMN_META -> {
+        ChangeColumnMetaCommand command = requirePayload(payload, ChangeColumnMetaCommand.class);
+        yield resolveByColumnId(command.columnId(), command.columnId());
+      }
+      case CHANGE_COLUMN_POSITION -> {
+        ChangeColumnPositionCommand command = requirePayload(payload, ChangeColumnPositionCommand.class);
+        yield resolveByColumnId(command.columnId(), command.columnId());
+      }
+      case DELETE_COLUMN -> {
+        DeleteColumnCommand command = requirePayload(payload, DeleteColumnCommand.class);
+        yield resolveByColumnId(command.columnId(), command.columnId());
+      }
+      case CREATE_CONSTRAINT -> {
+        CreateConstraintCommand command = requirePayload(payload, CreateConstraintCommand.class);
+        yield resolveTableContext(command.tableId());
+      }
+      case CHANGE_CONSTRAINT_NAME -> resolveChangeConstraintName(payload);
+      case CHANGE_CONSTRAINT_CHECK_EXPR -> {
+        ChangeConstraintCheckExprCommand command = requirePayload(payload, ChangeConstraintCheckExprCommand.class);
+        yield resolveByConstraintId(command.constraintId(), command.constraintId());
+      }
+      case CHANGE_CONSTRAINT_DEFAULT_EXPR -> {
+        ChangeConstraintDefaultExprCommand command = requirePayload(payload, ChangeConstraintDefaultExprCommand.class);
+        yield resolveByConstraintId(command.constraintId(), command.constraintId());
+      }
+      case DELETE_CONSTRAINT -> {
+        DeleteConstraintCommand command = requirePayload(payload, DeleteConstraintCommand.class);
+        yield resolveByConstraintId(command.constraintId(), command.constraintId());
+      }
+      case ADD_CONSTRAINT_COLUMN -> {
+        AddConstraintColumnCommand command = requirePayload(payload, AddConstraintColumnCommand.class);
+        yield resolveByConstraintId(command.constraintId(), null);
+      }
+      case REMOVE_CONSTRAINT_COLUMN -> {
+        RemoveConstraintColumnCommand command = requirePayload(payload, RemoveConstraintColumnCommand.class);
+        yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
+      }
+      case CHANGE_CONSTRAINT_COLUMN_POSITION -> {
+        ChangeConstraintColumnPositionCommand command = requirePayload(payload,
+            ChangeConstraintColumnPositionCommand.class);
+        yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
+      }
+      case CREATE_INDEX -> {
+        CreateIndexCommand command = requirePayload(payload, CreateIndexCommand.class);
+        yield resolveTableContext(command.tableId());
+      }
+      case CHANGE_INDEX_NAME -> resolveChangeIndexName(payload);
+      case CHANGE_INDEX_TYPE -> resolveChangeIndexType(payload);
+      case DELETE_INDEX -> {
+        DeleteIndexCommand command = requirePayload(payload, DeleteIndexCommand.class);
+        yield resolveByIndexId(command.indexId(), command.indexId());
+      }
+      case ADD_INDEX_COLUMN -> {
+        AddIndexColumnCommand command = requirePayload(payload, AddIndexColumnCommand.class);
+        yield resolveByIndexId(command.indexId(), null);
+      }
+      case REMOVE_INDEX_COLUMN -> {
+        RemoveIndexColumnCommand command = requirePayload(payload, RemoveIndexColumnCommand.class);
+        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+      }
+      case CHANGE_INDEX_COLUMN_POSITION -> {
+        ChangeIndexColumnPositionCommand command = requirePayload(payload,
+            ChangeIndexColumnPositionCommand.class);
+        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+      }
+      case CHANGE_INDEX_COLUMN_SORT_DIRECTION -> {
+        ChangeIndexColumnSortDirectionCommand command = requirePayload(payload,
+            ChangeIndexColumnSortDirectionCommand.class);
+        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+      }
+      case CREATE_RELATIONSHIP -> {
+        CreateRelationshipCommand command = requirePayload(payload, CreateRelationshipCommand.class);
+        yield resolveTableContext(command.fkTableId());
+      }
+      case CHANGE_RELATIONSHIP_NAME -> resolveChangeRelationshipName(payload);
+      case CHANGE_RELATIONSHIP_KIND -> {
+        ChangeRelationshipKindCommand command = requirePayload(payload, ChangeRelationshipKindCommand.class);
+        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+      }
+      case CHANGE_RELATIONSHIP_CARDINALITY -> resolveChangeRelationshipCardinality(payload);
+      case CHANGE_RELATIONSHIP_EXTRA -> {
+        ChangeRelationshipExtraCommand command = requirePayload(payload, ChangeRelationshipExtraCommand.class);
+        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+      }
+      case DELETE_RELATIONSHIP -> {
+        DeleteRelationshipCommand command = requirePayload(payload, DeleteRelationshipCommand.class);
+        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+      }
+      case ADD_RELATIONSHIP_COLUMN -> {
+        AddRelationshipColumnCommand command = requirePayload(payload, AddRelationshipColumnCommand.class);
+        yield resolveByRelationshipId(command.relationshipId(), null);
+      }
+      case REMOVE_RELATIONSHIP_COLUMN -> {
+        RemoveRelationshipColumnCommand command = requirePayload(payload, RemoveRelationshipColumnCommand.class);
+        yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
+      }
+      case CHANGE_RELATIONSHIP_COLUMN_POSITION -> {
+        ChangeRelationshipColumnPositionCommand command = requirePayload(payload,
+            ChangeRelationshipColumnPositionCommand.class);
+        yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
+      }
     };
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeTableName(Object payload) {
+    if (payload instanceof ChangeTableNameInverse inverse) {
+      return resolveByTableId(inverse.tableId(), inverse.tableId());
+    }
+    ChangeTableNameCommand command = requirePayload(payload, ChangeTableNameCommand.class);
+    return resolveByTableId(command.tableId(), command.tableId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeColumnName(Object payload) {
+    if (payload instanceof ChangeColumnNameInverse inverse) {
+      return resolveByColumnId(inverse.columnId(), inverse.columnId());
+    }
+    ChangeColumnNameCommand command = requirePayload(payload, ChangeColumnNameCommand.class);
+    return resolveByColumnId(command.columnId(), command.columnId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeColumnType(Object payload) {
+    if (payload instanceof ChangeColumnTypeInverse inverse) {
+      return resolveByColumnId(inverse.columnId(), inverse.columnId());
+    }
+    ChangeColumnTypeCommand command = requirePayload(payload, ChangeColumnTypeCommand.class);
+    return resolveByColumnId(command.columnId(), command.columnId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeConstraintName(Object payload) {
+    if (payload instanceof ChangeConstraintNameInverse inverse) {
+      return resolveByConstraintId(inverse.constraintId(), inverse.constraintId());
+    }
+    ChangeConstraintNameCommand command = requirePayload(payload, ChangeConstraintNameCommand.class);
+    return resolveByConstraintId(command.constraintId(), command.constraintId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeIndexName(Object payload) {
+    if (payload instanceof ChangeIndexNameInverse inverse) {
+      return resolveByIndexId(inverse.indexId(), inverse.indexId());
+    }
+    ChangeIndexNameCommand command = requirePayload(payload, ChangeIndexNameCommand.class);
+    return resolveByIndexId(command.indexId(), command.indexId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeIndexType(Object payload) {
+    if (payload instanceof ChangeIndexTypeInverse inverse) {
+      return resolveByIndexId(inverse.indexId(), inverse.indexId());
+    }
+    ChangeIndexTypeCommand command = requirePayload(payload, ChangeIndexTypeCommand.class);
+    return resolveByIndexId(command.indexId(), command.indexId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeRelationshipName(Object payload) {
+    if (payload instanceof ChangeRelationshipNameInverse inverse) {
+      return resolveByRelationshipId(inverse.relationshipId(), inverse.relationshipId());
+    }
+    ChangeRelationshipNameCommand command = requirePayload(payload, ChangeRelationshipNameCommand.class);
+    return resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+  }
+
+  private Mono<ResolvedErdMutationTarget> resolveChangeRelationshipCardinality(Object payload) {
+    if (payload instanceof ChangeRelationshipCardinalityInverse inverse) {
+      return resolveByRelationshipId(inverse.relationshipId(), inverse.relationshipId());
+    }
+    ChangeRelationshipCardinalityCommand command = requirePayload(payload,
+        ChangeRelationshipCardinalityCommand.class);
+    return resolveByRelationshipId(command.relationshipId(), command.relationshipId());
   }
 
   <T> FinalizedErdMutationTarget finalizeTarget(
@@ -279,16 +327,16 @@ class ErdMutationTargetResolver {
   private <T> String resolveCreatedEntityId(ErdOperationType operationType, MutationResult<T> mutationResult) {
     Object result = mutationResult.result();
     return switch (operationType) {
-    case CREATE_SCHEMA -> requireResult(result, CreateSchemaResult.class).id();
-    case CREATE_TABLE -> requireResult(result, CreateTableResult.class).tableId();
-    case CREATE_COLUMN -> requireResult(result, CreateColumnResult.class).columnId();
-    case CREATE_CONSTRAINT -> requireResult(result, CreateConstraintResult.class).constraintId();
-    case ADD_CONSTRAINT_COLUMN -> requireResult(result, AddConstraintColumnResult.class).constraintColumnId();
-    case CREATE_INDEX -> requireResult(result, CreateIndexResult.class).indexId();
-    case ADD_INDEX_COLUMN -> requireResult(result, AddIndexColumnResult.class).indexColumnId();
-    case CREATE_RELATIONSHIP -> requireResult(result, CreateRelationshipResult.class).relationshipId();
-    case ADD_RELATIONSHIP_COLUMN -> requireResult(result, AddRelationshipColumnResult.class).relationshipColumnId();
-    default -> throw new IllegalArgumentException("Unsupported create operation: " + operationType);
+      case CREATE_SCHEMA -> requireResult(result, CreateSchemaResult.class).id();
+      case CREATE_TABLE -> requireResult(result, CreateTableResult.class).tableId();
+      case CREATE_COLUMN -> requireResult(result, CreateColumnResult.class).columnId();
+      case CREATE_CONSTRAINT -> requireResult(result, CreateConstraintResult.class).constraintId();
+      case ADD_CONSTRAINT_COLUMN -> requireResult(result, AddConstraintColumnResult.class).constraintColumnId();
+      case CREATE_INDEX -> requireResult(result, CreateIndexResult.class).indexId();
+      case ADD_INDEX_COLUMN -> requireResult(result, AddIndexColumnResult.class).indexColumnId();
+      case CREATE_RELATIONSHIP -> requireResult(result, CreateRelationshipResult.class).relationshipId();
+      case ADD_RELATIONSHIP_COLUMN -> requireResult(result, AddRelationshipColumnResult.class).relationshipColumnId();
+      default -> throw new IllegalArgumentException("Unsupported create operation: " + operationType);
     };
   }
 
@@ -403,6 +451,7 @@ class ErdMutationTargetResolver {
       String projectId,
       String schemaId,
       ErdTouchedEntity touchedEntity) {
+
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ErdMutationTargetResolver.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ErdMutationTargetResolver.java
@@ -99,142 +99,142 @@ class ErdMutationTargetResolver {
 
   Mono<ResolvedErdMutationTarget> resolveBefore(ErdOperationType operationType, Object payload) {
     return switch (operationType) {
-      case CREATE_SCHEMA -> {
-        CreateSchemaCommand command = requirePayload(payload, CreateSchemaCommand.class);
-        yield Mono.just(new ResolvedErdMutationTarget(command.projectId(), null, null));
-      }
-      case CHANGE_SCHEMA_NAME -> {
-        ChangeSchemaNameCommand command = requirePayload(payload, ChangeSchemaNameCommand.class);
-        yield resolveBySchemaId(command.schemaId(), command.schemaId());
-      }
-      case DELETE_SCHEMA -> {
-        DeleteSchemaCommand command = requirePayload(payload, DeleteSchemaCommand.class);
-        yield resolveBySchemaId(command.schemaId(), command.schemaId());
-      }
-      case CREATE_TABLE -> {
-        CreateTableCommand command = requirePayload(payload, CreateTableCommand.class);
-        yield resolveSchemaContext(command.schemaId());
-      }
-      case CHANGE_TABLE_NAME -> resolveChangeTableName(payload);
-      case CHANGE_TABLE_META -> {
-        ChangeTableMetaCommand command = requirePayload(payload, ChangeTableMetaCommand.class);
-        yield resolveByTableId(command.tableId(), command.tableId());
-      }
-      case CHANGE_TABLE_EXTRA -> {
-        ChangeTableExtraCommand command = requirePayload(payload, ChangeTableExtraCommand.class);
-        yield resolveByTableId(command.tableId(), command.tableId());
-      }
-      case DELETE_TABLE -> {
-        DeleteTableCommand command = requirePayload(payload, DeleteTableCommand.class);
-        yield resolveByTableId(command.tableId(), command.tableId());
-      }
-      case CREATE_COLUMN -> {
-        CreateColumnCommand command = requirePayload(payload, CreateColumnCommand.class);
-        yield resolveTableContext(command.tableId());
-      }
-      case CHANGE_COLUMN_NAME -> resolveChangeColumnName(payload);
-      case CHANGE_COLUMN_TYPE -> resolveChangeColumnType(payload);
-      case CHANGE_COLUMN_META -> {
-        ChangeColumnMetaCommand command = requirePayload(payload, ChangeColumnMetaCommand.class);
-        yield resolveByColumnId(command.columnId(), command.columnId());
-      }
-      case CHANGE_COLUMN_POSITION -> {
-        ChangeColumnPositionCommand command = requirePayload(payload, ChangeColumnPositionCommand.class);
-        yield resolveByColumnId(command.columnId(), command.columnId());
-      }
-      case DELETE_COLUMN -> {
-        DeleteColumnCommand command = requirePayload(payload, DeleteColumnCommand.class);
-        yield resolveByColumnId(command.columnId(), command.columnId());
-      }
-      case CREATE_CONSTRAINT -> {
-        CreateConstraintCommand command = requirePayload(payload, CreateConstraintCommand.class);
-        yield resolveTableContext(command.tableId());
-      }
-      case CHANGE_CONSTRAINT_NAME -> resolveChangeConstraintName(payload);
-      case CHANGE_CONSTRAINT_CHECK_EXPR -> {
-        ChangeConstraintCheckExprCommand command = requirePayload(payload, ChangeConstraintCheckExprCommand.class);
-        yield resolveByConstraintId(command.constraintId(), command.constraintId());
-      }
-      case CHANGE_CONSTRAINT_DEFAULT_EXPR -> {
-        ChangeConstraintDefaultExprCommand command = requirePayload(payload, ChangeConstraintDefaultExprCommand.class);
-        yield resolveByConstraintId(command.constraintId(), command.constraintId());
-      }
-      case DELETE_CONSTRAINT -> {
-        DeleteConstraintCommand command = requirePayload(payload, DeleteConstraintCommand.class);
-        yield resolveByConstraintId(command.constraintId(), command.constraintId());
-      }
-      case ADD_CONSTRAINT_COLUMN -> {
-        AddConstraintColumnCommand command = requirePayload(payload, AddConstraintColumnCommand.class);
-        yield resolveByConstraintId(command.constraintId(), null);
-      }
-      case REMOVE_CONSTRAINT_COLUMN -> {
-        RemoveConstraintColumnCommand command = requirePayload(payload, RemoveConstraintColumnCommand.class);
-        yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
-      }
-      case CHANGE_CONSTRAINT_COLUMN_POSITION -> {
-        ChangeConstraintColumnPositionCommand command = requirePayload(payload,
-            ChangeConstraintColumnPositionCommand.class);
-        yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
-      }
-      case CREATE_INDEX -> {
-        CreateIndexCommand command = requirePayload(payload, CreateIndexCommand.class);
-        yield resolveTableContext(command.tableId());
-      }
-      case CHANGE_INDEX_NAME -> resolveChangeIndexName(payload);
-      case CHANGE_INDEX_TYPE -> resolveChangeIndexType(payload);
-      case DELETE_INDEX -> {
-        DeleteIndexCommand command = requirePayload(payload, DeleteIndexCommand.class);
-        yield resolveByIndexId(command.indexId(), command.indexId());
-      }
-      case ADD_INDEX_COLUMN -> {
-        AddIndexColumnCommand command = requirePayload(payload, AddIndexColumnCommand.class);
-        yield resolveByIndexId(command.indexId(), null);
-      }
-      case REMOVE_INDEX_COLUMN -> {
-        RemoveIndexColumnCommand command = requirePayload(payload, RemoveIndexColumnCommand.class);
-        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-      }
-      case CHANGE_INDEX_COLUMN_POSITION -> {
-        ChangeIndexColumnPositionCommand command = requirePayload(payload,
-            ChangeIndexColumnPositionCommand.class);
-        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-      }
-      case CHANGE_INDEX_COLUMN_SORT_DIRECTION -> {
-        ChangeIndexColumnSortDirectionCommand command = requirePayload(payload,
-            ChangeIndexColumnSortDirectionCommand.class);
-        yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
-      }
-      case CREATE_RELATIONSHIP -> {
-        CreateRelationshipCommand command = requirePayload(payload, CreateRelationshipCommand.class);
-        yield resolveTableContext(command.fkTableId());
-      }
-      case CHANGE_RELATIONSHIP_NAME -> resolveChangeRelationshipName(payload);
-      case CHANGE_RELATIONSHIP_KIND -> {
-        ChangeRelationshipKindCommand command = requirePayload(payload, ChangeRelationshipKindCommand.class);
-        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-      }
-      case CHANGE_RELATIONSHIP_CARDINALITY -> resolveChangeRelationshipCardinality(payload);
-      case CHANGE_RELATIONSHIP_EXTRA -> {
-        ChangeRelationshipExtraCommand command = requirePayload(payload, ChangeRelationshipExtraCommand.class);
-        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-      }
-      case DELETE_RELATIONSHIP -> {
-        DeleteRelationshipCommand command = requirePayload(payload, DeleteRelationshipCommand.class);
-        yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
-      }
-      case ADD_RELATIONSHIP_COLUMN -> {
-        AddRelationshipColumnCommand command = requirePayload(payload, AddRelationshipColumnCommand.class);
-        yield resolveByRelationshipId(command.relationshipId(), null);
-      }
-      case REMOVE_RELATIONSHIP_COLUMN -> {
-        RemoveRelationshipColumnCommand command = requirePayload(payload, RemoveRelationshipColumnCommand.class);
-        yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
-      }
-      case CHANGE_RELATIONSHIP_COLUMN_POSITION -> {
-        ChangeRelationshipColumnPositionCommand command = requirePayload(payload,
-            ChangeRelationshipColumnPositionCommand.class);
-        yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
-      }
+    case CREATE_SCHEMA -> {
+      CreateSchemaCommand command = requirePayload(payload, CreateSchemaCommand.class);
+      yield Mono.just(new ResolvedErdMutationTarget(command.projectId(), null, null));
+    }
+    case CHANGE_SCHEMA_NAME -> {
+      ChangeSchemaNameCommand command = requirePayload(payload, ChangeSchemaNameCommand.class);
+      yield resolveBySchemaId(command.schemaId(), command.schemaId());
+    }
+    case DELETE_SCHEMA -> {
+      DeleteSchemaCommand command = requirePayload(payload, DeleteSchemaCommand.class);
+      yield resolveBySchemaId(command.schemaId(), command.schemaId());
+    }
+    case CREATE_TABLE -> {
+      CreateTableCommand command = requirePayload(payload, CreateTableCommand.class);
+      yield resolveSchemaContext(command.schemaId());
+    }
+    case CHANGE_TABLE_NAME -> resolveChangeTableName(payload);
+    case CHANGE_TABLE_META -> {
+      ChangeTableMetaCommand command = requirePayload(payload, ChangeTableMetaCommand.class);
+      yield resolveByTableId(command.tableId(), command.tableId());
+    }
+    case CHANGE_TABLE_EXTRA -> {
+      ChangeTableExtraCommand command = requirePayload(payload, ChangeTableExtraCommand.class);
+      yield resolveByTableId(command.tableId(), command.tableId());
+    }
+    case DELETE_TABLE -> {
+      DeleteTableCommand command = requirePayload(payload, DeleteTableCommand.class);
+      yield resolveByTableId(command.tableId(), command.tableId());
+    }
+    case CREATE_COLUMN -> {
+      CreateColumnCommand command = requirePayload(payload, CreateColumnCommand.class);
+      yield resolveTableContext(command.tableId());
+    }
+    case CHANGE_COLUMN_NAME -> resolveChangeColumnName(payload);
+    case CHANGE_COLUMN_TYPE -> resolveChangeColumnType(payload);
+    case CHANGE_COLUMN_META -> {
+      ChangeColumnMetaCommand command = requirePayload(payload, ChangeColumnMetaCommand.class);
+      yield resolveByColumnId(command.columnId(), command.columnId());
+    }
+    case CHANGE_COLUMN_POSITION -> {
+      ChangeColumnPositionCommand command = requirePayload(payload, ChangeColumnPositionCommand.class);
+      yield resolveByColumnId(command.columnId(), command.columnId());
+    }
+    case DELETE_COLUMN -> {
+      DeleteColumnCommand command = requirePayload(payload, DeleteColumnCommand.class);
+      yield resolveByColumnId(command.columnId(), command.columnId());
+    }
+    case CREATE_CONSTRAINT -> {
+      CreateConstraintCommand command = requirePayload(payload, CreateConstraintCommand.class);
+      yield resolveTableContext(command.tableId());
+    }
+    case CHANGE_CONSTRAINT_NAME -> resolveChangeConstraintName(payload);
+    case CHANGE_CONSTRAINT_CHECK_EXPR -> {
+      ChangeConstraintCheckExprCommand command = requirePayload(payload, ChangeConstraintCheckExprCommand.class);
+      yield resolveByConstraintId(command.constraintId(), command.constraintId());
+    }
+    case CHANGE_CONSTRAINT_DEFAULT_EXPR -> {
+      ChangeConstraintDefaultExprCommand command = requirePayload(payload, ChangeConstraintDefaultExprCommand.class);
+      yield resolveByConstraintId(command.constraintId(), command.constraintId());
+    }
+    case DELETE_CONSTRAINT -> {
+      DeleteConstraintCommand command = requirePayload(payload, DeleteConstraintCommand.class);
+      yield resolveByConstraintId(command.constraintId(), command.constraintId());
+    }
+    case ADD_CONSTRAINT_COLUMN -> {
+      AddConstraintColumnCommand command = requirePayload(payload, AddConstraintColumnCommand.class);
+      yield resolveByConstraintId(command.constraintId(), null);
+    }
+    case REMOVE_CONSTRAINT_COLUMN -> {
+      RemoveConstraintColumnCommand command = requirePayload(payload, RemoveConstraintColumnCommand.class);
+      yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
+    }
+    case CHANGE_CONSTRAINT_COLUMN_POSITION -> {
+      ChangeConstraintColumnPositionCommand command = requirePayload(payload,
+          ChangeConstraintColumnPositionCommand.class);
+      yield resolveByConstraintColumnId(command.constraintColumnId(), command.constraintColumnId());
+    }
+    case CREATE_INDEX -> {
+      CreateIndexCommand command = requirePayload(payload, CreateIndexCommand.class);
+      yield resolveTableContext(command.tableId());
+    }
+    case CHANGE_INDEX_NAME -> resolveChangeIndexName(payload);
+    case CHANGE_INDEX_TYPE -> resolveChangeIndexType(payload);
+    case DELETE_INDEX -> {
+      DeleteIndexCommand command = requirePayload(payload, DeleteIndexCommand.class);
+      yield resolveByIndexId(command.indexId(), command.indexId());
+    }
+    case ADD_INDEX_COLUMN -> {
+      AddIndexColumnCommand command = requirePayload(payload, AddIndexColumnCommand.class);
+      yield resolveByIndexId(command.indexId(), null);
+    }
+    case REMOVE_INDEX_COLUMN -> {
+      RemoveIndexColumnCommand command = requirePayload(payload, RemoveIndexColumnCommand.class);
+      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+    }
+    case CHANGE_INDEX_COLUMN_POSITION -> {
+      ChangeIndexColumnPositionCommand command = requirePayload(payload,
+          ChangeIndexColumnPositionCommand.class);
+      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+    }
+    case CHANGE_INDEX_COLUMN_SORT_DIRECTION -> {
+      ChangeIndexColumnSortDirectionCommand command = requirePayload(payload,
+          ChangeIndexColumnSortDirectionCommand.class);
+      yield resolveByIndexColumnId(command.indexColumnId(), command.indexColumnId());
+    }
+    case CREATE_RELATIONSHIP -> {
+      CreateRelationshipCommand command = requirePayload(payload, CreateRelationshipCommand.class);
+      yield resolveTableContext(command.fkTableId());
+    }
+    case CHANGE_RELATIONSHIP_NAME -> resolveChangeRelationshipName(payload);
+    case CHANGE_RELATIONSHIP_KIND -> {
+      ChangeRelationshipKindCommand command = requirePayload(payload, ChangeRelationshipKindCommand.class);
+      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+    }
+    case CHANGE_RELATIONSHIP_CARDINALITY -> resolveChangeRelationshipCardinality(payload);
+    case CHANGE_RELATIONSHIP_EXTRA -> {
+      ChangeRelationshipExtraCommand command = requirePayload(payload, ChangeRelationshipExtraCommand.class);
+      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+    }
+    case DELETE_RELATIONSHIP -> {
+      DeleteRelationshipCommand command = requirePayload(payload, DeleteRelationshipCommand.class);
+      yield resolveByRelationshipId(command.relationshipId(), command.relationshipId());
+    }
+    case ADD_RELATIONSHIP_COLUMN -> {
+      AddRelationshipColumnCommand command = requirePayload(payload, AddRelationshipColumnCommand.class);
+      yield resolveByRelationshipId(command.relationshipId(), null);
+    }
+    case REMOVE_RELATIONSHIP_COLUMN -> {
+      RemoveRelationshipColumnCommand command = requirePayload(payload, RemoveRelationshipColumnCommand.class);
+      yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
+    }
+    case CHANGE_RELATIONSHIP_COLUMN_POSITION -> {
+      ChangeRelationshipColumnPositionCommand command = requirePayload(payload,
+          ChangeRelationshipColumnPositionCommand.class);
+      yield resolveByRelationshipColumnId(command.relationshipColumnId(), command.relationshipColumnId());
+    }
     };
   }
 
@@ -327,16 +327,16 @@ class ErdMutationTargetResolver {
   private <T> String resolveCreatedEntityId(ErdOperationType operationType, MutationResult<T> mutationResult) {
     Object result = mutationResult.result();
     return switch (operationType) {
-      case CREATE_SCHEMA -> requireResult(result, CreateSchemaResult.class).id();
-      case CREATE_TABLE -> requireResult(result, CreateTableResult.class).tableId();
-      case CREATE_COLUMN -> requireResult(result, CreateColumnResult.class).columnId();
-      case CREATE_CONSTRAINT -> requireResult(result, CreateConstraintResult.class).constraintId();
-      case ADD_CONSTRAINT_COLUMN -> requireResult(result, AddConstraintColumnResult.class).constraintColumnId();
-      case CREATE_INDEX -> requireResult(result, CreateIndexResult.class).indexId();
-      case ADD_INDEX_COLUMN -> requireResult(result, AddIndexColumnResult.class).indexColumnId();
-      case CREATE_RELATIONSHIP -> requireResult(result, CreateRelationshipResult.class).relationshipId();
-      case ADD_RELATIONSHIP_COLUMN -> requireResult(result, AddRelationshipColumnResult.class).relationshipColumnId();
-      default -> throw new IllegalArgumentException("Unsupported create operation: " + operationType);
+    case CREATE_SCHEMA -> requireResult(result, CreateSchemaResult.class).id();
+    case CREATE_TABLE -> requireResult(result, CreateTableResult.class).tableId();
+    case CREATE_COLUMN -> requireResult(result, CreateColumnResult.class).columnId();
+    case CREATE_CONSTRAINT -> requireResult(result, CreateConstraintResult.class).constraintId();
+    case ADD_CONSTRAINT_COLUMN -> requireResult(result, AddConstraintColumnResult.class).constraintColumnId();
+    case CREATE_INDEX -> requireResult(result, CreateIndexResult.class).indexId();
+    case ADD_INDEX_COLUMN -> requireResult(result, AddIndexColumnResult.class).indexColumnId();
+    case CREATE_RELATIONSHIP -> requireResult(result, CreateRelationshipResult.class).relationshipId();
+    case ADD_RELATIONSHIP_COLUMN -> requireResult(result, AddRelationshipColumnResult.class).relationshipColumnId();
+    default -> throw new IllegalArgumentException("Unsupported create operation: " + operationType);
     };
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ResolvedUndoRedoEligibility.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/ResolvedUndoRedoEligibility.java
@@ -16,9 +16,7 @@ public record ResolvedUndoRedoEligibility(
   }
 
   public ErdOperationLog executionBaseOperation() {
-    return action == UndoRedoAction.UNDO
-        ? currentChainTipOperation
-        : targetRootOriginalOperation;
+    return currentChainTipOperation;
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/exception/OperationErrorCode.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/domain/exception/OperationErrorCode.java
@@ -16,6 +16,7 @@ public enum OperationErrorCode implements DomainErrorCode {
   SUPERSEDED(HttpStatus.CONFLICT),
   ALREADY_UNDONE(HttpStatus.CONFLICT),
   REDO_NOT_ELIGIBLE(HttpStatus.CONFLICT),
+  INVERSE_PAYLOAD_MISSING(HttpStatus.CONFLICT),
   UNSUPPORTED(HttpStatus.CONFLICT);
 
   private final HttpStatus status;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipCardinalityService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipCardinalityService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.schemafy.core.common.MutationResult;
 import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipCardinalityInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.in.ChangeRelationshipCardinalityCommand;
@@ -48,7 +49,10 @@ public class ChangeRelationshipCardinalityService implements ChangeRelationshipC
               affectedTableIds.add(relationship.pkTableId());
               return changeRelationshipCardinalityPort
                   .changeRelationshipCardinality(relationship.id(), command.cardinality())
-                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                  .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
+                      .withInverse(new ChangeRelationshipCardinalityInverse(
+                          relationship.id(),
+                          relationship.cardinality())));
             }));
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipNameService.java
@@ -45,9 +45,9 @@ public class ChangeRelationshipNameService implements ChangeRelationshipNameUseC
           return getRelationshipByIdPort.findRelationshipById(command.relationshipId())
               .switchIfEmpty(Mono.error(new DomainException(RelationshipErrorCode.NOT_FOUND, "Relationship not found")))
               .flatMap(relationship -> relationshipExistsPort.existsByFkTableIdAndNameExcludingId(
-                      relationship.fkTableId(),
-                      normalizedName,
-                      relationship.id())
+                  relationship.fkTableId(),
+                  normalizedName,
+                  relationship.id())
                   .flatMap(exists -> {
                     if (exists) {
                       return Mono.error(new DomainException(RelationshipErrorCode.NAME_DUPLICATE,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/ChangeRelationshipNameService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.schemafy.core.common.MutationResult;
 import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.erd.operation.application.inverse.ChangeRelationshipNameInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.in.ChangeRelationshipNameCommand;
@@ -44,9 +45,9 @@ public class ChangeRelationshipNameService implements ChangeRelationshipNameUseC
           return getRelationshipByIdPort.findRelationshipById(command.relationshipId())
               .switchIfEmpty(Mono.error(new DomainException(RelationshipErrorCode.NOT_FOUND, "Relationship not found")))
               .flatMap(relationship -> relationshipExistsPort.existsByFkTableIdAndNameExcludingId(
-                  relationship.fkTableId(),
-                  normalizedName,
-                  relationship.id())
+                      relationship.fkTableId(),
+                      normalizedName,
+                      relationship.id())
                   .flatMap(exists -> {
                     if (exists) {
                       return Mono.error(new DomainException(RelationshipErrorCode.NAME_DUPLICATE,
@@ -57,7 +58,10 @@ public class ChangeRelationshipNameService implements ChangeRelationshipNameUseC
                     affectedTableIds.add(relationship.pkTableId());
                     return changeRelationshipNamePort
                         .changeRelationshipName(relationship.id(), normalizedName)
-                        .thenReturn(MutationResult.<Void>of(null, affectedTableIds));
+                        .thenReturn(MutationResult.<Void>of(null, affectedTableIds)
+                            .withInverse(new ChangeRelationshipNameInverse(
+                                relationship.id(),
+                                relationship.name())));
                   }));
         }));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
@@ -1,8 +1,9 @@
 package com.schemafy.core.erd.table.application.service;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,9 @@ import com.schemafy.core.erd.constraint.application.port.out.ConstraintExistsPor
 import com.schemafy.core.erd.constraint.application.port.out.GetConstraintsByTableIdPort;
 import com.schemafy.core.erd.constraint.domain.Constraint;
 import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse.ConstraintRename;
+import com.schemafy.core.erd.operation.application.inverse.ChangeTableNameInverse.RelationshipRename;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.out.ChangeRelationshipNamePort;
@@ -58,106 +62,183 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
   @Override
   public Mono<MutationResult<Void>> changeTableName(ChangeTableNameCommand command) {
     return erdMutationCoordinator.coordinate(ErdOperationType.CHANGE_TABLE_NAME, command,
-        () -> getTableByIdPort.findTableById(command.tableId())
-            .switchIfEmpty(Mono.error(
-                new DomainException(TableErrorCode.NOT_FOUND, "Table not found: " + command.tableId())))
-            .flatMap(table -> tableExistsPort.existsBySchemaIdAndName(table.schemaId(), command.newName())
-                .flatMap(exists -> {
-                  if (exists) {
-                    return Mono.error(new DomainException(TableErrorCode.NAME_DUPLICATE,
-                        "A table with the name '" + command.newName() + "' already exists in the schema."));
-                  }
+            () -> getTableByIdPort.findTableById(command.tableId())
+                .switchIfEmpty(Mono.error(
+                    new DomainException(TableErrorCode.NOT_FOUND, "Table not found: " + command.tableId())))
+                .flatMap(table -> tableExistsPort.existsBySchemaIdAndName(table.schemaId(), command.newName())
+                    .flatMap(exists -> {
+                      if (exists) {
+                        return Mono.error(new DomainException(TableErrorCode.NAME_DUPLICATE,
+                            "A table with the name '" + command.newName() + "' already exists in the schema."));
+                      }
 
-                  return changeTableNamePort.changeTableName(
-                      command.tableId(),
-                      command.newName())
-                      .then(renamePkConstraint(table.schemaId(), command.tableId(), command.newName()))
-                      .then(renameAutoRelationshipNames(table, command.newName()))
-                      .thenReturn(MutationResult.<Void>of(null, table.id()));
-                })))
+                      return buildRenamePlan(table, command.newName())
+                          .flatMap(plan -> changeTableNamePort.changeTableName(
+                                  command.tableId(),
+                                  command.newName())
+                              .then(applyConstraintRenames(plan.constraintRenames()))
+                              .then(applyRelationshipRenames(plan.relationshipRenames()))
+                              .thenReturn(MutationResult.<Void>of(null, table.id())
+                                  .withInverse(plan.toInverse(table))));
+                    })))
         .as(transactionalOperator::transactional);
   }
 
-  private Mono<Void> renamePkConstraint(String schemaId, String tableId, String newTableName) {
-    return getConstraintsByTableIdPort.findConstraintsByTableId(tableId)
-        .defaultIfEmpty(List.of())
-        .flatMap(constraints -> {
-          Optional<Constraint> pkOpt = constraints.stream()
-              .filter(c -> c.kind() == ConstraintKind.PRIMARY_KEY)
-              .findFirst();
+  private Mono<TableRenamePlan> buildRenamePlan(Table oldTable, String newTableName) {
+    Set<String> reservedConstraintNames = new HashSet<>();
+    Set<String> reservedRelationshipNames = new HashSet<>();
+    Mono<List<ConstraintRenamePlan>> constraintRenames = buildAutoConstraintRenamePlans(
+        oldTable,
+        newTableName,
+        reservedConstraintNames);
+    Mono<List<RelationshipRenamePlan>> relationshipRenames = buildAutoRelationshipRenamePlans(
+        oldTable,
+        newTableName,
+        reservedRelationshipNames);
 
-          if (pkOpt.isEmpty()) {
+    return Mono.zip(constraintRenames, relationshipRenames)
+        .map(tuple -> new TableRenamePlan(tuple.getT1(), tuple.getT2()));
+  }
+
+  private Mono<List<ConstraintRenamePlan>> buildAutoConstraintRenamePlans(
+      Table oldTable,
+      String newTableName,
+      Set<String> reservedConstraintNames) {
+    return getConstraintsByTableIdPort.findConstraintsByTableId(oldTable.id())
+        .defaultIfEmpty(List.of())
+        .flatMapMany(Flux::fromIterable)
+        .concatMap(constraint -> buildAutoConstraintRenamePlan(
+            constraint,
+            oldTable,
+            newTableName,
+            reservedConstraintNames))
+        .collectList();
+  }
+
+  private Mono<ConstraintRenamePlan> buildAutoConstraintRenamePlan(
+      Constraint constraint,
+      Table oldTable,
+      String newTableName,
+      Set<String> reservedConstraintNames) {
+    String prefix = constraintKindPrefix(constraint.kind());
+    String oldBaseName = normalizeName(prefix + oldTable.name());
+    OptionalInt suffixOpt = parseAutoNameSuffix(constraint.name(), oldBaseName);
+    if (suffixOpt.isEmpty()) {
+      return Mono.empty();
+    }
+    String newBaseName = normalizeName(prefix + newTableName);
+    int suffix = suffixOpt.getAsInt();
+    return resolveUniqueConstraintName(
+        oldTable.schemaId(),
+        newBaseName,
+        constraint.id(),
+        suffix,
+        reservedConstraintNames)
+        .flatMap(newName -> {
+          if (newName.equals(constraint.name())) {
             return Mono.empty();
           }
-
-          String baseName = "pk_" + newTableName;
-          return resolveUniqueConstraintName(schemaId, baseName, pkOpt.get().id())
-              .flatMap(newName -> changeConstraintNamePort.changeConstraintName(
-                  pkOpt.get().id(), newName));
+          reservedConstraintNames.add(newName);
+          return Mono.just(new ConstraintRenamePlan(
+              constraint.id(),
+              constraint.kind(),
+              constraint.name(),
+              newName));
         });
   }
 
-  private Mono<String> resolveUniqueConstraintName(
-      String schemaId, String baseName, String excludeId) {
-    return resolveUniqueConstraintName(schemaId, baseName, excludeId, 0);
+  private Mono<Void> applyConstraintRenames(List<ConstraintRenamePlan> plans) {
+    return Flux.fromIterable(plans)
+        .concatMap(plan -> changeConstraintNamePort.changeConstraintName(
+            plan.constraintId(),
+            plan.newName()))
+        .then();
   }
 
   private Mono<String> resolveUniqueConstraintName(
-      String schemaId, String baseName, String excludeId, int suffix) {
+      String schemaId,
+      String baseName,
+      String excludeId,
+      int suffix,
+      Set<String> reservedConstraintNames) {
     String candidate = suffix == 0 ? baseName : baseName + "_" + suffix;
+    if (reservedConstraintNames.contains(candidate)) {
+      return resolveUniqueConstraintName(
+          schemaId,
+          baseName,
+          excludeId,
+          suffix + 1,
+          reservedConstraintNames);
+    }
     return constraintExistsPort.existsBySchemaIdAndNameExcludingId(schemaId, candidate, excludeId)
         .flatMap(exists -> {
           if (exists) {
-            return resolveUniqueConstraintName(schemaId, baseName, excludeId, suffix + 1);
+            return resolveUniqueConstraintName(
+                schemaId,
+                baseName,
+                excludeId,
+                suffix + 1,
+                reservedConstraintNames);
           }
           return Mono.just(candidate);
         });
   }
 
-  private Mono<Void> renameAutoRelationshipNames(Table oldTable, String newTableName) {
+  private Mono<List<RelationshipRenamePlan>> buildAutoRelationshipRenamePlans(
+      Table oldTable,
+      String newTableName,
+      Set<String> reservedRelationshipNames) {
     return getRelationshipsByTableIdPort.findRelationshipsByTableId(oldTable.id())
         .defaultIfEmpty(List.of())
         .flatMapMany(Flux::fromIterable)
-        .concatMap(relationship -> renameAutoRelationshipName(relationship, oldTable, newTableName))
-        .then();
+        .concatMap(relationship -> buildAutoRelationshipRenamePlan(
+            relationship,
+            oldTable,
+            newTableName,
+            reservedRelationshipNames))
+        .collectList();
   }
 
-  private Mono<Void> renameAutoRelationshipName(
+  private Mono<RelationshipRenamePlan> buildAutoRelationshipRenamePlan(
       Relationship relationship,
       Table oldTable,
-      String newTableName) {
+      String newTableName,
+      Set<String> reservedRelationshipNames) {
     boolean isFkRenamed = relationship.fkTableId().equals(oldTable.id());
     boolean isPkRenamed = relationship.pkTableId().equals(oldTable.id());
     if (!isFkRenamed && !isPkRenamed) {
       return Mono.empty();
     }
     if (isFkRenamed && isPkRenamed) {
-      return renameAutoRelationshipName(
+      return buildAutoRelationshipRenamePlan(
           relationship,
           oldTable.name(),
           oldTable.name(),
           newTableName,
-          newTableName);
+          newTableName,
+          reservedRelationshipNames);
     }
     String otherTableId = isFkRenamed ? relationship.pkTableId() : relationship.fkTableId();
     return getTableByIdPort.findTableById(otherTableId)
-        .flatMap(otherTable -> renameAutoRelationshipName(
+        .flatMap(otherTable -> buildAutoRelationshipRenamePlan(
             relationship,
             isFkRenamed ? oldTable.name() : otherTable.name(),
             isPkRenamed ? oldTable.name() : otherTable.name(),
             isFkRenamed ? newTableName : otherTable.name(),
-            isPkRenamed ? newTableName : otherTable.name()))
+            isPkRenamed ? newTableName : otherTable.name(),
+            reservedRelationshipNames))
         .switchIfEmpty(Mono.empty());
   }
 
-  private Mono<Void> renameAutoRelationshipName(
+  private Mono<RelationshipRenamePlan> buildAutoRelationshipRenamePlan(
       Relationship relationship,
       String oldFkName,
       String oldPkName,
       String newFkName,
-      String newPkName) {
+      String newPkName,
+      Set<String> reservedRelationshipNames) {
     String oldBaseName = normalizeName("rel_" + oldFkName + "_to_" + oldPkName);
-    OptionalInt suffixOpt = parseAutoRelationshipSuffix(relationship.name(), oldBaseName);
+    OptionalInt suffixOpt = parseAutoNameSuffix(relationship.name(), oldBaseName);
     if (suffixOpt.isEmpty()) {
       return Mono.empty();
     }
@@ -167,7 +248,8 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
         relationship.fkTableId(),
         newBaseName,
         relationship.id(),
-        suffix)
+        suffix,
+        reservedRelationshipNames)
         .flatMap(newName -> {
           if (newName.equals(relationship.name())) {
             return Mono.empty();
@@ -175,38 +257,65 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
           if (!isValidRelationshipName(newName)) {
             return Mono.empty();
           }
-          return changeRelationshipNamePort.changeRelationshipName(relationship.id(), newName);
+          reservedRelationshipNames.add(relationshipNameKey(relationship.fkTableId(), newName));
+          return Mono.just(new RelationshipRenamePlan(relationship.id(), relationship.name(), newName));
         });
+  }
+
+  private Mono<Void> applyRelationshipRenames(List<RelationshipRenamePlan> plans) {
+    return Flux.fromIterable(plans)
+        .concatMap(plan -> changeRelationshipNamePort.changeRelationshipName(
+            plan.relationshipId(),
+            plan.newName()))
+        .then();
   }
 
   private Mono<String> resolveUniqueRelationshipName(
       String fkTableId,
       String baseName,
       String excludeId,
-      int suffix) {
+      int suffix,
+      Set<String> reservedRelationshipNames) {
     String candidate = suffix == 0 ? baseName : baseName + "_" + suffix;
+    if (reservedRelationshipNames.contains(relationshipNameKey(fkTableId, candidate))) {
+      return resolveUniqueRelationshipName(
+          fkTableId,
+          baseName,
+          excludeId,
+          suffix + 1,
+          reservedRelationshipNames);
+    }
     return relationshipExistsPort
         .existsByFkTableIdAndNameExcludingId(fkTableId, candidate, excludeId)
         .flatMap(exists -> {
           if (exists) {
-            return resolveUniqueRelationshipName(fkTableId, baseName, excludeId, suffix + 1);
+            return resolveUniqueRelationshipName(
+                fkTableId,
+                baseName,
+                excludeId,
+                suffix + 1,
+                reservedRelationshipNames);
           }
           return Mono.just(candidate);
         });
   }
 
-  private static OptionalInt parseAutoRelationshipSuffix(String relationshipName, String baseName) {
-    if (relationshipName == null || baseName == null) {
+  private static String relationshipNameKey(String fkTableId, String relationshipName) {
+    return fkTableId + "\u0000" + relationshipName;
+  }
+
+  private static OptionalInt parseAutoNameSuffix(String name, String baseName) {
+    if (name == null || baseName == null) {
       return OptionalInt.empty();
     }
-    if (relationshipName.equals(baseName)) {
+    if (name.equals(baseName)) {
       return OptionalInt.of(0);
     }
     String prefix = baseName + "_";
-    if (!relationshipName.startsWith(prefix)) {
+    if (!name.startsWith(prefix)) {
       return OptionalInt.empty();
     }
-    String suffix = relationshipName.substring(prefix.length());
+    String suffix = name.substring(prefix.length());
     if (suffix.isEmpty()) {
       return OptionalInt.empty();
     }
@@ -222,6 +331,16 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
     }
   }
 
+  private static String constraintKindPrefix(ConstraintKind kind) {
+    return switch (kind) {
+      case PRIMARY_KEY -> "pk_";
+      case UNIQUE -> "uq_";
+      case CHECK -> "ck_";
+      case DEFAULT -> "df_";
+      case NOT_NULL -> "nn_";
+    };
+  }
+
   private static String normalizeName(String name) {
     return name == null ? null : name.trim();
   }
@@ -233,6 +352,51 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
     } catch (DomainException exception) {
       return false;
     }
+  }
+
+  private record TableRenamePlan(
+      List<ConstraintRenamePlan> constraintRenames,
+      List<RelationshipRenamePlan> relationshipRenames) {
+
+    ChangeTableNameInverse toInverse(Table oldTable) {
+      ConstraintRenamePlan pkRename = firstPrimaryKeyRename();
+      return new ChangeTableNameInverse(
+          oldTable.id(),
+          oldTable.name(),
+          pkRename == null ? null : pkRename.constraintId(),
+          pkRename == null ? null : pkRename.oldName(),
+          constraintRenames.stream()
+              .map(rename -> new ConstraintRename(rename.constraintId(), rename.oldName()))
+              .toList(),
+          relationshipRenames.stream()
+              .map(rename -> new RelationshipRename(rename.relationshipId(), rename.oldName()))
+              .toList());
+    }
+
+    private ConstraintRenamePlan firstPrimaryKeyRename() {
+      for (ConstraintRenamePlan rename : constraintRenames) {
+        if (rename.kind() == ConstraintKind.PRIMARY_KEY) {
+          return rename;
+        }
+      }
+      return null;
+    }
+
+  }
+
+  private record ConstraintRenamePlan(
+      String constraintId,
+      ConstraintKind kind,
+      String oldName,
+      String newName) {
+
+  }
+
+  private record RelationshipRenamePlan(
+      String relationshipId,
+      String oldName,
+      String newName) {
+
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
@@ -62,25 +62,25 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
   @Override
   public Mono<MutationResult<Void>> changeTableName(ChangeTableNameCommand command) {
     return erdMutationCoordinator.coordinate(ErdOperationType.CHANGE_TABLE_NAME, command,
-            () -> getTableByIdPort.findTableById(command.tableId())
-                .switchIfEmpty(Mono.error(
-                    new DomainException(TableErrorCode.NOT_FOUND, "Table not found: " + command.tableId())))
-                .flatMap(table -> tableExistsPort.existsBySchemaIdAndName(table.schemaId(), command.newName())
-                    .flatMap(exists -> {
-                      if (exists) {
-                        return Mono.error(new DomainException(TableErrorCode.NAME_DUPLICATE,
-                            "A table with the name '" + command.newName() + "' already exists in the schema."));
-                      }
+        () -> getTableByIdPort.findTableById(command.tableId())
+            .switchIfEmpty(Mono.error(
+                new DomainException(TableErrorCode.NOT_FOUND, "Table not found: " + command.tableId())))
+            .flatMap(table -> tableExistsPort.existsBySchemaIdAndName(table.schemaId(), command.newName())
+                .flatMap(exists -> {
+                  if (exists) {
+                    return Mono.error(new DomainException(TableErrorCode.NAME_DUPLICATE,
+                        "A table with the name '" + command.newName() + "' already exists in the schema."));
+                  }
 
-                      return buildRenamePlan(table, command.newName())
-                          .flatMap(plan -> changeTableNamePort.changeTableName(
-                                  command.tableId(),
-                                  command.newName())
-                              .then(applyConstraintRenames(plan.constraintRenames()))
-                              .then(applyRelationshipRenames(plan.relationshipRenames()))
-                              .thenReturn(MutationResult.<Void>of(null, plan.affectedTableIds(table.id()))
-                                  .withInverse(plan.toInverse(table))));
-                    })))
+                  return buildRenamePlan(table, command.newName())
+                      .flatMap(plan -> changeTableNamePort.changeTableName(
+                          command.tableId(),
+                          command.newName())
+                          .then(applyConstraintRenames(plan.constraintRenames()))
+                          .then(applyRelationshipRenames(plan.relationshipRenames()))
+                          .thenReturn(MutationResult.<Void>of(null, plan.affectedTableIds(table.id()))
+                              .withInverse(plan.toInverse(table))));
+                })))
         .as(transactionalOperator::transactional);
   }
 
@@ -338,11 +338,11 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
 
   private static String constraintKindPrefix(ConstraintKind kind) {
     return switch (kind) {
-      case PRIMARY_KEY -> "pk_";
-      case UNIQUE -> "uq_";
-      case CHECK -> "ck_";
-      case DEFAULT -> "df_";
-      case NOT_NULL -> "nn_";
+    case PRIMARY_KEY -> "pk_";
+    case UNIQUE -> "uq_";
+    case CHECK -> "ck_";
+    case DEFAULT -> "df_";
+    case NOT_NULL -> "nn_";
     };
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
@@ -78,7 +78,7 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
                                   command.newName())
                               .then(applyConstraintRenames(plan.constraintRenames()))
                               .then(applyRelationshipRenames(plan.relationshipRenames()))
-                              .thenReturn(MutationResult.<Void>of(null, table.id())
+                              .thenReturn(MutationResult.<Void>of(null, plan.affectedTableIds(table.id()))
                                   .withInverse(plan.toInverse(table))));
                     })))
         .as(transactionalOperator::transactional);
@@ -258,7 +258,12 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
             return Mono.empty();
           }
           reservedRelationshipNames.add(relationshipNameKey(relationship.fkTableId(), newName));
-          return Mono.just(new RelationshipRenamePlan(relationship.id(), relationship.name(), newName));
+          return Mono.just(new RelationshipRenamePlan(
+              relationship.id(),
+              relationship.fkTableId(),
+              relationship.pkTableId(),
+              relationship.name(),
+              newName));
         });
   }
 
@@ -358,6 +363,16 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
       List<ConstraintRenamePlan> constraintRenames,
       List<RelationshipRenamePlan> relationshipRenames) {
 
+    Set<String> affectedTableIds(String tableId) {
+      Set<String> affectedTableIds = new HashSet<>();
+      affectedTableIds.add(tableId);
+      relationshipRenames.forEach(rename -> {
+        affectedTableIds.add(rename.fkTableId());
+        affectedTableIds.add(rename.pkTableId());
+      });
+      return affectedTableIds;
+    }
+
     ChangeTableNameInverse toInverse(Table oldTable) {
       ConstraintRenamePlan pkRename = firstPrimaryKeyRename();
       return new ChangeTableNameInverse(
@@ -369,7 +384,11 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
               .map(rename -> new ConstraintRename(rename.constraintId(), rename.oldName()))
               .toList(),
           relationshipRenames.stream()
-              .map(rename -> new RelationshipRename(rename.relationshipId(), rename.oldName()))
+              .map(rename -> new RelationshipRename(
+                  rename.relationshipId(),
+                  rename.oldName(),
+                  rename.fkTableId(),
+                  rename.pkTableId()))
               .toList());
     }
 
@@ -394,6 +413,8 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
 
   private record RelationshipRenamePlan(
       String relationshipId,
+      String fkTableId,
+      String pkTableId,
       String oldName,
       String newName) {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/ChangeTableNameService.java
@@ -141,7 +141,6 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
           reservedConstraintNames.add(newName);
           return Mono.just(new ConstraintRenamePlan(
               constraint.id(),
-              constraint.kind(),
               constraint.name(),
               newName));
         });
@@ -374,12 +373,9 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
     }
 
     ChangeTableNameInverse toInverse(Table oldTable) {
-      ConstraintRenamePlan pkRename = firstPrimaryKeyRename();
       return new ChangeTableNameInverse(
           oldTable.id(),
           oldTable.name(),
-          pkRename == null ? null : pkRename.constraintId(),
-          pkRename == null ? null : pkRename.oldName(),
           constraintRenames.stream()
               .map(rename -> new ConstraintRename(rename.constraintId(), rename.oldName()))
               .toList(),
@@ -392,20 +388,10 @@ public class ChangeTableNameService implements ChangeTableNameUseCase {
               .toList());
     }
 
-    private ConstraintRenamePlan firstPrimaryKeyRename() {
-      for (ConstraintRenamePlan rename : constraintRenames) {
-        if (rename.kind() == ConstraintKind.PRIMARY_KEY) {
-          return rename;
-        }
-      }
-      return null;
-    }
-
   }
 
   private record ConstraintRenamePlan(
       String constraintId,
-      ConstraintKind kind,
       String oldName,
       String newName) {
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/application/service/DefaultUndoRedoEligibilityServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/application/service/DefaultUndoRedoEligibilityServiceTest.java
@@ -126,7 +126,7 @@ class DefaultUndoRedoEligibilityServiceTest {
             assertThat(result.targetRootOriginalOperation().opId()).isEqualTo("op-3");
             assertThat(result.currentChainTipOperation().opId()).isEqualTo("op-4");
             assertThat(result.currentRedoCandidateOperation().opId()).isEqualTo("op-3");
-            assertThat(result.executionBaseOperation().opId()).isEqualTo("op-3");
+            assertThat(result.executionBaseOperation().opId()).isEqualTo("op-4");
           })
           .verifyComplete();
     }
@@ -199,7 +199,7 @@ class DefaultUndoRedoEligibilityServiceTest {
             assertThat(result.currentChainTipOperation().opId()).isEqualTo("op-3");
             assertThat(result.currentUndoCandidateOperation().opId()).isEqualTo("op-1");
             assertThat(result.currentRedoCandidateOperation().opId()).isEqualTo("op-2");
-            assertThat(result.executionBaseOperation().opId()).isEqualTo("op-2");
+            assertThat(result.executionBaseOperation().opId()).isEqualTo("op-3");
           })
           .verifyComplete();
     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
@@ -20,6 +20,10 @@ import com.schemafy.core.erd.constraint.application.port.in.CreateConstraintComm
 import com.schemafy.core.erd.constraint.application.port.in.CreateConstraintUseCase;
 import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.port.in.RedoErdOperationCommand;
+import com.schemafy.core.erd.operation.application.port.in.RedoErdOperationUseCase;
+import com.schemafy.core.erd.operation.application.port.in.UndoErdOperationCommand;
+import com.schemafy.core.erd.operation.application.port.in.UndoErdOperationUseCase;
 import com.schemafy.core.erd.operation.application.port.out.IncrementSchemaCollaborationRevisionPort;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 import com.schemafy.core.erd.operation.domain.exception.OperationErrorCode;
@@ -36,6 +40,8 @@ import com.schemafy.core.erd.schema.application.port.in.CreateSchemaUseCase;
 import com.schemafy.core.erd.support.ErdProjectIntegrationSupport;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraCommand;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraUseCase;
+import com.schemafy.core.erd.table.application.port.in.ChangeTableNameCommand;
+import com.schemafy.core.erd.table.application.port.in.ChangeTableNameUseCase;
 import com.schemafy.core.erd.table.application.port.in.CreateTableCommand;
 import com.schemafy.core.erd.table.application.port.in.CreateTableUseCase;
 import com.schemafy.core.erd.table.application.port.in.DeleteTableCommand;
@@ -67,6 +73,9 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
   ChangeTableExtraUseCase changeTableExtraUseCase;
 
   @Autowired
+  ChangeTableNameUseCase changeTableNameUseCase;
+
+  @Autowired
   DeleteTableUseCase deleteTableUseCase;
 
   @Autowired
@@ -86,6 +95,12 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
 
   @Autowired
   IncrementSchemaCollaborationRevisionPort incrementSchemaCollaborationRevisionPort;
+
+  @Autowired
+  UndoErdOperationUseCase undoErdOperationUseCase;
+
+  @Autowired
+  RedoErdOperationUseCase redoErdOperationUseCase;
 
   @Test
   @DisplayName("schema revision과 operation log를 순서대로 기록한다")
@@ -252,6 +267,91 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
 
     assertThat(operationCount(schemaId)).isEqualTo(beforeChangeCount);
     assertThat(currentRevision(schemaId)).isEqualTo(beforeChangeRevision);
+  }
+
+  @Test
+  @DisplayName("PK 쪽 table rename으로 관계 이름이 함께 바뀌면 undo/redo affectedTableIds에 양쪽 테이블을 포함한다")
+  void tableRenameUndoRedoIncludesRelationshipTablesWhenPkSideNameChanges() {
+    assertTableRenameUndoRedoIncludesRelationshipTables(true);
+  }
+
+  @Test
+  @DisplayName("FK 쪽 table rename으로 관계 이름이 함께 바뀌면 undo/redo affectedTableIds에 양쪽 테이블을 포함한다")
+  void tableRenameUndoRedoIncludesRelationshipTablesWhenFkSideNameChanges() {
+    assertTableRenameUndoRedoIncludesRelationshipTables(false);
+  }
+
+  private void assertTableRenameUndoRedoIncludesRelationshipTables(boolean renamePkSide) {
+    String sidePrefix = renamePkSide ? "pk" : "fk";
+    String projectId = createActiveProjectId("erd_operation_table_rename_" + sidePrefix + "_relationship_affected");
+
+    String schemaId = createSchemaUseCase.createSchema(new CreateSchemaCommand(
+        projectId,
+        "MySQL",
+        "table_rename_" + sidePrefix + "_relationship_affected_schema",
+        "utf8mb4",
+        "utf8mb4_general_ci")).block().result().id();
+
+    String pkTableId = createTableUseCase.createTable(new CreateTableCommand(
+        schemaId,
+        "users",
+        "utf8mb4",
+        "utf8mb4_general_ci",
+        null)).block().result().tableId();
+
+    String fkTableId = createTableUseCase.createTable(new CreateTableCommand(
+        schemaId,
+        "orders",
+        "utf8mb4",
+        "utf8mb4_general_ci",
+        null)).block().result().tableId();
+
+    String pkColumnId = createColumnUseCase.createColumn(new CreateColumnCommand(
+        pkTableId,
+        "id",
+        "INT",
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        "pk column")).block().result().columnId();
+
+    createConstraintUseCase.createConstraint(new CreateConstraintCommand(
+        pkTableId,
+        "pk_users",
+        ConstraintKind.PRIMARY_KEY,
+        null,
+        null,
+        List.of(new CreateConstraintColumnCommand(pkColumnId, 0)))).block();
+
+    createRelationshipUseCase.createRelationship(new CreateRelationshipCommand(
+        fkTableId,
+        pkTableId,
+        RelationshipKind.NON_IDENTIFYING,
+        Cardinality.ONE_TO_MANY,
+        null)).block();
+
+    String targetTableId = renamePkSide ? pkTableId : fkTableId;
+    String newTableName = renamePkSide ? "accounts" : "orders_v2";
+    var renameResult = changeTableNameUseCase.changeTableName(new ChangeTableNameCommand(
+        targetTableId,
+        newTableName)).block();
+
+    assertThat(renameResult.affectedTableIds())
+        .containsExactlyInAnyOrder(pkTableId, fkTableId);
+
+    String renameOpId = renameResult.operation().opId();
+
+    var undoResult = undoErdOperationUseCase.undo(new UndoErdOperationCommand(renameOpId)).block();
+    assertThat(undoResult.affectedTableIds())
+        .containsExactlyInAnyOrder(pkTableId, fkTableId);
+
+    var redoResult = redoErdOperationUseCase.redo(new RedoErdOperationCommand(renameOpId)).block();
+    assertThat(redoResult.affectedTableIds())
+        .containsExactlyInAnyOrder(pkTableId, fkTableId);
+    assertLastOperation(schemaId, "CHANGE_TABLE_NAME", currentRevision(schemaId), List.of(pkTableId, fkTableId));
   }
 
   @Test

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.column.application.port.in.CreateColumnCommand;
 import com.schemafy.core.erd.column.application.port.in.CreateColumnUseCase;
@@ -17,7 +18,10 @@ import com.schemafy.core.erd.constraint.application.port.in.CreateConstraintColu
 import com.schemafy.core.erd.constraint.application.port.in.CreateConstraintCommand;
 import com.schemafy.core.erd.constraint.application.port.in.CreateConstraintUseCase;
 import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
+import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.application.port.out.IncrementSchemaCollaborationRevisionPort;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+import com.schemafy.core.erd.operation.domain.exception.OperationErrorCode;
 import com.schemafy.core.erd.relationship.application.port.in.ChangeRelationshipKindCommand;
 import com.schemafy.core.erd.relationship.application.port.in.ChangeRelationshipKindUseCase;
 import com.schemafy.core.erd.relationship.application.port.in.CreateRelationshipCommand;
@@ -315,6 +319,41 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
         .containsExactlyInAnyOrder("CHANGE_SCHEMA_NAME", "CHANGE_TABLE_EXTRA");
   }
 
+  @Test
+  @DisplayName("파생 mutation은 resolve 당시 revision이 더 이상 최신이 아니면 커밋하지 않는다")
+  void rejectsDerivedMutationWhenBaseRevisionIsStale() {
+    String projectId = createActiveProjectId("erd_operation_stale_derived");
+
+    String schemaId = createSchemaUseCase.createSchema(new CreateSchemaCommand(
+        projectId,
+        "MySQL",
+        "stale_derived_schema",
+        "utf8mb4",
+        "utf8mb4_general_ci")).block().result().id();
+
+    String tableId = createTableUseCase.createTable(new CreateTableCommand(
+        schemaId,
+        "stale_derived_table",
+        "utf8mb4",
+        "utf8mb4_general_ci",
+        null)).block().result().tableId();
+
+    long currentRevision = currentRevision(schemaId);
+    long beforeCount = operationCount(schemaId);
+
+    StepVerifier.create(changeTableExtraUseCase.changeTableExtra(new ChangeTableExtraCommand(
+        tableId,
+        "{\"comment\":\"stale\"}"))
+        .contextWrite(ErdOperationContexts.withDerivation(ErdOperationDerivationKind.UNDO, "stale-parent")
+            .andThen(ErdOperationContexts.withBaseSchemaRevision(currentRevision - 1))))
+        .expectErrorMatches(DomainException.hasErrorCode(OperationErrorCode.SUPERSEDED))
+        .verify();
+
+    assertThat(currentRevision(schemaId)).isEqualTo(currentRevision);
+    assertThat(operationCount(schemaId)).isEqualTo(beforeCount);
+    assertThat(tableExtraIsNull(tableId)).isTrue();
+  }
+
   private long currentRevision(String schemaId) {
     return databaseClient.sql("""
         SELECT current_revision
@@ -323,6 +362,19 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
         """)
         .bind("schemaId", schemaId)
         .map((row, metadata) -> ((Number) row.get("current_revision")).longValue())
+        .one()
+        .block();
+  }
+
+  private boolean tableExtraIsNull(String tableId) {
+    return databaseClient.sql("""
+        SELECT COUNT(*) AS cnt
+        FROM db_tables
+        WHERE id = :tableId
+          AND extra IS NULL
+        """)
+        .bind("tableId", tableId)
+        .map((row, metadata) -> ((Number) row.get("cnt")).longValue() == 1)
         .one()
         .block();
   }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +40,7 @@ import com.schemafy.core.erd.table.application.port.in.CreateTableCommand;
 import com.schemafy.core.erd.table.application.port.in.CreateTableUseCase;
 import com.schemafy.core.erd.table.application.port.in.DeleteTableCommand;
 import com.schemafy.core.erd.table.application.port.in.DeleteTableUseCase;
+import com.schemafy.core.ulid.application.service.UlidGenerator;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -354,6 +356,47 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
     assertThat(tableExtraIsNull(tableId)).isTrue();
   }
 
+  @Test
+  @DisplayName("같은 operation을 부모로 하는 파생 operation log는 중복 기록할 수 없다")
+  void enforcesUniqueDerivedFromOperationId() {
+    String projectId = createActiveProjectId("erd_operation_unique_derived_from");
+
+    String schemaId = createSchemaUseCase.createSchema(new CreateSchemaCommand(
+        projectId,
+        "MySQL",
+        "unique_derived_from_schema",
+        "utf8mb4",
+        "utf8mb4_general_ci")).block().result().id();
+
+    String tableId = createTableUseCase.createTable(new CreateTableCommand(
+        schemaId,
+        "unique_derived_from_table",
+        "utf8mb4",
+        "utf8mb4_general_ci",
+        null)).block().result().tableId();
+
+    long committedRevision = currentRevision(schemaId) + 10;
+    String parentOpId = latestOperationId(schemaId);
+
+    StepVerifier.create(insertDerivedOperationLog(
+        UlidGenerator.generate(),
+        projectId,
+        schemaId,
+        committedRevision,
+        parentOpId))
+        .expectNext(1L)
+        .verifyComplete();
+
+    StepVerifier.create(insertDerivedOperationLog(
+        UlidGenerator.generate(),
+        projectId,
+        schemaId,
+        committedRevision + 1,
+        parentOpId))
+        .expectError(DataIntegrityViolationException.class)
+        .verify();
+  }
+
   private long currentRevision(String schemaId) {
     return databaseClient.sql("""
         SELECT current_revision
@@ -377,6 +420,73 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
         .map((row, metadata) -> ((Number) row.get("cnt")).longValue() == 1)
         .one()
         .block();
+  }
+
+  private String latestOperationId(String schemaId) {
+    return databaseClient.sql("""
+        SELECT op_id
+        FROM erd_operation_log
+        WHERE schema_id = :schemaId
+        ORDER BY committed_revision DESC
+        LIMIT 1
+        """)
+        .bind("schemaId", schemaId)
+        .map((row, metadata) -> row.get("op_id", String.class))
+        .one()
+        .block();
+  }
+
+  private Mono<Long> insertDerivedOperationLog(
+      String opId,
+      String projectId,
+      String schemaId,
+      long committedRevision,
+      String derivedFromOpId) {
+    return databaseClient.sql("""
+        INSERT INTO erd_operation_log (
+            op_id,
+            project_id,
+            schema_id,
+            op_type,
+            committed_revision,
+            base_schema_revision,
+            client_operation_id,
+            collab_session_id,
+            actor_user_id,
+            derivation_kind,
+            derived_from_op_id,
+            lifecycle_state,
+            payload_json,
+            inverse_payload_json,
+            touched_entities_json,
+            affected_table_ids_json
+        ) VALUES (
+            :opId,
+            :projectId,
+            :schemaId,
+            'CHANGE_TABLE_EXTRA',
+            :committedRevision,
+            :baseSchemaRevision,
+            NULL,
+            NULL,
+            'system',
+            'UNDO',
+            :derivedFromOpId,
+            'COMMITTED',
+            '{}',
+            NULL,
+            '[]',
+            '[]'
+        )
+        """)
+        .bind("opId", opId)
+        .bind("projectId", projectId)
+        .bind("schemaId", schemaId)
+        .bind("committedRevision", committedRevision)
+        .bind("baseSchemaRevision", committedRevision - 1)
+        .bind("derivedFromOpId", derivedFromOpId)
+        .fetch()
+        .rowsUpdated();
   }
 
   private long operationCount(String schemaId) {

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/UndoRedoEligibilityIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/UndoRedoEligibilityIntegrationTest.java
@@ -76,7 +76,7 @@ class UndoRedoEligibilityIntegrationTest extends ErdProjectIntegrationSupport {
           assertThat(result.targetRootOriginalOperation().opId()).isEqualTo(o3.opId());
           assertThat(result.currentChainTipOperation().opId()).isEqualTo(u3.opId());
           assertThat(result.currentRedoCandidateOperation().opId()).isEqualTo(o3.opId());
-          assertThat(result.executionBaseOperation().opId()).isEqualTo(o3.opId());
+          assertThat(result.executionBaseOperation().opId()).isEqualTo(u3.opId());
         })
         .verifyComplete();
   }
@@ -133,7 +133,7 @@ class UndoRedoEligibilityIntegrationTest extends ErdProjectIntegrationSupport {
     var o2 = append(opId("op-2"), schemaId, projectId, 2, ErdOperationDerivationKind.ORIGINAL, null);
     var o3 = append(opId("op-3"), schemaId, projectId, 3, ErdOperationDerivationKind.ORIGINAL, null);
     append(opId("op-4"), schemaId, projectId, 4, ErdOperationDerivationKind.UNDO, o3.opId());
-    append(opId("op-5"), schemaId, projectId, 5, ErdOperationDerivationKind.UNDO, o2.opId());
+    var u2 = append(opId("op-5"), schemaId, projectId, 5, ErdOperationDerivationKind.UNDO, o2.opId());
 
     StepVerifier.create(undoRedoEligibilityService.resolve(UndoRedoAction.REDO, o3.opId()))
         .expectErrorMatches(DomainException.hasErrorCode(OperationErrorCode.REDO_NOT_ELIGIBLE))
@@ -143,7 +143,7 @@ class UndoRedoEligibilityIntegrationTest extends ErdProjectIntegrationSupport {
         .assertNext(result -> {
           assertThat(result.targetRootOriginalOperation().opId()).isEqualTo(o2.opId());
           assertThat(result.currentRedoCandidateOperation().opId()).isEqualTo(o2.opId());
-          assertThat(result.executionBaseOperation().opId()).isEqualTo(o2.opId());
+          assertThat(result.executionBaseOperation().opId()).isEqualTo(u2.opId());
         })
         .verifyComplete();
   }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/ChangeTableNameServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/ChangeTableNameServiceTest.java
@@ -17,6 +17,8 @@ import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.erd.constraint.application.port.out.ChangeConstraintNamePort;
 import com.schemafy.core.erd.constraint.application.port.out.ConstraintExistsPort;
 import com.schemafy.core.erd.constraint.application.port.out.GetConstraintsByTableIdPort;
+import com.schemafy.core.erd.constraint.domain.Constraint;
+import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
 import com.schemafy.core.erd.relationship.application.port.out.ChangeRelationshipNamePort;
 import com.schemafy.core.erd.relationship.application.port.out.GetRelationshipsByTableIdPort;
 import com.schemafy.core.erd.relationship.application.port.out.RelationshipExistsPort;
@@ -34,8 +36,10 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChangeTableNameService")
@@ -112,6 +116,91 @@ class ChangeTableNameServiceTest {
             .existsBySchemaIdAndName(TableFixture.DEFAULT_SCHEMA_ID, command.newName());
         then(changeTableNamePort).should()
             .changeTableName(command.tableId(), command.newName());
+      }
+
+    }
+
+    @Nested
+    @DisplayName("자동 생성된 제약조건 이름이 있으면")
+    class WithAutoConstraintNames {
+
+      @Test
+      @DisplayName("테이블 rename에 맞춰 PK가 아닌 자동 제약조건 이름도 갱신한다")
+      void updatesAutoConstraintNamesAcrossKinds() {
+        var oldTable = new Table(
+            "table-1",
+            "schema-1",
+            "users",
+            TableFixture.DEFAULT_CHARSET,
+            TableFixture.DEFAULT_COLLATION);
+        var constraints = List.of(
+            constraint("pk-1", oldTable.id(), "pk_users", ConstraintKind.PRIMARY_KEY),
+            constraint("uq-1", oldTable.id(), "uq_users", ConstraintKind.UNIQUE),
+            constraint("uq-2", oldTable.id(), "uq_users_1", ConstraintKind.UNIQUE),
+            constraint("ck-1", oldTable.id(), "ck_users", ConstraintKind.CHECK),
+            constraint("df-1", oldTable.id(), "df_users", ConstraintKind.DEFAULT),
+            constraint("nn-1", oldTable.id(), "nn_users", ConstraintKind.NOT_NULL),
+            constraint("manual-1", oldTable.id(), "users_email_unique", ConstraintKind.UNIQUE));
+        var command = new com.schemafy.core.erd.table.application.port.in.ChangeTableNameCommand(
+            oldTable.id(),
+            "accounts");
+
+        given(tableExistsPort.existsBySchemaIdAndName(oldTable.schemaId(), command.newName()))
+            .willReturn(Mono.just(false));
+        given(getTableByIdPort.findTableById(oldTable.id()))
+            .willReturn(Mono.just(oldTable));
+        given(changeTableNamePort.changeTableName(oldTable.id(), command.newName()))
+            .willReturn(Mono.empty());
+        given(getConstraintsByTableIdPort.findConstraintsByTableId(oldTable.id()))
+            .willReturn(Mono.just(constraints));
+        given(getRelationshipsByTableIdPort.findRelationshipsByTableId(oldTable.id()))
+            .willReturn(Mono.just(List.of()));
+        givenConstraintNameAvailable(oldTable.schemaId(), "pk_accounts", "pk-1");
+        givenConstraintNameAvailable(oldTable.schemaId(), "uq_accounts", "uq-1");
+        givenConstraintNameAvailable(oldTable.schemaId(), "uq_accounts_1", "uq-2");
+        givenConstraintNameAvailable(oldTable.schemaId(), "ck_accounts", "ck-1");
+        givenConstraintNameAvailable(oldTable.schemaId(), "df_accounts", "df-1");
+        givenConstraintNameAvailable(oldTable.schemaId(), "nn_accounts", "nn-1");
+        given(changeConstraintNamePort.changeConstraintName(any(), any()))
+            .willReturn(Mono.empty());
+
+        StepVerifier.create(sut.changeTableName(command))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("pk-1", "pk_accounts");
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("uq-1", "uq_accounts");
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("uq-2", "uq_accounts_1");
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("ck-1", "ck_accounts");
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("df-1", "df_accounts");
+        then(changeConstraintNamePort).should()
+            .changeConstraintName("nn-1", "nn_accounts");
+        then(changeConstraintNamePort).should(never())
+            .changeConstraintName(eq("manual-1"), any());
+      }
+
+      private void givenConstraintNameAvailable(
+          String schemaId,
+          String name,
+          String constraintId) {
+        given(constraintExistsPort.existsBySchemaIdAndNameExcludingId(
+            schemaId,
+            name,
+            constraintId))
+            .willReturn(Mono.just(false));
+      }
+
+      private Constraint constraint(
+          String id,
+          String tableId,
+          String name,
+          ConstraintKind kind) {
+        return new Constraint(id, tableId, name, kind, null, null);
       }
 
     }

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/ChangeTableNameServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/ChangeTableNameServiceTest.java
@@ -35,6 +35,7 @@ import com.schemafy.core.erd.table.fixture.TableFixture;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -116,6 +117,62 @@ class ChangeTableNameServiceTest {
             .existsBySchemaIdAndName(TableFixture.DEFAULT_SCHEMA_ID, command.newName());
         then(changeTableNamePort).should()
             .changeTableName(command.tableId(), command.newName());
+      }
+
+      @Test
+      @DisplayName("PK 쪽 테이블 rename으로 관계 이름이 바뀌면 FK 테이블도 affectedTableIds에 포함한다")
+      void includesRelatedTableWhenPkSideRelationshipNameChanges() {
+        var oldTable = new Table(
+            "table-1",
+            "schema-1",
+            "users",
+            TableFixture.DEFAULT_CHARSET,
+            TableFixture.DEFAULT_COLLATION);
+        var fkTable = new Table(
+            "table-2",
+            "schema-1",
+            "orders",
+            TableFixture.DEFAULT_CHARSET,
+            TableFixture.DEFAULT_COLLATION);
+        var relationship = new Relationship(
+            "rel-1",
+            oldTable.id(),
+            fkTable.id(),
+            "rel_orders_to_users",
+            RelationshipKind.NON_IDENTIFYING,
+            Cardinality.ONE_TO_MANY,
+            null);
+        var command = new com.schemafy.core.erd.table.application.port.in.ChangeTableNameCommand(
+            oldTable.id(),
+            "accounts");
+
+        given(tableExistsPort.existsBySchemaIdAndName(any(), any()))
+            .willReturn(Mono.just(false));
+        given(getTableByIdPort.findTableById(oldTable.id()))
+            .willReturn(Mono.just(oldTable));
+        given(getTableByIdPort.findTableById(fkTable.id()))
+            .willReturn(Mono.just(fkTable));
+        given(changeTableNamePort.changeTableName(any(), any()))
+            .willReturn(Mono.empty());
+        given(getConstraintsByTableIdPort.findConstraintsByTableId(any()))
+            .willReturn(Mono.just(List.of()));
+        given(getRelationshipsByTableIdPort.findRelationshipsByTableId(oldTable.id()))
+            .willReturn(Mono.just(List.of(relationship)));
+        given(relationshipExistsPort.existsByFkTableIdAndNameExcludingId(
+            relationship.fkTableId(),
+            "rel_orders_to_accounts",
+            relationship.id()))
+            .willReturn(Mono.just(false));
+        given(changeRelationshipNamePort.changeRelationshipName(any(), any()))
+            .willReturn(Mono.empty());
+
+        StepVerifier.create(sut.changeTableName(command))
+            .assertNext(result -> assertThat(result.affectedTableIds())
+                .containsExactlyInAnyOrder(oldTable.id(), fkTable.id()))
+            .verifyComplete();
+
+        then(changeRelationshipNamePort).should()
+            .changeRelationshipName(relationship.id(), "rel_orders_to_accounts");
       }
 
     }
@@ -210,8 +267,8 @@ class ChangeTableNameServiceTest {
     class WithAutoRelationshipNames {
 
       @Test
-      @DisplayName("테이블 rename에 맞춰 관계 이름을 갱신한다")
-      void updatesAutoRelationshipName() {
+      @DisplayName("FK 쪽 테이블 rename으로 관계 이름이 바뀌면 PK 테이블도 affectedTableIds에 포함한다")
+      void includesRelatedTableWhenFkSideRelationshipNameChanges() {
         var oldTable = new Table(
             "table-1",
             "schema-1",
@@ -257,7 +314,8 @@ class ChangeTableNameServiceTest {
             .willReturn(Mono.empty());
 
         StepVerifier.create(sut.changeTableName(command))
-            .expectNextCount(1)
+            .assertNext(result -> assertThat(result.affectedTableIds())
+                .containsExactlyInAnyOrder(oldTable.id(), pkTable.id()))
             .verifyComplete();
 
         then(changeRelationshipNamePort).should()

--- a/apps/backend/sql-resources/ddl/h2/erd_operation_log.sql
+++ b/apps/backend/sql-resources/ddl/h2/erd_operation_log.sql
@@ -19,3 +19,6 @@ CREATE TABLE IF NOT EXISTS erd_operation_log (
     CONSTRAINT pk_erd_operation_log PRIMARY KEY (op_id),
     CONSTRAINT uq_erd_operation_log_schema_revision UNIQUE (schema_id, committed_revision)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_erd_operation_log_derived_from_op
+    ON erd_operation_log (derived_from_op_id);

--- a/apps/backend/sql-resources/ddl/mariadb/erd_operation_log.sql
+++ b/apps/backend/sql-resources/ddl/mariadb/erd_operation_log.sql
@@ -19,3 +19,6 @@ CREATE TABLE IF NOT EXISTS erd_operation_log (
     CONSTRAINT pk_erd_operation_log PRIMARY KEY (op_id),
     CONSTRAINT uq_erd_operation_log_schema_revision UNIQUE (schema_id, committed_revision)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_erd_operation_log_derived_from_op
+    ON erd_operation_log (derived_from_op_id);


### PR DESCRIPTION
## 개요

- ERD 단순 속성 변경 계열 mutation에 대한 undo/redo 실행 경로 추가
- 원본 mutation 실행 시 inverse payload를 operation log에 저장하고, undo/redo 시 해당 payload를 기반으로 반대 방향 mutation 수행
- undo/redo 실행 시 다시 redo 가능한 forward snapshot을 캡처하도록 handler 구성
- table rename, column type cascade처럼 부수 변경이 발생하는 단순 속성 변경 케이스까지 operation log / affected table / inverse payload 흐름 정리

## 이슈

- close #301
