### PR TITLE
fix(#389): fix signup refresh bug

### DIFF
--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -3,6 +3,7 @@ import { useFormState } from '../hooks';
 import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { signUp } from '@/features/auth/api';
+import { authStore } from '@/store/auth.store';
 import type { ValidationRules, SignUpFormValues } from '../types';
 
 const formFields = [
@@ -84,12 +85,13 @@ export const SignUpForm = () => {
     setIsSubmitting(true);
 
     try {
-      await signUp({
+      const user = await signUp({
         email: form.email,
         name: form.name,
         password: form.password,
       });
 
+      authStore.setUser(user);
       resetForm();
       navigate({ to: '/' });
     } catch {


### PR DESCRIPTION
## 개요

회원가입을 한 직후 로그인되지 않은 상태에서 새로고침을 하면, 로그인이 되는 버그를 고쳤습니다.

## 해결 방법
회원가입 성공 후 authStore.setUser(user)로 유저 정보를 전역 스토어에 저장한 다음 resetForm() → navigate({ to: '/' }) 수행

요약: 회원가입 성공 시 서버가 내려준 유저(access token 포함)를 그냥 버리고 메인으로 이동하던 것을, 이제 authStore에 유저를 세팅한 뒤 이동하도록 수정했습니다. 
가입 직후 별도 로그인 없이 인증 상태가 유지되게 만든 변경입니다. 