### PR TITLE
refactor(#311): 재사용 가능한 훅으로 useCanvasController refactor

### DIFF
--- a/apps/frontend/src/features/collaboration/hooks/useChatInputAnchor.ts
+++ b/apps/frontend/src/features/collaboration/hooks/useChatInputAnchor.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useThrottledCallback } from '@/hooks/useThrottledCallback';
+
+const CHAT_EXIT_ANIMATION_MS = 200;
+const CHAT_FOLLOW_THROTTLE_MS = 50;
+const CHAT_OFFSET_PX = 16;
+
+type Position = { x: number; y: number };
+
+export const useChatInputAnchor = () => {
+  const [position, setPosition] = useState<Position | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    };
+  }, []);
+
+  const close = useCallback(() => {
+    if (exitTimerRef.current) return;
+    setIsOpen(false);
+    setIsExiting(true);
+    exitTimerRef.current = setTimeout(() => {
+      setPosition(null);
+      setIsExiting(false);
+      exitTimerRef.current = null;
+    }, CHAT_EXIT_ANIMATION_MS);
+  }, []);
+
+  const open = useCallback((nextPosition: Position) => {
+    if (exitTimerRef.current) {
+      clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+    setIsExiting(false);
+    setPosition(nextPosition);
+    setIsOpen(true);
+  }, []);
+
+  const followMouse = useThrottledCallback(
+    (clientX: number, clientY: number) => {
+      setPosition({ x: clientX + CHAT_OFFSET_PX, y: clientY + CHAT_OFFSET_PX });
+    },
+    CHAT_FOLLOW_THROTTLE_MS,
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleWindowMouseMove = (e: MouseEvent) => {
+      followMouse(e.clientX, e.clientY);
+    };
+
+    const handleMouseLeave = () => {
+      close();
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const chatInputEl = document.querySelector('[data-chat-input]');
+      if (!chatInputEl || !chatInputEl.contains(e.target as Node)) {
+        close();
+      }
+    };
+
+    window.addEventListener('mousemove', handleWindowMouseMove);
+    document.addEventListener('mouseleave', handleMouseLeave);
+    window.addEventListener('mousedown', handleClickOutside, true);
+
+    return () => {
+      window.removeEventListener('mousemove', handleWindowMouseMove);
+      document.removeEventListener('mouseleave', handleMouseLeave);
+      window.removeEventListener('mousedown', handleClickOutside, true);
+    };
+  }, [isOpen, close, followMouse]);
+
+  return { position, isOpen, isExiting, open, close };
+};

--- a/apps/frontend/src/features/drawing/hooks/useCanvasController.ts
+++ b/apps/frontend/src/features/drawing/hooks/useCanvasController.ts
@@ -10,17 +10,16 @@ import { useSchemas } from './useSchemas';
 import { useErdMutationSync } from './useErdMutationSync';
 import type { Point, RelationshipConfig } from '../types';
 import { collaborationStore } from '@/store/collaboration.store';
+import { useThrottledCallback } from '@/hooks/useThrottledCallback';
+import { useChatInputAnchor } from '@/features/collaboration/hooks/useChatInputAnchor';
 
 const CURSOR_THROTTLE_MS = 50;
-const CHAT_EXIT_ANIMATION_MS = 200;
 
 export const useCanvasController = () => {
   const { projectId, selectedSchemaId } = useSelectedSchema();
   const { data: schemas } = useSchemas(projectId);
   useErdMutationSync(selectedSchemaId, projectId);
   const { screenToFlowPosition } = useReactFlow();
-  const lastCursorSendTime = useRef<number>(0);
-  const lastChatPositionTime = useRef<number>(0);
 
   const [relationshipConfig, setRelationshipConfig] =
     useState<RelationshipConfig>({
@@ -35,12 +34,7 @@ export const useCanvasController = () => {
   } | null>(null);
   const tempMemoPositionRef = useRef(tempMemoPosition);
   tempMemoPositionRef.current = tempMemoPosition;
-  const [chatInputPosition, setChatInputPosition] = useState<Point | null>(
-    null,
-  );
-  const [isChatOpen, setIsChatOpen] = useState(false);
-  const [isChatExiting, setIsChatExiting] = useState(false);
-  const chatExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chat = useChatInputAnchor();
   const [isShortcutPanelOpen, setIsShortcutPanelOpen] = useState(false);
 
   useEffect(() => {
@@ -58,71 +52,12 @@ export const useCanvasController = () => {
     return () => window.removeEventListener('mousemove', handleGlobalMouseMove);
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (chatExitTimerRef.current) clearTimeout(chatExitTimerRef.current);
-    };
-  }, []);
-
-  const closeChatInput = useCallback(() => {
-    if (chatExitTimerRef.current) return;
-    setIsChatOpen(false);
-    setIsChatExiting(true);
-    chatExitTimerRef.current = setTimeout(() => {
-      setChatInputPosition(null);
-      setIsChatExiting(false);
-      chatExitTimerRef.current = null;
-    }, CHAT_EXIT_ANIMATION_MS);
-  }, []);
-
-  const openChatInput = useCallback((position: Point) => {
-    if (chatExitTimerRef.current) {
-      clearTimeout(chatExitTimerRef.current);
-      chatExitTimerRef.current = null;
-    }
-    setIsChatExiting(false);
-    setChatInputPosition(position);
-    setIsChatOpen(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isChatOpen) return;
-
-    const handleWindowMouseMove = (e: MouseEvent) => {
-      const now = Date.now();
-      if (now - lastChatPositionTime.current < CURSOR_THROTTLE_MS) return;
-      lastChatPositionTime.current = now;
-      setChatInputPosition({ x: e.clientX + 16, y: e.clientY + 16 });
-    };
-
-    const handleMouseLeave = () => {
-      closeChatInput();
-    };
-
-    const handleClickOutside = (e: MouseEvent) => {
-      const chatInputEl = document.querySelector('[data-chat-input]');
-      if (!chatInputEl || !chatInputEl.contains(e.target as Node)) {
-        closeChatInput();
-      }
-    };
-
-    window.addEventListener('mousemove', handleWindowMouseMove);
-    document.addEventListener('mouseleave', handleMouseLeave);
-    window.addEventListener('mousedown', handleClickOutside, true);
-
-    return () => {
-      window.removeEventListener('mousemove', handleWindowMouseMove);
-      document.removeEventListener('mouseleave', handleMouseLeave);
-      window.removeEventListener('mousedown', handleClickOutside, true);
-    };
-  }, [isChatOpen, closeChatInput]);
-
   useCanvasKeyboard({
     mousePositionRef,
-    isChatOpen,
+    isChatOpen: chat.isOpen,
     isShortcutPanelOpen,
     activeTool,
-    openChatInput,
+    openChatInput: chat.open,
     setActiveTool,
   });
 
@@ -194,23 +129,20 @@ export const useCanvasController = () => {
     [activeTool, addTable, handleMemoCancel, screenToFlowPosition],
   );
 
+  const sendCursorThrottled = useThrottledCallback(
+    (clientX: number, clientY: number) => {
+      const flowPosition = screenToFlowPosition({ x: clientX, y: clientY });
+      collaborationStore.sendCursor(flowPosition.x, flowPosition.y);
+    },
+    CURSOR_THROTTLE_MS,
+  );
+
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
-      const position = { x: e.clientX, y: e.clientY };
-
-      mousePositionRef.current = position;
-
-      const now = Date.now();
-      if (now - lastCursorSendTime.current >= CURSOR_THROTTLE_MS) {
-        lastCursorSendTime.current = now;
-        const flowPosition = screenToFlowPosition({
-          x: position.x,
-          y: position.y,
-        });
-        collaborationStore.sendCursor(flowPosition.x, flowPosition.y);
-      }
+      mousePositionRef.current = { x: e.clientX, y: e.clientY };
+      sendCursorThrottled(e.clientX, e.clientY);
     },
-    [screenToFlowPosition],
+    [sendCursorThrottled],
   );
 
   return {
@@ -218,8 +150,8 @@ export const useCanvasController = () => {
       relationshipConfig,
       activeTool,
       tempMemoPosition,
-      chatInputPosition,
-      isChatExiting,
+      chatInputPosition: chat.position,
+      isChatExiting: chat.isExiting,
       selectedRelationship,
       isShortcutPanelOpen,
     },
@@ -227,7 +159,6 @@ export const useCanvasController = () => {
       setRelationshipConfig,
       setActiveTool,
       setTempMemoPosition,
-      setChatInputPosition,
       setSelectedRelationship,
       setIsShortcutPanelOpen,
     },
@@ -250,7 +181,7 @@ export const useCanvasController = () => {
       handleMemoCancel,
       handleMemoCreate,
       handleChatSend,
-      closeChatInput,
+      closeChatInput: chat.close,
       handlePaneClick,
       handleMouseMove,
     },

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useTheme } from './useTheme';
 export { useChatMessages } from './useChatMessages';
+export { useThrottledCallback } from './useThrottledCallback';

--- a/apps/frontend/src/hooks/useThrottledCallback.ts
+++ b/apps/frontend/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,20 @@
+import { useCallback, useRef } from 'react';
+
+export const useThrottledCallback = <Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  intervalMs: number,
+) => {
+  const lastTimeRef = useRef(0);
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  return useCallback(
+    (...args: Args) => {
+      const now = Date.now();
+      if (now - lastTimeRef.current < intervalMs) return;
+      lastTimeRef.current = now;
+      fnRef.current(...args);
+    },
+    [intervalMs],
+  );
+};


### PR DESCRIPTION
## 개요

#311의 추가 전 useCanvasController에서 응집도가 명확한 두 책임을 선제적으로 분리한다.

- useThrottledCallback 추가 (leading-edge 시간 기반 throttle): 중복된 lastCursorSendTime / lastChatPositionTime ref를 통합한다.
- useChatInputAnchor 추가: 채팅 입력창의 위치 상태, 오픈/클로즈 전이, exit 애니메이션, 전역 mouse/click 리스너를 캡슐화

## 스크린샷

## 이슈

#311 

- close #311