### PR TITLE
chore: load .env from api config

### DIFF
--- a/apps/backend/api/build.gradle
+++ b/apps/backend/api/build.gradle
@@ -112,6 +112,10 @@ tasks.named('bootJar') {
 	exclude('ddl/**')
 }
 
+tasks.named('bootRun') {
+	workingDir = rootProject.projectDir
+}
+
 spotbugs {
 	toolVersion = '4.8.6'
 	effort = 'max'

--- a/apps/backend/api/src/main/resources/application-local.yml
+++ b/apps/backend/api/src/main/resources/application-local.yml
@@ -1,34 +1,7 @@
 spring:
-  application:
-    name: core
   config:
     activate:
       on-profile: local
-
-  r2dbc:
-    url: 'r2dbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:schemafy}'
-    username: '${DB_USER:schemafy}'
-    password: '${DB_PASSWORD:schemafy}'
-    pool:
-      enabled: true
-      initial-size: 5
-      max-size: 20
-
-  sql:
-    init:
-      schema-locations: classpath:ddl/mariadb/**/*.sql
-      mode: always
-
-cache:
-  caffeine:
-    enabled: true
-    maximum-size: 10000
-    expire-after-write-minutes: 30
-    expire-after-access-minutes: 10
-  redis:
-    enabled: true
-    default-ttl-minutes: 30
-    key-prefix: 'cache::'
 
 jwt:
   secret: my-super-secret-key-for-jwt-token-generation-min-256-bits-required

--- a/apps/backend/api/src/main/resources/application-server.yml
+++ b/apps/backend/api/src/main/resources/application-server.yml
@@ -1,34 +1,7 @@
 spring:
-  application:
-    name: core
   config:
     activate:
       on-profile: server
-
-  r2dbc:
-    url: r2dbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:schemafy}
-    username: ${DB_USER:schemafy}
-    password: ${DB_PASSWORD:schemafy}
-    pool:
-      enabled: true
-      initial-size: 5
-      max-size: 20
-
-  sql:
-    init:
-      mode: always
-      schema-locations: classpath:ddl/mariadb/**/*.sql
-
-cache:
-  caffeine:
-    enabled: true
-    maximum-size: 10000
-    expire-after-write-minutes: 30
-    expire-after-access-minutes: 10
-  redis:
-    enabled: true
-    default-ttl-minutes: 30
-    key-prefix: "cache::"
 
 jwt:
   secret: ${JWT_SECRET:my-super-secret-key-for-jwt-token-generation-min-256-bits-required}

--- a/apps/backend/api/src/main/resources/application.yml
+++ b/apps/backend/api/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  config:
+    import:
+      - "optional:file:.env[.properties]"
+
   profiles:
     active: local
 

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -16,6 +16,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter.js';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
+      envFilePath: ['.env', '../../.env'],
     }),
     BackendClientModule,
     CollaborationModule,


### PR DESCRIPTION
## 개요

- API 설정에서 `.env` 파일을 optional properties config로 import하도록 추가
- `api:bootRun` 실행 위치를 프로젝트 루트로 고정
- BFF ConfigModule도 프로젝트 루트 `.env`를 읽도록 정리
- 공통 설정은 `application.yml`에 두고 local/server profile 파일은 환경별 override만 남도록 정리
