### PR TITLE
chore: add agent skill frontmatter

### DIFF
--- a/.agents/skills/perf-audit-canvas-ops/SKILL.md
+++ b/.agents/skills/perf-audit-canvas-ops/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: perf-audit-canvas-ops
+description: Schemafy 캔버스 조작 성능을 Playwright로 측정하고 테이블 추가, 컬럼 추가, 엣지 연결 작업의 렌더링 비용과 병목을 분석할 때 사용.
+---
+
+# perf-audit-canvas-ops
+
+캔버스 조작 성능 측정. 테이블 추가·컬럼 추가·엣지 연결의 렌더 비용을 측정한다.
+
+## 사용법
+
+```
+/perf-audit-canvas-ops [이메일] [비밀번호]
+```
+
+생략 시 기본값: `test@example.com` / `password123`. 경로 고정: `/canvas`.
+
+> ⚠️ 루트에서 `npm run dev` 먼저 실행 (프론트엔드 3001, BFF 4000, Spring Boot 8080, DB).
+
+---
+
+## 실행 절차
+
+### 1단계: Playwright 측정
+
+```bash
+cd apps/frontend && PERF_PATH=/canvas PERF_EMAIL=<이메일> PERF_PASSWORD=<비밀번호> npx playwright test tests/perf-audit-canvas-ops.spec.ts --project=chromium --reporter=line
+```
+
+| 작업 키       | 내용                         | 스킵 조건                |
+| ------------- | ---------------------------- | ------------------------ |
+| `addTable1`   | 첫 번째 테이블 추가 (좌상단) | -                        |
+| `addTable2`   | 두 번째 테이블 추가 (우하단) | -                        |
+| `addColumn`   | 첫 번째 테이블에 컬럼 추가   | "Add Column" 버튼 비가시 |
+| `connectEdge` | 두 테이블 간 엣지 연결       | 핸들 8개 미만            |
+
+스킵 시 `skipped: true` 기록 (0ms/0회 아님). 리포트 분석 시 측정 실패로 처리.
+
+**즉시 중단 조건:** 테스트 실패 | `/signin` 리다이렉트(인증 실패) | JSON 미생성
+
+### 2단계: 결과 JSON 읽기
+
+`apps/frontend/performance/results/`에서 `*_canvas-ops.json` 최근 파일 읽기.
+
+### 3단계: 리포트 생성
+
+`apps/frontend/performance/reports/YYYY-MM-DD_canvas-ops.md`에 저장.
+
+```markdown
+# Performance Audit: Canvas Ops
+
+> 측정일시: <timestamp> | 브라우저: Chromium | 환경: 로컬 dev 서버
+
+## 작업별 성능 요약
+
+| 작업          | 소요시간 | 렌더 횟수 | Long Task | 상태     |
+| ------------- | -------- | --------- | --------- | -------- |
+| 테이블 추가 1 | Xms      | X회       | X개       | ✅/⚠️/❌ |
+| 테이블 추가 2 | Xms      | X회       | X개       | ✅/⚠️/❌ |
+| 컬럼 추가     | Xms      | X회       | X개       | ✅/⚠️/❌ |
+| 엣지 연결     | Xms      | X회       | X개       | ✅/⚠️/❌ |
+
+## 최종 스냅샷
+
+| 지표          | 측정값 |
+| ------------- | ------ |
+| JS 힙 (used)  | XMB    |
+| JS 힙 (total) | XMB    |
+| DOM 노드 수   | X개    |
+| 이벤트 리스너 | X개    |
+| 스타일 재계산 | X회    |
+| 스크립트 실행 | Xs     |
+
+> Long Task: 0개=양호, 1~2개=주의, 3개+=위험. 렌더 횟수는 작업 간 상대 비교 용도.
+
+## 원인 분석
+
+(렌더·Long Task가 높은 작업 위주)
+
+## 해결 방법
+
+(원인별 구체적 해결 방법. 가능하면 코드 예시 포함)
+```
+
+---
+
+## 주의사항
+
+- Toolbar 셀렉터: `data-testid="toolbar-table"`, `data-testid="toolbar-pointer"`
+- 결과 파일 누적 저장 → 항상 최근 파일 기준으로 분석

--- a/.agents/skills/perf-audit-canvas-scale/SKILL.md
+++ b/.agents/skills/perf-audit-canvas-scale/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: perf-audit-canvas-scale
+description: Schemafy 캔버스에서 테이블 수를 3개, 5개, 10개 규모로 늘리며 테이블 추가, 컬럼 추가, 엣지 연결의 규모별 렌더링 비용과 반복 컬럼 추가 열화 추이를 측정하고 분석할 때 사용.
+---
+
+# perf-audit-canvas-scale
+
+규모별 캔버스 성능 측정. 3→5→10개 규모로 확장하며 같은 작업의 렌더 비용 변화를 추적한다. 컬럼 5회 연속 추가로 반복 시 열화 추이도 측정.
+
+## 사용법
+
+```
+/perf-audit-canvas-scale [이메일] [비밀번호]
+```
+
+생략 시 기본값: `test@example.com` / `password123`. 경로 고정: `/canvas`. 소요: ~1~2분.
+
+> ⚠️ 루트에서 `npm run dev` 먼저 실행 (프론트엔드 3001, BFF 4000, Spring Boot 8080, DB).
+
+---
+
+## 실행 절차
+
+### 1단계: Playwright 측정
+
+```bash
+cd apps/frontend && PERF_PATH=/canvas PERF_EMAIL=<이메일> PERF_PASSWORD=<비밀번호> npx playwright test tests/perf-audit-canvas-scale.spec.ts --project=chromium --reporter=line
+```
+
+**측정 구조:** N개 셋업 후 addTable 측정(+1) → 결과 `tableCount` = N+1.
+
+| 단계         | tableCount | 내용                                          |
+| ------------ | ---------- | --------------------------------------------- |
+| Scale 3→4    | 4          | addTable·addColumn·connectEdge 측정           |
+| Scale 5→6    | 6          | addTable·addColumn·connectEdge 측정           |
+| Scale 10→11  | 11         | addTable·addColumn·connectEdge 측정           |
+| repeatColumn | 11         | 마지막 addTable 직후, 컬럼 5회 연속 추가 측정 |
+
+| 작업          | 스킵 조건                |
+| ------------- | ------------------------ |
+| `addColumn`   | "Add Column" 버튼 비가시 |
+| `connectEdge` | 핸들 8개 미만            |
+
+스킵 시 `skipped: true` 기록 (0ms/0회 아님). 리포트 분석 시 측정 실패로 처리.
+
+**즉시 중단 조건:** 테스트 실패 | `/signin` 리다이렉트(인증 실패) | JSON 미생성
+
+### 2단계: 결과 JSON 읽기
+
+`apps/frontend/performance/results/`에서 `*_canvas-scale.json` 최근 파일 읽기.
+
+### 3단계: 리포트 생성
+
+`apps/frontend/performance/reports/YYYY-MM-DD_canvas-scale.md`에 저장.
+
+```markdown
+# Performance Audit: Canvas Scale
+
+> 측정일시: <timestamp> | 브라우저: Chromium | 환경: 로컬 dev 서버
+
+## 규모별 성능 추이
+
+### addTable (테이블 추가)
+
+| tableCount | 소요시간 | 렌더 횟수 | Long Task | skipped |
+| ---------- | -------- | --------- | --------- | ------- |
+| 4          | Xms      | X회       | X개       | -       |
+| 6          | Xms      | X회       | X개       | -       |
+| 11         | Xms      | X회       | X개       | -       |
+
+### addColumn (컬럼 추가)
+
+| tableCount | 소요시간 | 렌더 횟수 | Long Task | skipped |
+| ---------- | -------- | --------- | --------- | ------- |
+| 4          | Xms      | X회       | X개       | true/-  |
+| 6          | Xms      | X회       | X개       | true/-  |
+| 11         | Xms      | X회       | X개       | true/-  |
+
+### connectEdge (엣지 연결)
+
+(동일 형식)
+
+## 반복 작업 추이 (컬럼 5회 연속, tableCount=11)
+
+| 회차 | 소요시간 | 렌더 횟수 | Long Task | skipped |
+| ---- | -------- | --------- | --------- | ------- |
+| 1회  | Xms      | X회       | X개       | true/-  |
+| 2회  | Xms      | X회       | X개       | true/-  |
+| 3회  | Xms      | X회       | X개       | true/-  |
+| 4회  | Xms      | X회       | X개       | true/-  |
+| 5회  | Xms      | X회       | X개       | true/-  |
+
+## 규모별 힙·CDP 스냅샷
+
+| tableCount | JS 힙 (used) | JS 힙 (total) | 이벤트 리스너 | 스타일 재계산 | 스크립트 실행 | DOM 노드 |
+| ---------- | ------------ | ------------- | ------------- | ------------- | ------------- | -------- |
+| 4          | XMB          | XMB           | X개           | X회           | Xs            | X개      |
+| 6          | XMB          | XMB           | X개           | X회           | Xs            | X개      |
+| 11         | XMB          | XMB           | X개           | X회           | Xs            | X개      |
+
+> 이벤트 리스너가 테이블 수에 비례 선형 증가 → 가상화·이벤트 위임 필요 신호.
+> 반복 작업에서 렌더 횟수 증가 → 누적 상태·메모리 누수 가능성.
+
+## 원인 분석
+
+(규모 증가에 따른 렌더·리스너·힙 변화, 선형/비선형 여부)
+
+## 해결 방법
+
+(원인별 구체적 해결 방법. 가능하면 코드 예시 포함)
+```
+
+---
+
+## 주의사항
+
+- 셋업 중 테이블 겹침 → 클릭 엉킴 → 이상값. 새 캔버스에서 실행해야 정확.
+- `connectEdge`: 규모 커질수록 핸들 인덱스 불일치 가능 → 렌더값 0 기록 가능
+- 결과 파일 누적 저장 → 항상 최근 파일 기준으로 분석

--- a/.agents/skills/perf-audit/SKILL.md
+++ b/.agents/skills/perf-audit/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: perf-audit
+description: 프론트엔드 페이지 성능을 Playwright로 측정하고 최신 performance 결과 JSON을 분석해 LCP, INP, Long Task, 렌더링 병목 원인을 리포트할 때 사용.
+---
+
+# perf-audit
+
+프론트엔드 성능 자동 측정 + AI 원인 분석 리포트 생성 skill.
+
+## 사용법
+
+```
+/perf-audit <경로> [이메일] [비밀번호]
+```
+
+- `<경로>`: `/`로 시작하는 앱 내부 경로 (쿼리스트링 가능, 해시·외부 URL 불가)
+- `/canvas`로 시작하면 자동 로그인. 생략 시 기본값: `test@example.com` / `password123`
+- 캔버스 조작 성능(테이블·컬럼·엣지)은 `/perf-audit-canvas-ops` 사용
+
+> ⚠️ 루트에서 `npm run dev` 먼저 실행 (프론트엔드 3001, BFF 4000, Spring Boot 8080, DB).
+
+---
+
+## 실행 절차
+
+### 1단계: Playwright 측정
+
+인증 불필요 (`/`, `/signin` 등):
+```bash
+cd apps/frontend && PERF_PATH=<경로> npx playwright test tests/perf-audit.spec.ts --project=chromium --reporter=line
+```
+
+인증 필요 (`/canvas` 등):
+```bash
+cd apps/frontend && PERF_PATH=<경로> PERF_EMAIL=<이메일> PERF_PASSWORD=<비밀번호> npx playwright test tests/perf-audit.spec.ts --project=chromium --reporter=line
+```
+
+**페이지 준비 판정:** `/canvas` → `.react-flow` 가시화 | 그 외 → `load` 이벤트. LCP 안정화: 위 조건 후 LCP 감지 또는 최대 3초 중 빠른 것.
+
+**즉시 중단 조건:** 테스트 실패 | `/signin` 리다이렉트(인증 실패) | JSON 미생성
+
+### 2단계: 결과 JSON 읽기
+
+`apps/frontend/performance/results/`에서 최근 `.json` 파일 읽기.
+
+### 3단계: 리포트 생성
+
+`apps/frontend/performance/reports/YYYY-MM-DD_<safePath>.md`에 저장.
+
+> ⚠️ 아래 기준은 로컬 dev 서버 참고값. 프로덕션/CI와 수치 차이 있음.
+
+#### 지표 판정 기준
+
+**일반 페이지** (`/`, `/signin` 등):
+
+| 지표      | 양호     | 주의        | 위험     |
+| --------- | -------- | ----------- | -------- |
+| LCP       | < 2500ms | 2500~4000ms | > 4000ms |
+| FCP       | < 1800ms | 1800~3000ms | > 3000ms |
+| CLS       | < 0.1    | 0.1~0.25    | > 0.25   |
+| 로드 타임 | < 3000ms | 3000~5000ms | > 5000ms |
+| JS 힙     | < 50MB   | 50~100MB    | > 100MB  |
+
+**캔버스 페이지** (`/canvas` 등):
+
+| 지표             | 양호    | 주의      | 위험    | 비고                    |
+| ---------------- | ------- | --------- | ------- | ----------------------- |
+| LCP / FCP        | —       | —         | —       | SPA 캐시로 항상 낮음    |
+| CLS              | < 0.1   | 0.1~0.25  | > 0.25  | —                       |
+| 로드 타임        | < 3000ms| 3000~5000ms| > 5000ms| `.react-flow` 기준      |
+| JS 힙            | < 100MB | 100~200MB | > 200MB | 노드 수 비례            |
+| 상호작용 렌더/초  | < 5/s   | 5~15/s    | > 15/s  | 마우스 이동 3초 측정    |
+| Long Task 수     | 0       | 1~3       | > 3     | 50ms+ 블로킹            |
+
+#### 리포트 형식
+
+**일반 페이지:**
+
+```markdown
+# Performance Audit: <경로>
+
+> 측정일시: <timestamp> | 브라우저: Chromium | 환경: 로컬 dev 서버
+
+## 측정 지표 요약
+
+| 지표            | 측정값 | 기준    | 상태     |
+| --------------- | ------ | ------- | -------- |
+| LCP             | Xms    | <2500ms | ✅/⚠️/❌ |
+| FCP             | Xms    | <1800ms | ✅/⚠️/❌ |
+| CLS             | X      | <0.1    | ✅/⚠️/❌ |
+| 로드 타임       | Xms    | <3000ms | ✅/⚠️/❌ |
+| JS 힙           | XMB    | <50MB   | ✅/⚠️/❌ |
+| React 커밋 횟수 | X회    | —       | 참고용   |
+| DOM 노드 수     | X개    | —       | 참고용   |
+
+## 원인 분석
+
+(문제 지표 위주로 측정 데이터 근거 서술)
+
+## 해결 방법
+
+(원인별 구체적 해결 방법. 가능하면 코드 예시 포함)
+```
+
+**캔버스 페이지 (`/canvas` 등):**
+
+```markdown
+# Performance Audit: <경로>
+
+> 측정일시: <timestamp> | 브라우저: Chromium | 환경: 로컬 dev 서버
+
+## 측정 지표 요약
+
+| 지표               | 측정값 | 기준    | 상태     |
+| ------------------ | ------ | ------- | -------- |
+| LCP                | Xms    | —       | 참고용   |
+| FCP                | Xms    | —       | 참고용   |
+| CLS                | X      | <0.1    | ✅/⚠️/❌ |
+| 로드 타임          | Xms    | <3000ms | ✅/⚠️/❌ |
+| JS 힙              | XMB    | <100MB  | ✅/⚠️/❌ |
+| React 커밋 횟수    | X회    | —       | 참고용   |
+| DOM 노드 수        | X개    | —       | 참고용   |
+| 상호작용 총 렌더/초 | X/s   | < 5/s   | ✅/⚠️/❌ |
+| Long Task 수       | X개    | 0개     | ✅/⚠️/❌ |
+
+### 상호작용 phases 상세
+
+| Phase     | renderCount | longTaskCount |
+| --------- | ----------- | ------------- |
+| mouseMove | X           | X             |
+| wheelZoom | X           | X             |
+| pan       | X           | X             |
+
+## 원인 분석
+
+(문제 지표 위주로 측정 데이터 근거 서술)
+
+## 해결 방법
+
+(원인별 구체적 해결 방법. 가능하면 코드 예시 포함)
+```
+
+---
+
+## 주의사항
+
+- 서버 자동 시작 안 함. 측정 전 `npm run dev` 직접 실행
+- Chromium 단독 실행 (CDP 전용). 전체 `test:e2e` 실행 시 자동 skip
+- 결과 파일 누적 저장 → 항상 최근 파일 기준으로 분석


### PR DESCRIPTION
## 개요

- `.agents/skills` 하위 성능 측정 skill 3종에 필수 YAML frontmatter 추가
- Codex skill loader가 사용하는 `name`, `description` 메타데이터를 정의해 invalid `SKILL.md` 로딩 경고 해소

