### PR TITLE
refactor(#395): tune dark mode canvas colors

### DIFF
--- a/apps/frontend/src/features/drawing/components/ConstraintSection.tsx
+++ b/apps/frontend/src/features/drawing/components/ConstraintSection.tsx
@@ -25,7 +25,7 @@ export const ConstraintSection = ({
   };
 
   return (
-    <div className="border-t-2 border-schemafy-button-bg">
+    <div className="border-t-2 border-schemafy-table-header-bg">
       <div className="bg-schemafy-dark-gray-40 p-2 flex items-center justify-between">
         <span className="text-xs font-medium text-schemafy-text">
           CONSTRAINTS

--- a/apps/frontend/src/features/drawing/components/IndexSection.tsx
+++ b/apps/frontend/src/features/drawing/components/IndexSection.tsx
@@ -19,7 +19,7 @@ export const IndexSection = ({
   }
 
   return (
-    <div className="border-t-2 border-schemafy-button-bg">
+    <div className="border-t-2 border-schemafy-table-header-bg">
       <div className="bg-schemafy-dark-gray-40 p-2 flex items-center justify-between">
         <span className="text-xs font-medium text-schemafy-text">INDEXES</span>
         {isEditMode && (

--- a/apps/frontend/src/features/drawing/components/ReactFlowCanvas.tsx
+++ b/apps/frontend/src/features/drawing/components/ReactFlowCanvas.tsx
@@ -201,7 +201,10 @@ const ReactFlowCanvasComponent = ({
           pannable
         />
         <CustomControls />
-        <Background variant={BackgroundVariant.Dots} />
+        <Background
+          variant={BackgroundVariant.Dots}
+          color="var(--color-schemafy-canvas-dot)"
+        />
         {activeTool === 'table' && <TablePreview />}
         {activeTool === 'memo' && <MemoPreview />}
       </ReactFlow>

--- a/apps/frontend/src/features/drawing/components/TableHeader.tsx
+++ b/apps/frontend/src/features/drawing/components/TableHeader.tsx
@@ -37,7 +37,7 @@ export const TableHeader = ({
   };
 
   return (
-    <div className="bg-schemafy-button-bg text-schemafy-button-text p-3 flex items-center justify-between gap-4">
+    <div className="bg-schemafy-table-header-bg text-schemafy-button-text p-3 flex items-center justify-between gap-4">
       <div className="flex items-center gap-2 flex-1">
         {isEditing ? (
           <div className="flex items-center gap-2 flex-1">

--- a/apps/frontend/src/features/drawing/components/TableNode/index.tsx
+++ b/apps/frontend/src/features/drawing/components/TableNode/index.tsx
@@ -123,7 +123,7 @@ const TableNodeComponent = ({ data, id }: TableProps) => {
   };
 
   return (
-    <div className="group bg-schemafy-bg border-2 border-schemafy-button-bg rounded-lg shadow-md min-w-48 overflow-hidden">
+    <div className="group bg-schemafy-bg border-2 border-schemafy-table-header-bg rounded-lg shadow-md min-w-48 overflow-hidden">
       <ConnectionHandles nodeId={id} />
       <TableHeader
         tableName={data.tableName}

--- a/apps/frontend/src/features/drawing/components/TablePreview.tsx
+++ b/apps/frontend/src/features/drawing/components/TablePreview.tsx
@@ -19,7 +19,7 @@ export const TablePreview = () => {
   return (
     <div
       ref={divRef}
-      className="bg-schemafy-button-bg rounded-lg"
+      className="bg-schemafy-table-header-bg rounded-lg"
       style={{
         display: 'none',
         position: 'absolute',

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -40,8 +40,10 @@
   --color-schemafy-destructive: hsl(var(--schemafy-destructive));
   --color-schemafy-button-bg: hsl(var(--schemafy-button-bg));
   --color-schemafy-button-text: hsl(var(--schemafy-button-text));
+  --color-schemafy-table-header-bg: hsl(var(--schemafy-table-header-bg));
   --color-schemafy-bg-80: hsl(var(--schemafy-bg) / 0.8);
   --color-schemafy-tools: hsl(var(--schemafy-tools));
+  --color-schemafy-canvas-dot: hsl(var(--schemafy-canvas-dot));
   --color-schemafy-yellow: hsl(var(--schemafy-yellow));
   --color-schemafy-blue: hsl(var(--schemafy-blue));
   --color-schemafy-green: hsl(var(--schemafy-green));
@@ -83,7 +85,9 @@
     --schemafy-destructive: 0 84% 60%;
     --schemafy-button-bg: 0 0% 8%;
     --schemafy-button-text: 0 0% 100%;
+    --schemafy-table-header-bg: 0 0% 8%;
     --schemafy-tools: 0 0% 46% / 0.8;
+    --schemafy-canvas-dot: 0 0% 46% / 0.35;
     --schemafy-yellow: 40 96% 40%;
     --schemafy-blue: 218 70% 50%;
     --schemafy-green: 160 84% 36%;
@@ -197,39 +201,41 @@
   }
 
   .dark {
-    --background: 0 0% 12%;
-    --foreground: 0 0% 99%;
-    --card: 0 0% 12%;
-    --card-foreground: 0 0% 99%;
-    --popover: 0 0% 12%;
-    --popover-foreground: 0 0% 99%;
-    --primary: 240 1% 44%;
-    --primary-foreground: 0 0% 99%;
-    --secondary: 0 0% 30%;
-    --secondary-foreground: 0 0% 99%;
-    --muted: 0 0% 30%;
-    --muted-foreground: 240 1% 44%;
-    --accent: 0 0% 99%;
-    --accent-foreground: 0 0% 12%;
-    --destructive: 0 61% 39%;
-    --destructive-foreground: 0 0% 99%;
-    --border: 240 1% 44%;
-    --input: 0 0% 30%;
-    --ring: 0 0% 83%;
+    --background: 240 4% 11%;
+    --foreground: 0 0% 88%;
+    --card: 240 4% 14%;
+    --card-foreground: 0 0% 88%;
+    --popover: 240 4% 14%;
+    --popover-foreground: 0 0% 88%;
+    --primary: 0 0% 88%;
+    --primary-foreground: 240 4% 11%;
+    --secondary: 240 4% 18%;
+    --secondary-foreground: 0 0% 88%;
+    --muted: 240 4% 18%;
+    --muted-foreground: 0 0% 60%;
+    --accent: 240 4% 22%;
+    --accent-foreground: 0 0% 88%;
+    --destructive: 0 66% 58%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 4% 26%;
+    --input: 240 4% 18%;
+    --ring: 0 0% 64%;
 
-    --schemafy-bg: 0 0% 12%;
-    --schemafy-text: 0 0% 99%;
-    --schemafy-secondary: 0 0% 30%;
-    --schemafy-dark-gray: 220 13% 91%;
-    --schemafy-light-gray: 240 1% 44%;
-    --schemafy-dark-gray-40: 240 1% 44% / 0.4;
-    --schemafy-destructive: 0 61% 39%;
-    --schemafy-button-bg: 240 1% 44%;
-    --schemafy-button-text: 0 0% 100%;
-    --schemafy-tools: 240 1% 44%;
-    --schemafy-yellow: 40 85% 65%;
-    --schemafy-blue: 218 70% 65%;
-    --schemafy-green: 160 70% 58%;
+    --schemafy-bg: 240 4% 11%;
+    --schemafy-text: 0 0% 88%;
+    --schemafy-secondary: 240 4% 18%;
+    --schemafy-dark-gray: 0 0% 60%;
+    --schemafy-light-gray: 240 4% 26%;
+    --schemafy-dark-gray-40: 0 0% 60% / 0.4;
+    --schemafy-destructive: 0 66% 58%;
+    --schemafy-button-bg: 240 4% 25%;
+    --schemafy-button-text: 0 0% 88%;
+    --schemafy-table-header-bg: 0 0% 22%;
+    --schemafy-tools: 0 0% 60% / 0.8;
+    --schemafy-canvas-dot: 0 0% 60% / 0.28;
+    --schemafy-yellow: 42 78% 58%;
+    --schemafy-blue: 218 58% 60%;
+    --schemafy-green: 160 54% 44%;
   }
 }
 

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -85,7 +85,7 @@
     --schemafy-destructive: 0 84% 60%;
     --schemafy-button-bg: 0 0% 8%;
     --schemafy-button-text: 0 0% 100%;
-    --schemafy-table-header-bg: 0 0% 8%;
+    --schemafy-table-header-bg: var(--schemafy-button-bg);
     --schemafy-tools: 0 0% 46% / 0.8;
     --schemafy-canvas-dot: 0 0% 46% / 0.35;
     --schemafy-yellow: 40 96% 40%;


### PR DESCRIPTION
## 개요

다크모드 색상 조합을 변경했습니다. (제 미감 내 최선,,)

## 스크린샷

### As-Is
<img width="1470" height="923" alt="스크린샷 2026-06-07 오후 11 25 40" src="https://github.com/user-attachments/assets/faf1066a-35e0-4174-8c49-8286a4820d88" />

### To-Be
<img width="1470" height="923" alt="스크린샷 2026-06-07 오후 11 25 32" src="https://github.com/user-attachments/assets/4ea3eb30-6e50-4e8e-b0d5-880b7933d3e4" />


## 이슈


- close #395