### PR TITLE
feat(#388): include participants in session ready event

### DIFF
--- a/apps/backend/api/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/api/src/docs/asciidoc/api-guide.adoc
@@ -4070,6 +4070,14 @@ WebSocket 연결이 완료된 직후 현재 클라이언트에게만 1회 전송
 {
   "type": "SESSION_READY",
   "sessionId": "session-uuid",
+  "participants": [
+    {
+      "sessionId": "session-uuid",
+      "userId": "01HNQD...",
+      "userName": "cjeongmin",
+      "profileImageUrl": null
+    }
+  ],
   "timestamp": 1703577600000
 }
 ----
@@ -4087,6 +4095,26 @@ WebSocket 연결이 완료된 직후 현재 클라이언트에게만 1회 전송
 |`sessionId`
 |현재 연결된 클라이언트의 WebSocket 세션 ID
 |String
+
+|`participants`
+|현재 프로젝트에 접속 중인 WebSocket 세션 단위 참가자 목록
+|Array
+
+|`participants[].sessionId`
+|접속 중인 WebSocket 세션 ID
+|String
+
+|`participants[].userId`
+|접속 중인 사용자 ID (ULID)
+|String
+
+|`participants[].userName`
+|접속 중인 사용자 이름
+|String
+
+|`participants[].profileImageUrl`
+|접속 중인 사용자의 프로필 이미지 URL. 현재는 `null`일 수 있으며, 프로필 이미지 연동 시 같은 필드를 사용합니다.
+|String 또는 Null
 
 |`timestamp`
 |이벤트 발생 시간 (Unix milliseconds)
@@ -4141,7 +4169,7 @@ WebSocket 연결이 완료된 직후 현재 클라이언트에게만 1회 전송
 
 ===== LEAVE
 
-사용자가 프로젝트에서 나갔을 때 브로드캐스트됩니다.
+사용자가 프로젝트에서 나가거나 protocol heartbeat TTL 만료로 비정상 종료 세션이 정리됐을 때 브로드캐스트됩니다.
 
 [source,json]
 ----

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/ProjectPresenceParticipant.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/ProjectPresenceParticipant.java
@@ -1,0 +1,13 @@
+package com.schemafy.api.collaboration.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record ProjectPresenceParticipant(
+    String sessionId,
+    String userId,
+    String userName,
+    String profileImageUrl) {
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/CollaborationOutboundFactory.java
@@ -1,18 +1,21 @@
 package com.schemafy.api.collaboration.dto.event;
 
+import java.util.List;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.schemafy.api.collaboration.dto.CursorPosition;
 import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public final class CollaborationOutboundFactory {
 
   private CollaborationOutboundFactory() {}
 
-  public static SessionReadyEvent.Outbound sessionReady(String sessionId) {
-    return SessionReadyEvent.Outbound.of(sessionId);
+  public static SessionReadyEvent.Outbound sessionReady(String sessionId,
+      List<ProjectPresenceParticipant> participants) {
+    return SessionReadyEvent.Outbound.of(sessionId, participants);
   }
 
   public static JoinEvent.Outbound join(String sessionId, String userId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/SessionReadyEvent.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/dto/event/SessionReadyEvent.java
@@ -1,7 +1,10 @@
 package com.schemafy.api.collaboration.dto.event;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 
 public final class SessionReadyEvent {
 
@@ -10,10 +13,13 @@ public final class SessionReadyEvent {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record Outbound(
       String sessionId,
+      List<ProjectPresenceParticipant> participants,
       long timestamp) implements CollaborationOutbound {
 
-    public static Outbound of(String sessionId) {
-      return new Outbound(sessionId, System.currentTimeMillis());
+    public static Outbound of(String sessionId,
+        List<ProjectPresenceParticipant> participants) {
+      List<ProjectPresenceParticipant> snapshot = List.copyOf(participants);
+      return new Outbound(sessionId, snapshot, System.currentTimeMillis());
     }
 
     @Override

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
@@ -19,11 +19,13 @@ import com.schemafy.api.collaboration.service.CollaborationDirectMessageSender;
 import com.schemafy.api.collaboration.service.CollaborationService;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.api.collaboration.service.presence.CollaborationPresenceProperties;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.api.common.security.principal.AuthenticatedUser;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Slf4j
@@ -36,6 +38,7 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
   private final CollaborationService collaborationService;
   private final SessionRegistry sessionRegistry;
   private final ProjectAccessValidator projectAccessValidator;
+  private final CollaborationPresenceProperties presenceProperties;
 
   @Override
   public Mono<Void> handle(WebSocketSession session) {
@@ -119,38 +122,37 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
     SessionEntry entry = sessionRegistry.addSession(projectId, sessionId,
         session, authInfo);
 
-    Mono<Void> sessionReady = directMessageSender
-        .sendSessionReady(entry, sessionId)
-        .doOnError(e -> log.warn(
-            "[CollaborationWebSocketHandler] Failed to send session ready: sessionId={}, error={}",
-            sessionId, e.getMessage()));
-
-    Mono<Void> notifyJoin = collaborationService
-        .notifyJoin(projectId, sessionId, userId, userName)
+    Mono<Void> notifyJoin = Mono.defer(() -> collaborationService
+        .notifyJoin(projectId, sessionId, userId, userName))
         .doOnError(e -> log.warn(
             "[CollaborationWebSocketHandler] Failed to notify join: sessionId={}, error={}",
             sessionId, e.getMessage()))
         .onErrorResume(e -> Mono.empty());
 
+    Mono<Void> closeSignal = session.closeStatus().then();
+
     Mono<Void> inbound = session.receive()
-        .map(WebSocketMessage::getPayloadAsText)
-        .flatMap(payload -> collaborationService
-            .handleMessage(projectId, sessionId, payload)
-            .doOnError(e -> log.warn(
-                "[CollaborationWebSocketHandler] Failed to handle message: sessionId={}, error={}",
-                sessionId, e.getMessage()))
-            .onErrorResume(e -> Mono.empty()))
+        .flatMap(message -> handleInboundMessage(projectId, sessionId,
+            message))
         .doOnError(error -> log.error(
             "[CollaborationWebSocketHandler] Inbound error: sessionId={}",
             sessionId, error))
         .then();
 
-    Mono<Void> outbound = session.send(entry.outboundFlux())
+    Flux<WebSocketMessage> presencePings = Flux
+        .interval(presenceProperties.getHeartbeatInterval())
+        .takeUntilOther(closeSignal)
+        .map(tick -> session.pingMessage(bufferFactory -> bufferFactory.wrap(new byte[0])))
+        .doOnError(error -> log.error(
+            "[CollaborationWebSocketHandler] Presence ping error: sessionId={}",
+            sessionId, error));
+
+    Mono<Void> outbound = session
+        .send(Flux.merge(entry.outboundFlux(), presencePings))
         .doOnError(error -> log.error(
             "[CollaborationWebSocketHandler] Outbound error: sessionId={}",
             sessionId, error));
 
-    Mono<Void> closeSignal = session.closeStatus().then();
     Mono<Void> cursorPipeline = entry.sampledCursorFlux()
         .takeUntilOther(closeSignal)
         .flatMap(cursor -> collaborationService
@@ -160,8 +162,14 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
             sessionId, error))
         .then();
 
-    return sessionReady
-        .then(notifyJoin)
+    return collaborationService
+        .registerSession(projectId, sessionId, userId, userName)
+        .flatMap(participants -> directMessageSender
+            .sendSessionReady(entry, sessionId, participants)
+            .doOnError(e -> log.warn(
+                "[CollaborationWebSocketHandler] Failed to send session ready: sessionId={}, error={}",
+                sessionId, e.getMessage()))
+            .then(notifyJoin))
         .then(Mono.zip(inbound, outbound, cursorPipeline).then())
         .doFinally(signalType -> {
           log.info(
@@ -175,6 +183,28 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
               .onErrorResume(e -> Mono.empty())
               .subscribe();
         });
+  }
+
+  private Mono<Void> handleInboundMessage(String projectId,
+      String sessionId, WebSocketMessage message) {
+    if (message.getType() == WebSocketMessage.Type.PONG) {
+      return collaborationService.refreshPresence(projectId, sessionId)
+          .doOnError(e -> log.warn(
+              "[CollaborationWebSocketHandler] Failed to refresh presence from pong: sessionId={}, error={}",
+              sessionId, e.getMessage()))
+          .onErrorResume(e -> Mono.empty());
+    }
+
+    if (message.getType() != WebSocketMessage.Type.TEXT) {
+      return Mono.empty();
+    }
+
+    return collaborationService
+        .handleMessage(projectId, sessionId, message.getPayloadAsText())
+        .doOnError(e -> log.warn(
+            "[CollaborationWebSocketHandler] Failed to handle message: sessionId={}, error={}",
+            sessionId, e.getMessage()))
+        .onErrorResume(e -> Mono.empty());
   }
 
   private Mono<Void> handleUnauthenticated(WebSocketSession session) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
@@ -52,27 +52,32 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
     return session.getHandshakeInfo()
         .getPrincipal()
         .ofType(Authentication.class)
-        .flatMap(authentication -> {
-          Object principal = authentication.getPrincipal();
-          if (!(principal instanceof AuthenticatedUser user)) {
-            return handleUnauthenticated(session);
-          }
+        .map(Optional::of)
+        .defaultIfEmpty(Optional.empty())
+        .flatMap(authenticationOpt -> authenticationOpt
+            .map(authentication -> handleAuthentication(session, authentication,
+                projectIdOpt.get()))
+            .orElseGet(() -> handleUnauthenticated(session)));
+  }
 
-          String userId = user.userId();
-          String userName = user.userName();
-          if (userId == null || userId.isBlank()) {
-            return handleUnauthenticated(session);
-          }
-          if (userName == null || userName.isBlank()) {
-            return handleUnauthenticated(session);
-          }
+  private Mono<Void> handleAuthentication(WebSocketSession session,
+      Authentication authentication, String projectId) {
+    Object principal = authentication.getPrincipal();
+    if (!(principal instanceof AuthenticatedUser user)) {
+      return handleUnauthenticated(session);
+    }
 
-          WebSocketAuthInfo authInfo = WebSocketAuthInfo.of(userId,
-              userName);
-          return validateProjectAccess(session, authInfo,
-              projectIdOpt.get());
-        })
-        .switchIfEmpty(Mono.defer(() -> handleUnauthenticated(session)));
+    String userId = user.userId();
+    String userName = user.userName();
+    if (userId == null || userId.isBlank()) {
+      return handleUnauthenticated(session);
+    }
+    if (userName == null || userName.isBlank()) {
+      return handleUnauthenticated(session);
+    }
+
+    WebSocketAuthInfo authInfo = WebSocketAuthInfo.of(userId, userName);
+    return validateProjectAccess(session, authInfo, projectId);
   }
 
   private Optional<String> extractProjectId(URI uri) {
@@ -170,7 +175,7 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
                 "[CollaborationWebSocketHandler] Failed to send session ready: sessionId={}, error={}",
                 sessionId, e.getMessage()))
             .then(notifyJoin))
-        .then(Mono.zip(inbound, outbound, cursorPipeline).then())
+        .then(Mono.when(inbound, outbound, cursorPipeline))
         .doFinally(signalType -> {
           log.info(
               "[CollaborationWebSocketHandler] WebSocket disconnected: sessionId={}, signal={}",

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
@@ -72,7 +72,7 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
           return validateProjectAccess(session, authInfo,
               projectIdOpt.get());
         })
-        .switchIfEmpty(handleUnauthenticated(session));
+        .switchIfEmpty(Mono.defer(() -> handleUnauthenticated(session)));
   }
 
   private Optional<String> extractProjectId(URI uri) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
@@ -1,7 +1,10 @@
 package com.schemafy.api.collaboration.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
@@ -18,8 +21,10 @@ public class CollaborationDirectMessageSender {
 
   private final CollaborationPayloadSerializer payloadSerializer;
 
-  public Mono<Void> sendSessionReady(SessionEntry entry, String sessionId) {
-    return send(entry, CollaborationOutboundFactory.sessionReady(sessionId));
+  public Mono<Void> sendSessionReady(SessionEntry entry, String sessionId,
+      List<ProjectPresenceParticipant> participants) {
+    return send(entry,
+        CollaborationOutboundFactory.sessionReady(sessionId, participants));
   }
 
   public Mono<Void> send(SessionEntry entry, CollaborationOutbound event) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
@@ -2,6 +2,7 @@ package com.schemafy.api.collaboration.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import com.schemafy.api.collaboration.dto.BroadcastMessage;
 import com.schemafy.api.collaboration.dto.CollaborationEventType;
 import com.schemafy.api.collaboration.dto.CursorPosition;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
@@ -18,6 +20,8 @@ import com.schemafy.api.collaboration.dto.event.CursorEvent;
 import com.schemafy.api.collaboration.service.handler.InboundMessageHandler;
 import com.schemafy.api.collaboration.service.handler.MessageContext;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
+import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.json.JsonCodec;
 
@@ -34,6 +38,7 @@ public class CollaborationService {
   private final SessionRegistry sessionRegistry;
   private final CollaborationEventPublisher eventPublisher;
   private final CollaborationPayloadSerializer payloadSerializer;
+  private final ProjectPresenceStore presenceStore;
   private final JsonCodec jsonCodec;
   private final Map<CollaborationEventType, InboundMessageHandler> handlers;
   private final Map<String, CursorPosition> cursorDedupeCache = new ConcurrentHashMap<>();
@@ -42,11 +47,13 @@ public class CollaborationService {
       SessionRegistry sessionRegistry,
       CollaborationEventPublisher eventPublisher,
       CollaborationPayloadSerializer payloadSerializer,
+      ProjectPresenceStore presenceStore,
       JsonCodec jsonCodec,
       List<InboundMessageHandler> handlerList) {
     this.sessionRegistry = sessionRegistry;
     this.eventPublisher = eventPublisher;
     this.payloadSerializer = payloadSerializer;
+    this.presenceStore = presenceStore;
     this.jsonCodec = jsonCodec;
     this.handlers = handlerList.stream()
         .collect(Collectors.toMap(
@@ -80,36 +87,101 @@ public class CollaborationService {
         CollaborationOutboundFactory.cursor(sessionId, userInfo, cursor));
   }
 
+  public Mono<List<ProjectPresenceParticipant>> registerSession(
+      String projectId, String sessionId, String userId, String userName) {
+    return presenceStore.register(projectId, sessionId, userId, userName)
+        .thenMany(presenceStore.removeExpired(projectId))
+        .flatMap(participant -> eventPublisher.publish(projectId,
+            CollaborationOutboundFactory.leave(participant.sessionId(),
+                participant.userId(), participant.userName()))
+            .thenReturn(participant))
+        .thenMany(presenceStore.findParticipants(projectId))
+        .map(CollaborationService::toParticipant)
+        .collectList()
+        .onErrorResume(e -> {
+          log.warn(
+              "[CollaborationService] Failed to register presence: projectId={}, sessionId={}, error={}",
+              projectId, sessionId, e.getMessage());
+          return Mono.just(List.of(new ProjectPresenceParticipant(sessionId,
+              userId, userName, null)));
+        });
+  }
+
+  public Mono<Void> refreshPresence(String projectId, String sessionId) {
+    return presenceStore.refresh(projectId, sessionId)
+        .switchIfEmpty(Mono.defer(() -> reRegisterPresence(projectId,
+            sessionId)))
+        .doOnError(e -> log.warn(
+            "[CollaborationService] Failed to refresh presence: projectId={}, sessionId={}, error={}",
+            projectId, sessionId, e.getMessage()))
+        .onErrorResume(e -> Mono.empty())
+        .then();
+  }
+
+  private Mono<ProjectPresenceSession> reRegisterPresence(String projectId,
+      String sessionId) {
+    return Mono.justOrEmpty(sessionRegistry.getSessionEntry(projectId,
+        sessionId))
+        .flatMap(entry -> {
+          String userId = entry.authInfo().getUserId();
+          String userName = entry.authInfo().getUserName();
+          return presenceStore.register(projectId, sessionId, userId, userName)
+              .flatMap(presence -> eventPublisher.publish(projectId,
+                  CollaborationOutboundFactory.join(sessionId, userId,
+                      userName))
+                  .thenReturn(presence));
+        });
+  }
+
   public Mono<Void> removeSession(String projectId, String sessionId) {
     cursorDedupeCache.remove(sessionId);
 
-    SessionEntry entry = sessionRegistry
-        .getSessionEntry(projectId, sessionId)
-        .orElse(null);
-    if (entry == null) {
-      log.warn(
-          "[CollaborationService] Session not found for removal: sessionId={}",
-          sessionId);
-      return Mono.fromRunnable(
-          () -> sessionRegistry.removeSession(projectId, sessionId))
-          .then();
-    }
+    Optional<SessionEntry> localEntry = sessionRegistry
+        .getSessionEntry(projectId, sessionId);
 
-    String userId = entry.authInfo().getUserId();
-    String userName = entry.authInfo().getUserName();
+    Mono<ProjectPresenceSession> participant = presenceStore
+        .remove(projectId, sessionId)
+        .switchIfEmpty(Mono.defer(() -> Mono.justOrEmpty(localEntry)
+            .map(entry -> new ProjectPresenceSession(sessionId,
+                entry.authInfo().getUserId(), entry.authInfo().getUserName(),
+                System.currentTimeMillis(), System.currentTimeMillis()))));
 
-    return Mono
-        .fromRunnable(() -> sessionRegistry.removeSession(projectId,
-            sessionId))
-        .then(eventPublisher.publish(projectId,
-            CollaborationOutboundFactory.leave(sessionId, userId,
-                userName)));
+    return participant
+        .flatMap(presence -> eventPublisher.publish(projectId,
+            CollaborationOutboundFactory.leave(presence.sessionId(),
+                presence.userId(), presence.userName())))
+        .doOnError(e -> log.warn(
+            "[CollaborationService] Failed to remove presence: projectId={}, sessionId={}, error={}",
+            projectId, sessionId, e.getMessage()))
+        .onErrorResume(e -> Mono.empty())
+        .then(Mono.fromRunnable(() -> {
+          if (localEntry.isEmpty()) {
+            log.warn(
+                "[CollaborationService] Session not found for local removal: sessionId={}",
+                sessionId);
+          }
+          sessionRegistry.removeSession(projectId, sessionId);
+        }));
   }
 
   public Mono<Void> notifyJoin(String projectId, String sessionId,
       String userId, String userName) {
     return eventPublisher.publish(projectId,
         CollaborationOutboundFactory.join(sessionId, userId, userName));
+  }
+
+  public Mono<Void> removeExpiredPresenceSessions() {
+    return presenceStore.findActiveProjectIds()
+        .flatMap(projectId -> presenceStore.removeExpired(projectId)
+            .flatMap(participant -> eventPublisher.publish(projectId,
+                CollaborationOutboundFactory.leave(participant.sessionId(),
+                    participant.userId(), participant.userName())))
+            .then())
+        .doOnError(e -> log.warn(
+            "[CollaborationService] Failed to remove expired presence sessions: {}",
+            e.getMessage()))
+        .onErrorResume(e -> Mono.empty())
+        .then();
   }
 
   /** handle inbound message */
@@ -189,6 +261,12 @@ public class CollaborationService {
         .onErrorMap(IllegalArgumentException.class,
             e -> new RuntimeException("[CollaborationService] failed to deserialize JSON",
                 e));
+  }
+
+  private static ProjectPresenceParticipant toParticipant(
+      ProjectPresenceSession session) {
+    return new ProjectPresenceParticipant(session.sessionId(),
+        session.userId(), session.userName(), null);
   }
 
   private boolean isDuplicateCursor(CursorPosition first,

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
@@ -134,34 +134,35 @@ public class CollaborationService {
   }
 
   public Mono<Void> removeSession(String projectId, String sessionId) {
-    cursorDedupeCache.remove(sessionId);
+    return Mono.defer(() -> {
+      cursorDedupeCache.remove(sessionId);
 
-    Optional<SessionEntry> localEntry = sessionRegistry
-        .getSessionEntry(projectId, sessionId);
+      Optional<SessionEntry> localEntry = sessionRegistry
+          .getSessionEntry(projectId, sessionId);
+      if (localEntry.isEmpty()) {
+        log.warn(
+            "[CollaborationService] Session not found for local removal: sessionId={}",
+            sessionId);
+      }
+      sessionRegistry.removeSession(projectId, sessionId);
 
-    Mono<ProjectPresenceSession> participant = presenceStore
-        .remove(projectId, sessionId)
-        .switchIfEmpty(Mono.defer(() -> Mono.justOrEmpty(localEntry)
-            .map(entry -> new ProjectPresenceSession(sessionId,
-                entry.authInfo().getUserId(), entry.authInfo().getUserName(),
-                System.currentTimeMillis(), System.currentTimeMillis()))));
+      Mono<ProjectPresenceSession> participant = presenceStore
+          .remove(projectId, sessionId)
+          .switchIfEmpty(Mono.defer(() -> Mono.justOrEmpty(localEntry)
+              .map(entry -> new ProjectPresenceSession(sessionId,
+                  entry.authInfo().getUserId(), entry.authInfo().getUserName(),
+                  System.currentTimeMillis(), System.currentTimeMillis()))));
 
-    return participant
-        .flatMap(presence -> eventPublisher.publish(projectId,
-            CollaborationOutboundFactory.leave(presence.sessionId(),
-                presence.userId(), presence.userName())))
-        .doOnError(e -> log.warn(
-            "[CollaborationService] Failed to remove presence: projectId={}, sessionId={}, error={}",
-            projectId, sessionId, e.getMessage()))
-        .onErrorResume(e -> Mono.empty())
-        .then(Mono.fromRunnable(() -> {
-          if (localEntry.isEmpty()) {
-            log.warn(
-                "[CollaborationService] Session not found for local removal: sessionId={}",
-                sessionId);
-          }
-          sessionRegistry.removeSession(projectId, sessionId);
-        }));
+      return participant
+          .flatMap(presence -> eventPublisher.publish(projectId,
+              CollaborationOutboundFactory.leave(presence.sessionId(),
+                  presence.userId(), presence.userName())))
+          .doOnError(e -> log.warn(
+              "[CollaborationService] Failed to remove presence: projectId={}, sessionId={}, error={}",
+              projectId, sessionId, e.getMessage()))
+          .onErrorResume(e -> Mono.empty())
+          .then();
+    });
   }
 
   public Mono<Void> notifyJoin(String projectId, String sessionId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/CollaborationPresenceProperties.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/CollaborationPresenceProperties.java
@@ -1,0 +1,26 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "collaboration.presence")
+public class CollaborationPresenceProperties {
+
+  private Duration sessionTtl = Duration.ofSeconds(90);
+  private Duration heartbeatInterval = Duration.ofSeconds(30);
+  private Duration cleanupInterval = Duration.ofSeconds(30);
+
+  public Duration getSessionTtl() { return sessionTtl; }
+
+  public void setSessionTtl(Duration sessionTtl) { this.sessionTtl = sessionTtl; }
+
+  public Duration getHeartbeatInterval() { return heartbeatInterval; }
+
+  public void setHeartbeatInterval(Duration heartbeatInterval) { this.heartbeatInterval = heartbeatInterval; }
+
+  public Duration getCleanupInterval() { return cleanupInterval; }
+
+  public void setCleanupInterval(Duration cleanupInterval) { this.cleanupInterval = cleanupInterval; }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceCleanupService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceCleanupService.java
@@ -1,0 +1,48 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.api.collaboration.service.CollaborationService;
+import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnRedisEnabled
+public class ProjectPresenceCleanupService {
+
+  private final CollaborationService collaborationService;
+  private final CollaborationPresenceProperties properties;
+
+  private Disposable cleanupTask;
+
+  @PostConstruct
+  public void start() {
+    cleanupTask = Flux.interval(properties.getCleanupInterval())
+        .concatMap(tick -> collaborationService.removeExpiredPresenceSessions()
+            .onErrorResume(error -> {
+              log.warn(
+                  "[ProjectPresenceCleanupService] Presence cleanup failed: {}",
+                  error.getMessage());
+              return Mono.empty();
+            }))
+        .subscribe();
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (cleanupTask != null && !cleanupTask.isDisposed()) {
+      cleanupTask.dispose();
+    }
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceRedisScripts.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceRedisScripts.java
@@ -9,6 +9,10 @@ final class ProjectPresenceRedisScripts {
       new ClassPathResource("redis/presence/write-session.lua"),
       Long.class);
 
+  static final RedisScript<String> REFRESH_SESSION = RedisScript.of(
+      new ClassPathResource("redis/presence/refresh-session.lua"),
+      String.class);
+
   static final RedisScript<String> REMOVE_EXPIRED_SESSION = RedisScript.of(
       new ClassPathResource("redis/presence/remove-expired-session.lua"),
       String.class);

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceRedisScripts.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceRedisScripts.java
@@ -1,0 +1,22 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.script.RedisScript;
+
+final class ProjectPresenceRedisScripts {
+
+  static final RedisScript<Long> WRITE_SESSION = RedisScript.of(
+      new ClassPathResource("redis/presence/write-session.lua"),
+      Long.class);
+
+  static final RedisScript<String> REMOVE_EXPIRED_SESSION = RedisScript.of(
+      new ClassPathResource("redis/presence/remove-expired-session.lua"),
+      String.class);
+
+  static final RedisScript<Long> CLEANUP_EMPTY_PROJECT = RedisScript.of(
+      new ClassPathResource("redis/presence/cleanup-empty-project.lua"),
+      Long.class);
+
+  private ProjectPresenceRedisScripts() {}
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceSession.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceSession.java
@@ -1,0 +1,12 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProjectPresenceSession(
+    String sessionId,
+    String userId,
+    String userName,
+    long joinedAt,
+    long lastSeenAt) {
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceStore.java
@@ -1,0 +1,21 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ProjectPresenceStore {
+
+  Mono<ProjectPresenceSession> register(String projectId, String sessionId,
+      String userId, String userName);
+
+  Mono<ProjectPresenceSession> refresh(String projectId, String sessionId);
+
+  Mono<ProjectPresenceSession> remove(String projectId, String sessionId);
+
+  Flux<ProjectPresenceSession> findParticipants(String projectId);
+
+  Flux<String> findActiveProjectIds();
+
+  Flux<ProjectPresenceSession> removeExpired(String projectId);
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -112,7 +112,9 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
         .next()
         .flatMap(this::deserializeSession)
         .flatMap(presenceSession -> cleanupProjectIfEmpty(projectId)
-            .thenReturn(presenceSession));
+            .thenReturn(presenceSession))
+        .switchIfEmpty(Mono.defer(() -> cleanupProjectIfEmpty(projectId)
+            .then(Mono.empty())));
   }
 
   private Mono<ProjectPresenceSession> findSession(String projectId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -41,6 +41,21 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
           redis.call('ZREM', expiresKey, sessionId)
           return payload
           """, String.class);
+  private static final RedisScript<Long> CLEANUP_EMPTY_PROJECT_SCRIPT = RedisScript
+      .of("""
+          local activeProjectsKey = KEYS[1]
+          local participantsKey = KEYS[2]
+          local expiresKey = KEYS[3]
+          local projectId = ARGV[1]
+
+          if redis.call('HLEN', participantsKey) > 0 then
+            return 0
+          end
+
+          redis.call('SREM', activeProjectsKey, projectId)
+          redis.call('DEL', participantsKey, expiresKey)
+          return 1
+          """, Long.class);
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final JsonCodec jsonCodec;
@@ -143,14 +158,13 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
   private Mono<ProjectPresenceSession> writeSession(String projectId,
       ProjectPresenceSession presenceSession) {
     return serializeSession(presenceSession)
-        .flatMap(payload -> Mono.when(
-            redisTemplate.<String, String>opsForHash()
-                .put(participantsKey(projectId), presenceSession.sessionId(),
-                    payload),
-            redisTemplate.opsForZSet()
+        .flatMap(payload -> redisTemplate.<String, String>opsForHash()
+            .put(participantsKey(projectId), presenceSession.sessionId(),
+                payload)
+            .then(redisTemplate.opsForZSet()
                 .add(expiresKey(projectId), presenceSession.sessionId(),
-                    expiresAt(presenceSession.lastSeenAt())),
-            redisTemplate.opsForSet()
+                    expiresAt(presenceSession.lastSeenAt())))
+            .then(redisTemplate.opsForSet()
                 .add(ACTIVE_PROJECTS_KEY, projectId))
             .thenReturn(presenceSession));
   }
@@ -165,19 +179,11 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
   }
 
   private Mono<Void> cleanupProjectIfEmpty(String projectId) {
-    return redisTemplate.<String, String>opsForHash()
-        .size(participantsKey(projectId))
-        .flatMap(size -> {
-          if (size > 0) {
-            return Mono.empty();
-          }
-          return Mono.when(
-              redisTemplate.opsForSet()
-                  .remove(ACTIVE_PROJECTS_KEY, projectId),
-              redisTemplate.delete(participantsKey(projectId)),
-              redisTemplate.delete(expiresKey(projectId)))
-              .then();
-        });
+    return redisTemplate.execute(CLEANUP_EMPTY_PROJECT_SCRIPT,
+        List.of(ACTIVE_PROJECTS_KEY, participantsKey(projectId),
+            expiresKey(projectId)),
+        List.of(projectId))
+        .then();
   }
 
   private Mono<String> serializeSession(

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -50,14 +50,13 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
       String sessionId) {
     long now = now();
 
-    return findSession(projectId, sessionId)
-        .map(existing -> new ProjectPresenceSession(
-            existing.sessionId(),
-            existing.userId(),
-            existing.userName(),
-            existing.joinedAt(),
-            now))
-        .flatMap(session -> writeSession(projectId, session));
+    return redisTemplate.execute(ProjectPresenceRedisScripts.REFRESH_SESSION,
+        List.of(participantsKey(projectId), expiresKey(projectId),
+            ACTIVE_PROJECTS_KEY),
+        List.of(sessionId, Long.toString(now), Double.toString(expiresAt(now)),
+            projectId))
+        .next()
+        .flatMap(this::deserializeSession);
   }
 
   @Override

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -1,9 +1,11 @@
 package com.schemafy.api.collaboration.service.presence;
 
 import java.util.Comparator;
+import java.util.List;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
@@ -22,6 +24,23 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
 
   private static final String ACTIVE_PROJECTS_KEY = "collaboration:presence:projects";
   private static final String PROJECT_KEY_PREFIX = "collaboration:presence:project:";
+  private static final RedisScript<String> REMOVE_EXPIRED_SESSION_SCRIPT = RedisScript
+      .of("""
+          local participantsKey = KEYS[1]
+          local expiresKey = KEYS[2]
+          local sessionId = ARGV[1]
+          local now = tonumber(ARGV[2])
+          local score = redis.call('ZSCORE', expiresKey, sessionId)
+
+          if not score or tonumber(score) > now then
+            return nil
+          end
+
+          local payload = redis.call('HGET', participantsKey, sessionId)
+          redis.call('HDEL', participantsKey, sessionId)
+          redis.call('ZREM', expiresKey, sessionId)
+          return payload
+          """, String.class);
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final JsonCodec jsonCodec;
@@ -98,8 +117,20 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
             return cleanupProjectIfEmpty(projectId).thenMany(Flux.empty());
           }
           return Flux.fromIterable(sessionIds)
-              .flatMap(sessionId -> remove(projectId, sessionId));
+              .flatMap(sessionId -> removeExpiredSession(projectId, sessionId,
+                  now));
         });
+  }
+
+  private Mono<ProjectPresenceSession> removeExpiredSession(String projectId,
+      String sessionId, long now) {
+    return redisTemplate.execute(REMOVE_EXPIRED_SESSION_SCRIPT,
+        List.of(participantsKey(projectId), expiresKey(projectId)),
+        List.of(sessionId, Long.toString(now)))
+        .next()
+        .flatMap(this::deserializeSession)
+        .flatMap(presenceSession -> cleanupProjectIfEmpty(projectId)
+            .thenReturn(presenceSession));
   }
 
   private Mono<ProjectPresenceSession> findSession(String projectId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -1,0 +1,189 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import java.util.Comparator;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.json.JsonCodec;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnRedisEnabled
+public class RedisProjectPresenceStore implements ProjectPresenceStore {
+
+  private static final String ACTIVE_PROJECTS_KEY = "collaboration:presence:projects";
+  private static final String PROJECT_KEY_PREFIX = "collaboration:presence:project:";
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final JsonCodec jsonCodec;
+  private final CollaborationPresenceProperties properties;
+
+  @Override
+  public Mono<ProjectPresenceSession> register(String projectId,
+      String sessionId, String userId, String userName) {
+    long now = now();
+
+    return findSession(projectId, sessionId)
+        .defaultIfEmpty(new ProjectPresenceSession(sessionId, userId,
+            userName, now, now))
+        .map(existing -> new ProjectPresenceSession(
+            sessionId,
+            userId,
+            userName,
+            existing.joinedAt(),
+            now))
+        .flatMap(session -> writeSession(projectId, session));
+  }
+
+  @Override
+  public Mono<ProjectPresenceSession> refresh(String projectId,
+      String sessionId) {
+    long now = now();
+
+    return findSession(projectId, sessionId)
+        .map(existing -> new ProjectPresenceSession(
+            existing.sessionId(),
+            existing.userId(),
+            existing.userName(),
+            existing.joinedAt(),
+            now))
+        .flatMap(session -> writeSession(projectId, session));
+  }
+
+  @Override
+  public Mono<ProjectPresenceSession> remove(String projectId,
+      String sessionId) {
+    return findSession(projectId, sessionId)
+        .flatMap(presenceSession -> deleteSession(projectId, sessionId)
+            .thenReturn(presenceSession))
+        .switchIfEmpty(deleteSession(projectId, sessionId)
+            .then(Mono.<ProjectPresenceSession>empty()));
+  }
+
+  @Override
+  public Flux<ProjectPresenceSession> findParticipants(String projectId) {
+    return redisTemplate.<String, String>opsForHash()
+        .values(participantsKey(projectId))
+        .flatMap(this::deserializeSession)
+        .sort(Comparator
+            .comparingLong(ProjectPresenceSession::joinedAt)
+            .thenComparing(ProjectPresenceSession::sessionId));
+  }
+
+  @Override
+  public Flux<String> findActiveProjectIds() {
+    return redisTemplate.opsForSet()
+        .members(ACTIVE_PROJECTS_KEY);
+  }
+
+  @Override
+  public Flux<ProjectPresenceSession> removeExpired(String projectId) {
+    long now = now();
+    Range<Double> expiredRange = Range.closed(0.0, (double) now);
+
+    return redisTemplate.opsForZSet()
+        .rangeByScore(expiresKey(projectId), expiredRange)
+        .collectList()
+        .flatMapMany(sessionIds -> {
+          if (sessionIds.isEmpty()) {
+            return cleanupProjectIfEmpty(projectId).thenMany(Flux.empty());
+          }
+          return Flux.fromIterable(sessionIds)
+              .flatMap(sessionId -> remove(projectId, sessionId));
+        });
+  }
+
+  private Mono<ProjectPresenceSession> findSession(String projectId,
+      String sessionId) {
+    return redisTemplate.<String, String>opsForHash()
+        .get(participantsKey(projectId), sessionId)
+        .flatMap(this::deserializeSession);
+  }
+
+  private Mono<ProjectPresenceSession> writeSession(String projectId,
+      ProjectPresenceSession presenceSession) {
+    return serializeSession(presenceSession)
+        .flatMap(payload -> Mono.when(
+            redisTemplate.<String, String>opsForHash()
+                .put(participantsKey(projectId), presenceSession.sessionId(),
+                    payload),
+            redisTemplate.opsForZSet()
+                .add(expiresKey(projectId), presenceSession.sessionId(),
+                    expiresAt(presenceSession.lastSeenAt())),
+            redisTemplate.opsForSet()
+                .add(ACTIVE_PROJECTS_KEY, projectId))
+            .thenReturn(presenceSession));
+  }
+
+  private Mono<Void> deleteSession(String projectId, String sessionId) {
+    return Mono.when(
+        redisTemplate.<String, String>opsForHash()
+            .remove(participantsKey(projectId), sessionId),
+        redisTemplate.opsForZSet()
+            .remove(expiresKey(projectId), sessionId))
+        .then(cleanupProjectIfEmpty(projectId));
+  }
+
+  private Mono<Void> cleanupProjectIfEmpty(String projectId) {
+    return redisTemplate.<String, String>opsForHash()
+        .size(participantsKey(projectId))
+        .flatMap(size -> {
+          if (size > 0) {
+            return Mono.empty();
+          }
+          return Mono.when(
+              redisTemplate.opsForSet()
+                  .remove(ACTIVE_PROJECTS_KEY, projectId),
+              redisTemplate.delete(participantsKey(projectId)),
+              redisTemplate.delete(expiresKey(projectId)))
+              .then();
+        });
+  }
+
+  private Mono<String> serializeSession(
+      ProjectPresenceSession presenceSession) {
+    return Mono.fromCallable(() -> jsonCodec.serialize(presenceSession))
+        .onErrorMap(IllegalArgumentException.class,
+            e -> new RuntimeException(
+                "[RedisProjectPresenceStore] failed to serialize presence session",
+                e));
+  }
+
+  private Mono<ProjectPresenceSession> deserializeSession(
+      String payload) {
+    return Mono.fromCallable(
+        () -> jsonCodec.parse(payload, ProjectPresenceSession.class))
+        .onErrorResume(error -> {
+          log.warn(
+              "[RedisProjectPresenceStore] Ignoring invalid presence session payload: {}",
+              error.getMessage());
+          return Mono.empty();
+        });
+  }
+
+  private String participantsKey(String projectId) {
+    return PROJECT_KEY_PREFIX + projectId + ":participants";
+  }
+
+  private String expiresKey(String projectId) {
+    return PROJECT_KEY_PREFIX + projectId + ":expires";
+  }
+
+  private double expiresAt(long lastSeenAt) {
+    return lastSeenAt + properties.getSessionTtl().toMillis();
+  }
+
+  private long now() {
+    return System.currentTimeMillis();
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
-import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
@@ -24,53 +23,6 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
 
   private static final String ACTIVE_PROJECTS_KEY = "collaboration:presence:projects";
   private static final String PROJECT_KEY_PREFIX = "collaboration:presence:project:";
-  private static final RedisScript<Long> WRITE_SESSION_SCRIPT = RedisScript
-      .of("""
-          local participantsKey = KEYS[1]
-          local expiresKey = KEYS[2]
-          local activeProjectsKey = KEYS[3]
-          local sessionId = ARGV[1]
-          local payload = ARGV[2]
-          local expiresAt = tonumber(ARGV[3])
-          local projectId = ARGV[4]
-
-          redis.call('HSET', participantsKey, sessionId, payload)
-          redis.call('ZADD', expiresKey, expiresAt, sessionId)
-          redis.call('SADD', activeProjectsKey, projectId)
-          return 1
-          """, Long.class);
-  private static final RedisScript<String> REMOVE_EXPIRED_SESSION_SCRIPT = RedisScript
-      .of("""
-          local participantsKey = KEYS[1]
-          local expiresKey = KEYS[2]
-          local sessionId = ARGV[1]
-          local now = tonumber(ARGV[2])
-          local score = redis.call('ZSCORE', expiresKey, sessionId)
-
-          if not score or tonumber(score) > now then
-            return nil
-          end
-
-          local payload = redis.call('HGET', participantsKey, sessionId)
-          redis.call('HDEL', participantsKey, sessionId)
-          redis.call('ZREM', expiresKey, sessionId)
-          return payload
-          """, String.class);
-  private static final RedisScript<Long> CLEANUP_EMPTY_PROJECT_SCRIPT = RedisScript
-      .of("""
-          local activeProjectsKey = KEYS[1]
-          local participantsKey = KEYS[2]
-          local expiresKey = KEYS[3]
-          local projectId = ARGV[1]
-
-          if redis.call('HLEN', participantsKey) > 0 then
-            return 0
-          end
-
-          redis.call('SREM', activeProjectsKey, projectId)
-          redis.call('DEL', participantsKey, expiresKey)
-          return 1
-          """, Long.class);
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final JsonCodec jsonCodec;
@@ -154,7 +106,7 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
 
   private Mono<ProjectPresenceSession> removeExpiredSession(String projectId,
       String sessionId, long now) {
-    return redisTemplate.execute(REMOVE_EXPIRED_SESSION_SCRIPT,
+    return redisTemplate.execute(ProjectPresenceRedisScripts.REMOVE_EXPIRED_SESSION,
         List.of(participantsKey(projectId), expiresKey(projectId)),
         List.of(sessionId, Long.toString(now)))
         .next()
@@ -173,7 +125,8 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
   private Mono<ProjectPresenceSession> writeSession(String projectId,
       ProjectPresenceSession presenceSession) {
     return serializeSession(presenceSession)
-        .flatMap(payload -> redisTemplate.execute(WRITE_SESSION_SCRIPT,
+        .flatMap(payload -> redisTemplate.execute(
+            ProjectPresenceRedisScripts.WRITE_SESSION,
             List.of(participantsKey(projectId), expiresKey(projectId),
                 ACTIVE_PROJECTS_KEY),
             List.of(presenceSession.sessionId(), payload,
@@ -192,7 +145,7 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
   }
 
   private Mono<Void> cleanupProjectIfEmpty(String projectId) {
-    return redisTemplate.execute(CLEANUP_EMPTY_PROJECT_SCRIPT,
+    return redisTemplate.execute(ProjectPresenceRedisScripts.CLEANUP_EMPTY_PROJECT,
         List.of(ACTIVE_PROJECTS_KEY, participantsKey(projectId),
             expiresKey(projectId)),
         List.of(projectId))

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -24,6 +24,21 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
 
   private static final String ACTIVE_PROJECTS_KEY = "collaboration:presence:projects";
   private static final String PROJECT_KEY_PREFIX = "collaboration:presence:project:";
+  private static final RedisScript<Long> WRITE_SESSION_SCRIPT = RedisScript
+      .of("""
+          local participantsKey = KEYS[1]
+          local expiresKey = KEYS[2]
+          local activeProjectsKey = KEYS[3]
+          local sessionId = ARGV[1]
+          local payload = ARGV[2]
+          local expiresAt = tonumber(ARGV[3])
+          local projectId = ARGV[4]
+
+          redis.call('HSET', participantsKey, sessionId, payload)
+          redis.call('ZADD', expiresKey, expiresAt, sessionId)
+          redis.call('SADD', activeProjectsKey, projectId)
+          return 1
+          """, Long.class);
   private static final RedisScript<String> REMOVE_EXPIRED_SESSION_SCRIPT = RedisScript
       .of("""
           local participantsKey = KEYS[1]
@@ -158,15 +173,13 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
   private Mono<ProjectPresenceSession> writeSession(String projectId,
       ProjectPresenceSession presenceSession) {
     return serializeSession(presenceSession)
-        .flatMap(payload -> redisTemplate.<String, String>opsForHash()
-            .put(participantsKey(projectId), presenceSession.sessionId(),
-                payload)
-            .then(redisTemplate.opsForZSet()
-                .add(expiresKey(projectId), presenceSession.sessionId(),
-                    expiresAt(presenceSession.lastSeenAt())))
-            .then(redisTemplate.opsForSet()
-                .add(ACTIVE_PROJECTS_KEY, projectId))
-            .thenReturn(presenceSession));
+        .flatMap(payload -> redisTemplate.execute(WRITE_SESSION_SCRIPT,
+            List.of(participantsKey(projectId), expiresKey(projectId),
+                ACTIVE_PROJECTS_KEY),
+            List.of(presenceSession.sessionId(), payload,
+                Double.toString(expiresAt(presenceSession.lastSeenAt())),
+                projectId))
+            .then(Mono.just(presenceSession)));
   }
 
   private Mono<Void> deleteSession(String projectId, String sessionId) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -66,8 +66,8 @@ public class RedisProjectPresenceStore implements ProjectPresenceStore {
     return findSession(projectId, sessionId)
         .flatMap(presenceSession -> deleteSession(projectId, sessionId)
             .thenReturn(presenceSession))
-        .switchIfEmpty(deleteSession(projectId, sessionId)
-            .then(Mono.<ProjectPresenceSession>empty()));
+        .switchIfEmpty(Mono.defer(() -> deleteSession(projectId, sessionId)
+            .then(Mono.<ProjectPresenceSession>empty())));
   }
 
   @Override

--- a/apps/backend/api/src/main/resources/application.yml
+++ b/apps/backend/api/src/main/resources/application.yml
@@ -44,6 +44,12 @@ cache:
     default-ttl-minutes: 30
     key-prefix: 'cache::'
 
+collaboration:
+  presence:
+    session-ttl: ${COLLABORATION_PRESENCE_SESSION_TTL:90s}
+    heartbeat-interval: ${COLLABORATION_PRESENCE_HEARTBEAT_INTERVAL:30s}
+    cleanup-interval: ${COLLABORATION_PRESENCE_CLEANUP_INTERVAL:30s}
+
 hmac:
   secret: ${HMAC_SECRET:default-hmac-secret-change-me-in-production}
   previous-secret: ${HMAC_PREVIOUS_SECRET:}

--- a/apps/backend/api/src/main/resources/redis/presence/cleanup-empty-project.lua
+++ b/apps/backend/api/src/main/resources/redis/presence/cleanup-empty-project.lua
@@ -1,0 +1,12 @@
+-- KEYS[1] activeProjectsKey
+-- KEYS[2] participantsKey
+-- KEYS[3] expiresKey
+-- ARGV[1] projectId
+
+if redis.call('HLEN', KEYS[2]) > 0 then
+  return 0
+end
+
+redis.call('SREM', KEYS[1], ARGV[1])
+redis.call('DEL', KEYS[2], KEYS[3])
+return 1

--- a/apps/backend/api/src/main/resources/redis/presence/refresh-session.lua
+++ b/apps/backend/api/src/main/resources/redis/presence/refresh-session.lua
@@ -1,0 +1,27 @@
+-- KEYS[1] participantsKey
+-- KEYS[2] expiresKey
+-- KEYS[3] activeProjectsKey
+-- ARGV[1] sessionId
+-- ARGV[2] lastSeenAt
+-- ARGV[3] expiresAt
+-- ARGV[4] projectId
+
+local payload = redis.call('HGET', KEYS[1], ARGV[1])
+
+if not payload then
+  return nil
+end
+
+local parsed, session = pcall(cjson.decode, payload)
+
+if not parsed or type(session) ~= 'table' then
+  return nil
+end
+
+session['lastSeenAt'] = tonumber(ARGV[2])
+local refreshedPayload = cjson.encode(session)
+
+redis.call('HSET', KEYS[1], ARGV[1], refreshedPayload)
+redis.call('ZADD', KEYS[2], tonumber(ARGV[3]), ARGV[1])
+redis.call('SADD', KEYS[3], ARGV[4])
+return refreshedPayload

--- a/apps/backend/api/src/main/resources/redis/presence/remove-expired-session.lua
+++ b/apps/backend/api/src/main/resources/redis/presence/remove-expired-session.lua
@@ -1,0 +1,15 @@
+-- KEYS[1] participantsKey
+-- KEYS[2] expiresKey
+-- ARGV[1] sessionId
+-- ARGV[2] now
+
+local score = redis.call('ZSCORE', KEYS[2], ARGV[1])
+
+if not score or tonumber(score) > tonumber(ARGV[2]) then
+  return nil
+end
+
+local payload = redis.call('HGET', KEYS[1], ARGV[1])
+redis.call('HDEL', KEYS[1], ARGV[1])
+redis.call('ZREM', KEYS[2], ARGV[1])
+return payload

--- a/apps/backend/api/src/main/resources/redis/presence/write-session.lua
+++ b/apps/backend/api/src/main/resources/redis/presence/write-session.lua
@@ -1,0 +1,12 @@
+-- KEYS[1] participantsKey
+-- KEYS[2] expiresKey
+-- KEYS[3] activeProjectsKey
+-- ARGV[1] sessionId
+-- ARGV[2] payload
+-- ARGV[3] expiresAt
+-- ARGV[4] projectId
+
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('ZADD', KEYS[2], tonumber(ARGV[3]), ARGV[1])
+redis.call('SADD', KEYS[3], ARGV[4])
+return 1

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/SessionReadyEventTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/dto/event/SessionReadyEventTest.java
@@ -1,10 +1,13 @@
 package com.schemafy.api.collaboration.dto.event;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,22 +18,29 @@ class SessionReadyEventTest {
       .findAndRegisterModules();
 
   @Test
-  @DisplayName("Outbound 직렬화 시 type과 sessionId가 포함된다")
-  void serialize_includes_type_and_session_id() throws Exception {
+  @DisplayName("Outbound 직렬화 시 type, sessionId, 참가자 snapshot이 포함된다")
+  void serialize_includes_type_session_id_and_participants() throws Exception {
     SessionReadyEvent.Outbound event = SessionReadyEvent.Outbound.of(
-        "session-1");
+        "session-1", List.of(new ProjectPresenceParticipant(
+            "session-1", "user-1", "tester", null)));
 
     String json = objectMapper.writeValueAsString(event);
 
     assertThat(json).contains("\"type\":\"SESSION_READY\"");
     assertThat(json).contains("\"sessionId\":\"session-1\"");
+    assertThat(json).doesNotContain("participantCount");
+    assertThat(json).contains("\"participants\"");
+    assertThat(json).contains("\"userName\":\"tester\"");
+    assertThat(json).contains("\"profileImageUrl\":null");
+    assertThat(json).doesNotContain("joinedAt");
+    assertThat(json).doesNotContain("lastSeenAt");
   }
 
   @Test
   @DisplayName("Outbound 역직렬화 시 올바른 타입으로 복원된다")
   void deserialize_restores_correct_type() throws Exception {
     SessionReadyEvent.Outbound original = SessionReadyEvent.Outbound.of(
-        "session-1");
+        "session-1", List.of());
 
     String json = objectMapper.writeValueAsString(original);
     CollaborationOutbound deserialized = objectMapper.readValue(json,
@@ -40,6 +50,7 @@ class SessionReadyEventTest {
     SessionReadyEvent.Outbound event = (SessionReadyEvent.Outbound) deserialized;
     assertThat(event.type()).isEqualTo(CollaborationEventType.SESSION_READY);
     assertThat(event.sessionId()).isEqualTo("session-1");
+    assertThat(event.participants()).isEmpty();
     assertThat(event.timestamp()).isGreaterThan(0);
   }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
@@ -1,11 +1,15 @@
 package com.schemafy.api.collaboration.handler;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.List;
 
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.reactive.socket.HandshakeInfo;
+import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,22 +18,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Publisher;
 
 import com.schemafy.api.collaboration.security.ProjectAccessValidator;
 import com.schemafy.api.collaboration.service.CollaborationDirectMessageSender;
 import com.schemafy.api.collaboration.service.CollaborationService;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.api.collaboration.service.presence.CollaborationPresenceProperties;
 import com.schemafy.api.common.security.principal.AuthenticatedUser;
 
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,7 +69,7 @@ class CollaborationWebSocketHandlerTest {
   void handle_sends_session_ready_before_join() {
     CollaborationWebSocketHandler handler = new CollaborationWebSocketHandler(
         directMessageSender, collaborationService, sessionRegistry,
-        projectAccessValidator);
+        projectAccessValidator, new CollaborationPresenceProperties());
     Authentication authentication = new UsernamePasswordAuthenticationToken(
         AuthenticatedUser.of("user-1", "tester"), null);
     HandshakeInfo handshakeInfo = new HandshakeInfo(
@@ -73,7 +83,11 @@ class CollaborationWebSocketHandlerTest {
     given(sessionRegistry.addSession(eq("project-1"), eq("session-1"),
         eq(session), any()))
         .willReturn(entry);
-    given(directMessageSender.sendSessionReady(entry, "session-1"))
+    given(collaborationService.registerSession("project-1", "session-1",
+        "user-1", "tester"))
+        .willReturn(Mono.just(List.of()));
+    given(directMessageSender.sendSessionReady(entry, "session-1",
+        List.of()))
         .willReturn(Mono.empty());
     given(collaborationService.notifyJoin("project-1", "session-1",
         "user-1", "tester"))
@@ -90,8 +104,10 @@ class CollaborationWebSocketHandlerTest {
     Disposable subscription = handler.handle(session).subscribe();
 
     InOrder inOrder = inOrder(directMessageSender, collaborationService);
+    inOrder.verify(collaborationService).registerSession("project-1",
+        "session-1", "user-1", "tester");
     inOrder.verify(directMessageSender).sendSessionReady(entry,
-        "session-1");
+        "session-1", List.of());
     inOrder.verify(collaborationService).notifyJoin("project-1",
         "session-1", "user-1", "tester");
 
@@ -99,6 +115,122 @@ class CollaborationWebSocketHandlerTest {
 
     verify(sessionRegistry).addSession(eq("project-1"), eq("session-1"),
         eq(session), any());
+  }
+
+  @Test
+  @DisplayName("브라우저 PONG을 받으면 presence heartbeat를 갱신한다")
+  void handle_refreshes_presence_when_pong_received() {
+    CollaborationWebSocketHandler handler = new CollaborationWebSocketHandler(
+        directMessageSender, collaborationService, sessionRegistry,
+        projectAccessValidator, new CollaborationPresenceProperties());
+    Authentication authentication = new UsernamePasswordAuthenticationToken(
+        AuthenticatedUser.of("user-1", "tester"), null);
+    HandshakeInfo handshakeInfo = new HandshakeInfo(
+        URI.create("ws://localhost/ws/collaboration?projectId=project-1"),
+        HttpHeaders.EMPTY, Mono.just(authentication), null);
+
+    given(session.getHandshakeInfo()).willReturn(handshakeInfo);
+    given(session.getId()).willReturn("session-1");
+    given(projectAccessValidator.canAccess("project-1", "user-1"))
+        .willReturn(Mono.just(true));
+    given(sessionRegistry.addSession(eq("project-1"), eq("session-1"),
+        eq(session), any()))
+        .willReturn(entry);
+    given(collaborationService.registerSession("project-1", "session-1",
+        "user-1", "tester"))
+        .willReturn(Mono.just(List.of()));
+    given(directMessageSender.sendSessionReady(entry, "session-1",
+        List.of()))
+        .willReturn(Mono.empty());
+    given(collaborationService.notifyJoin("project-1", "session-1",
+        "user-1", "tester"))
+        .willReturn(Mono.empty());
+    given(session.receive()).willReturn(Flux.just(message(
+        WebSocketMessage.Type.PONG)));
+    given(entry.outboundFlux()).willReturn(Flux.never());
+    given(session.send(any())).willReturn(Mono.never());
+    given(session.close(any())).willReturn(Mono.empty());
+    given(session.closeStatus()).willReturn(Mono.never());
+    given(entry.sampledCursorFlux()).willReturn(Flux.never());
+    given(collaborationService.refreshPresence("project-1", "session-1"))
+        .willReturn(Mono.empty());
+    given(collaborationService.removeSession("project-1", "session-1"))
+        .willReturn(Mono.empty());
+
+    Disposable subscription = handler.handle(session).subscribe();
+
+    verify(collaborationService, timeout(1000)).refreshPresence("project-1",
+        "session-1");
+
+    subscription.dispose();
+  }
+
+  @Test
+  @DisplayName("presence heartbeat는 protocol PING frame으로 전송한다")
+  void handle_sends_protocol_ping_frame_for_presence_heartbeat() {
+    CollaborationPresenceProperties properties = new CollaborationPresenceProperties();
+    properties.setHeartbeatInterval(Duration.ofMillis(10));
+    CollaborationWebSocketHandler handler = new CollaborationWebSocketHandler(
+        directMessageSender, collaborationService, sessionRegistry,
+        projectAccessValidator, properties);
+    Authentication authentication = new UsernamePasswordAuthenticationToken(
+        AuthenticatedUser.of("user-1", "tester"), null);
+    HandshakeInfo handshakeInfo = new HandshakeInfo(
+        URI.create("ws://localhost/ws/collaboration?projectId=project-1"),
+        HttpHeaders.EMPTY, Mono.just(authentication), null);
+    Sinks.Many<WebSocketMessage> sentMessages = Sinks.many()
+        .unicast()
+        .onBackpressureBuffer();
+
+    given(session.getHandshakeInfo()).willReturn(handshakeInfo);
+    given(session.getId()).willReturn("session-1");
+    given(projectAccessValidator.canAccess("project-1", "user-1"))
+        .willReturn(Mono.just(true));
+    given(sessionRegistry.addSession(eq("project-1"), eq("session-1"),
+        eq(session), any()))
+        .willReturn(entry);
+    given(collaborationService.registerSession("project-1", "session-1",
+        "user-1", "tester"))
+        .willReturn(Mono.just(List.of()));
+    given(directMessageSender.sendSessionReady(entry, "session-1",
+        List.of()))
+        .willReturn(Mono.empty());
+    given(collaborationService.notifyJoin("project-1", "session-1",
+        "user-1", "tester"))
+        .willReturn(Mono.empty());
+    given(session.receive()).willReturn(Flux.never());
+    given(entry.outboundFlux()).willReturn(Flux.never());
+    given(session.close(any())).willReturn(Mono.empty());
+    given(session.closeStatus()).willReturn(Mono.never());
+    given(entry.sampledCursorFlux()).willReturn(Flux.never());
+    given(session.pingMessage(any())).willReturn(message(
+        WebSocketMessage.Type.PING));
+    given(session.send(any())).willAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      Publisher<WebSocketMessage> publisher = invocation.getArgument(0);
+      return Flux.from(publisher)
+          .doOnNext(message -> sentMessages.tryEmitNext(message))
+          .then();
+    });
+    given(collaborationService.removeSession("project-1", "session-1"))
+        .willReturn(Mono.empty());
+
+    Disposable subscription = handler.handle(session).subscribe();
+
+    StepVerifier.create(sentMessages.asFlux()
+        .filter(message -> message.getType() == WebSocketMessage.Type.PING)
+        .next())
+        .assertNext(message -> assertThat(message.getType())
+            .isEqualTo(WebSocketMessage.Type.PING))
+        .expectComplete()
+        .verify(Duration.ofSeconds(1));
+
+    subscription.dispose();
+  }
+
+  private WebSocketMessage message(WebSocketMessage.Type type) {
+    return new WebSocketMessage(type,
+        new DefaultDataBufferFactory().wrap(new byte[0]));
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -95,7 +96,6 @@ class CollaborationWebSocketHandlerTest {
     given(session.receive()).willReturn(Flux.never());
     given(entry.outboundFlux()).willReturn(Flux.never());
     given(session.send(any())).willReturn(Mono.never());
-    given(session.close(any())).willReturn(Mono.empty());
     given(session.closeStatus()).willReturn(Mono.never());
     given(entry.sampledCursorFlux()).willReturn(Flux.never());
     given(collaborationService.removeSession("project-1", "session-1"))
@@ -149,7 +149,6 @@ class CollaborationWebSocketHandlerTest {
         WebSocketMessage.Type.PONG)));
     given(entry.outboundFlux()).willReturn(Flux.never());
     given(session.send(any())).willReturn(Mono.never());
-    given(session.close(any())).willReturn(Mono.empty());
     given(session.closeStatus()).willReturn(Mono.never());
     given(entry.sampledCursorFlux()).willReturn(Flux.never());
     given(collaborationService.refreshPresence("project-1", "session-1"))
@@ -163,6 +162,8 @@ class CollaborationWebSocketHandlerTest {
         "session-1");
 
     subscription.dispose();
+
+    verify(session, never()).close(any());
   }
 
   @Test
@@ -200,7 +201,6 @@ class CollaborationWebSocketHandlerTest {
         .willReturn(Mono.empty());
     given(session.receive()).willReturn(Flux.never());
     given(entry.outboundFlux()).willReturn(Flux.never());
-    given(session.close(any())).willReturn(Mono.empty());
     given(session.closeStatus()).willReturn(Mono.never());
     given(entry.sampledCursorFlux()).willReturn(Flux.never());
     given(session.pingMessage(any())).willReturn(message(

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSenderTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSenderTest.java
@@ -1,5 +1,7 @@
 package com.schemafy.api.collaboration.service;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.core.common.json.JsonCodec;
 
@@ -31,11 +34,25 @@ class CollaborationDirectMessageSenderTest {
           new JsonCodec(new ObjectMapper().findAndRegisterModules())));
 
   @Test
-  @DisplayName("SESSION_READY를 현재 세션에 직접 전송한다")
-  void sendSessionReady_emits_serialized_payload() {
+  @DisplayName("세션 큐 적재 실패 시 에러를 반환한다")
+  void sendSessionReady_returns_error_when_emit_fails() {
+    given(entry.send(anyString())).willReturn(Sinks.EmitResult.FAIL_TERMINATED);
+
+    StepVerifier.create(sender.sendSessionReady(entry, "session-1",
+        List.of()))
+        .expectErrorSatisfies(error -> assertThat(error)
+            .hasMessageContaining("FAIL_TERMINATED"))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("SESSION_READY를 참가자 snapshot과 함께 직접 전송한다")
+  void sendSessionReady_emits_participant_snapshot() {
     given(entry.send(anyString())).willReturn(Sinks.EmitResult.OK);
 
-    StepVerifier.create(sender.sendSessionReady(entry, "session-1"))
+    StepVerifier.create(sender.sendSessionReady(entry, "session-1",
+        List.of(new ProjectPresenceParticipant("session-1",
+            "user-1", "tester", null))))
         .verifyComplete();
 
     ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(
@@ -44,18 +61,14 @@ class CollaborationDirectMessageSenderTest {
     assertThat(payloadCaptor.getValue())
         .contains("\"type\":\"SESSION_READY\"");
     assertThat(payloadCaptor.getValue())
-        .contains("\"sessionId\":\"session-1\"");
-  }
-
-  @Test
-  @DisplayName("세션 큐 적재 실패 시 에러를 반환한다")
-  void sendSessionReady_returns_error_when_emit_fails() {
-    given(entry.send(anyString())).willReturn(Sinks.EmitResult.FAIL_TERMINATED);
-
-    StepVerifier.create(sender.sendSessionReady(entry, "session-1"))
-        .expectErrorSatisfies(error -> assertThat(error)
-            .hasMessageContaining("FAIL_TERMINATED"))
-        .verify();
+        .contains("\"userName\":\"tester\"");
+    assertThat(payloadCaptor.getValue())
+        .doesNotContain("participantCount");
+    assertThat(payloadCaptor.getValue())
+        .contains("\"profileImageUrl\":null");
+    assertThat(payloadCaptor.getValue())
+        .doesNotContain("joinedAt")
+        .doesNotContain("lastSeenAt");
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -19,12 +20,14 @@ import com.schemafy.api.collaboration.dto.PreviewAction;
 import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.dto.event.CursorEvent;
+import com.schemafy.api.collaboration.dto.event.LeaveEvent;
 import com.schemafy.api.collaboration.security.WebSocketAuthInfo;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
 import com.schemafy.core.common.json.JsonCodec;
 
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -34,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -250,6 +254,56 @@ class CollaborationServiceTest {
     verify(eventPublisher, times(1)).publish(
         eq("project-1"),
         argThat(event -> event.sessionId().equals("session-2")));
+  }
+
+  @Test
+  @DisplayName("세션 제거는 Redis cleanup이 지연되어도 로컬 세션을 먼저 제거한다")
+  void removeSession_removes_local_session_before_remote_cleanup() {
+    given(sessionRegistry.getSessionEntry("project-1", "session-1"))
+        .willReturn(Optional.empty());
+    given(presenceStore.remove("project-1", "session-1"))
+        .willReturn(Mono.never());
+
+    Disposable subscription = collaborationService.removeSession("project-1",
+        "session-1")
+        .subscribe();
+
+    InOrder inOrder = inOrder(sessionRegistry, presenceStore);
+    inOrder.verify(sessionRegistry).getSessionEntry("project-1",
+        "session-1");
+    inOrder.verify(sessionRegistry).removeSession("project-1",
+        "session-1");
+    inOrder.verify(presenceStore).remove("project-1", "session-1");
+
+    subscription.dispose();
+  }
+
+  @Test
+  @DisplayName("Redis presence가 없어도 로컬 세션 정보로 LEAVE를 발행한다")
+  void removeSession_publishes_leave_from_local_entry_when_presence_missing() {
+    SessionEntry entry = mock(SessionEntry.class);
+    given(sessionRegistry.getSessionEntry("project-1", "session-1"))
+        .willReturn(Optional.of(entry));
+    given(entry.authInfo()).willReturn(WebSocketAuthInfo.of("user-1",
+        "tester"));
+    given(presenceStore.remove("project-1", "session-1"))
+        .willReturn(Mono.empty());
+    given(eventPublisher.publish(eq("project-1"), any()))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(collaborationService.removeSession("project-1",
+        "session-1"))
+        .verifyComplete();
+
+    InOrder inOrder = inOrder(sessionRegistry, presenceStore, eventPublisher);
+    inOrder.verify(sessionRegistry).removeSession("project-1",
+        "session-1");
+    inOrder.verify(presenceStore).remove("project-1", "session-1");
+    inOrder.verify(eventPublisher).publish(eq("project-1"),
+        argThat(event -> event instanceof LeaveEvent.Outbound leave
+            && leave.sessionId().equals("session-1")
+            && leave.userId().equals("user-1")
+            && leave.userName().equals("tester")));
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
@@ -1,5 +1,8 @@
 package com.schemafy.api.collaboration.service;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,14 +16,27 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.schemafy.api.collaboration.dto.BroadcastMessage;
 import com.schemafy.api.collaboration.dto.CursorPosition;
 import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.dto.event.CursorEvent;
+import com.schemafy.api.collaboration.security.WebSocketAuthInfo;
+import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
+import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
 import com.schemafy.core.common.json.JsonCodec;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +49,9 @@ class CollaborationServiceTest {
   @Mock
   private CollaborationEventPublisher eventPublisher;
 
+  @Mock
+  private ProjectPresenceStore presenceStore;
+
   private ObjectMapper objectMapper;
   private CollaborationService collaborationService;
 
@@ -43,7 +62,8 @@ class CollaborationServiceTest {
     CollaborationPayloadSerializer serializer = new CollaborationPayloadSerializer(
         jsonCodec);
     collaborationService = new CollaborationService(sessionRegistry,
-        eventPublisher, serializer, jsonCodec, java.util.List.of());
+        eventPublisher, serializer, presenceStore, jsonCodec,
+        List.of());
   }
 
   @Test
@@ -148,13 +168,88 @@ class CollaborationServiceTest {
   @DisplayName("SESSION_READY 이벤트는 Redis 브로드캐스트를 무시한다")
   void handleRedisMessage_ignores_session_ready_event() throws Exception {
     String message = objectMapper.writeValueAsString(
-        CollaborationOutboundFactory.sessionReady("session-1"));
+        CollaborationOutboundFactory.sessionReady("session-1",
+            List.of()));
 
     StepVerifier.create(
         collaborationService.handleRedisMessage("project-1", message))
         .verifyComplete();
 
-    verify(sessionRegistry, never()).broadcast(org.mockito.ArgumentMatchers.any());
+    verify(sessionRegistry, never()).broadcast(any());
+  }
+
+  @Test
+  @DisplayName("세션 등록 시 Redis presence 등록 후 현재 참가자 snapshot을 반환한다")
+  void registerSession_returns_presence_snapshot() {
+    ProjectPresenceSession current = new ProjectPresenceSession(
+        "session-1", "user-1", "tester", 1000L, 1000L);
+    ProjectPresenceSession other = new ProjectPresenceSession(
+        "session-2", "user-2", "other", 900L, 950L);
+    given(presenceStore.register("project-1", "session-1", "user-1",
+        "tester"))
+        .willReturn(Mono.just(current));
+    given(presenceStore.removeExpired("project-1")).willReturn(Flux.empty());
+    given(presenceStore.findParticipants("project-1"))
+        .willReturn(Flux.just(other, current));
+
+    StepVerifier.create(collaborationService.registerSession("project-1",
+        "session-1", "user-1", "tester"))
+        .assertNext(participants -> {
+          assertThat(participants)
+              .extracting(ProjectPresenceParticipant::sessionId)
+              .containsExactly("session-2", "session-1");
+          assertThat(participants)
+              .allSatisfy(participant -> assertThat(
+                  participant.profileImageUrl()).isNull());
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("presence refresh 시 Redis 세션이 없으면 로컬 세션으로 재등록하고 JOIN을 발행한다")
+  void refreshPresence_reregisters_missing_presence_and_publishes_join() {
+    SessionEntry entry = mock(SessionEntry.class);
+    ProjectPresenceSession restored = new ProjectPresenceSession(
+        "session-1", "user-1", "tester", 1000L, 1000L);
+    given(presenceStore.refresh("project-1", "session-1"))
+        .willReturn(Mono.empty());
+    given(sessionRegistry.getSessionEntry("project-1", "session-1"))
+        .willReturn(Optional.of(entry));
+    given(entry.authInfo()).willReturn(WebSocketAuthInfo.of("user-1",
+        "tester"));
+    given(presenceStore.register("project-1", "session-1", "user-1",
+        "tester"))
+        .willReturn(Mono.just(restored));
+    given(eventPublisher.publish(eq("project-1"), any()))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(collaborationService.refreshPresence("project-1",
+        "session-1"))
+        .verifyComplete();
+
+    verify(eventPublisher).publish(eq("project-1"),
+        argThat(event -> event.type().name().equals("JOIN")
+            && event.sessionId().equals("session-1")));
+  }
+
+  @Test
+  @DisplayName("만료된 presence 세션은 LEAVE 이벤트로 발행한다")
+  void removeExpiredPresenceSessions_publishes_leave_events() {
+    ProjectPresenceSession expired = new ProjectPresenceSession(
+        "session-2", "user-2", "other", 900L, 950L);
+    given(presenceStore.findActiveProjectIds())
+        .willReturn(Flux.just("project-1"));
+    given(presenceStore.removeExpired("project-1"))
+        .willReturn(Flux.just(expired));
+    given(eventPublisher.publish(eq("project-1"), any()))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(collaborationService.removeExpiredPresenceSessions())
+        .verifyComplete();
+
+    verify(eventPublisher, times(1)).publish(
+        eq("project-1"),
+        argThat(event -> event.sessionId().equals("session-2")));
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveHashOperations;
+import org.springframework.data.redis.core.ReactiveSetOperations;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.data.redis.core.ReactiveZSetOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,10 +28,14 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +45,7 @@ class RedisProjectPresenceStoreTest {
 
   private static final String PARTICIPANTS_KEY = "collaboration:presence:project:project-1:participants";
   private static final String EXPIRES_KEY = "collaboration:presence:project:project-1:expires";
+  private static final String ACTIVE_PROJECTS_KEY = "collaboration:presence:projects";
 
   @Mock
   private ReactiveStringRedisTemplate redisTemplate;
@@ -47,7 +54,10 @@ class RedisProjectPresenceStoreTest {
   private ReactiveZSetOperations<String, String> zSetOps;
 
   @Mock
-  private ReactiveHashOperations<String, Object, Object> hashOps;
+  private ReactiveHashOperations<String, String, String> hashOps;
+
+  @Mock
+  private ReactiveSetOperations<String, String> setOps;
 
   private JsonCodec jsonCodec;
   private RedisProjectPresenceStore presenceStore;
@@ -87,9 +97,7 @@ class RedisProjectPresenceStoreTest {
     given(zSetOps.rangeByScore(eq(EXPIRES_KEY), any(Range.class)))
         .willReturn(Flux.just("session-1"));
     given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
-        .willReturn(Flux.just(payload));
-    given(redisTemplate.opsForHash()).willReturn(hashOps);
-    given(hashOps.size(PARTICIPANTS_KEY)).willReturn(Mono.just(1L));
+        .willReturn(Flux.just(payload), Flux.just(0L));
 
     StepVerifier.create(presenceStore.removeExpired("project-1"))
         .assertNext(session -> assertThat(session.sessionId())
@@ -99,12 +107,49 @@ class RedisProjectPresenceStoreTest {
     ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
         List.class);
     ArgumentCaptor<List> argsCaptor = ArgumentCaptor.forClass(List.class);
-    verify(redisTemplate).execute(any(RedisScript.class), keysCaptor.capture(),
-        argsCaptor.capture());
+    verify(redisTemplate, times(2)).execute(any(RedisScript.class),
+        keysCaptor.capture(), argsCaptor.capture());
 
-    assertThat(keysCaptor.getValue()).containsExactly(PARTICIPANTS_KEY,
+    assertThat(keysCaptor.getAllValues().get(0)).containsExactly(PARTICIPANTS_KEY,
         EXPIRES_KEY);
-    assertThat(argsCaptor.getValue()).first().isEqualTo("session-1");
+    assertThat(argsCaptor.getAllValues().get(0)).first().isEqualTo("session-1");
+    assertThat(keysCaptor.getAllValues().get(1)).containsExactly(
+        ACTIVE_PROJECTS_KEY, PARTICIPANTS_KEY, EXPIRES_KEY);
+    assertThat(argsCaptor.getAllValues().get(1)).first().isEqualTo("project-1");
+
+    verify(hashOps, never()).size(PARTICIPANTS_KEY);
+    verify(redisTemplate, never()).delete(PARTICIPANTS_KEY);
+    verify(redisTemplate, never()).delete(EXPIRES_KEY);
+  }
+
+  @Test
+  @DisplayName("presence 등록은 참가자 저장 후 만료 score와 active project marker를 순서대로 기록한다")
+  void register_writes_presence_before_active_project_marker() {
+    given(redisTemplate.<String, String>opsForHash()).willReturn(hashOps);
+    given(hashOps.get(PARTICIPANTS_KEY, "session-1"))
+        .willReturn(Mono.empty());
+    given(hashOps.put(eq(PARTICIPANTS_KEY), eq("session-1"), anyString()))
+        .willReturn(Mono.just(true));
+    given(redisTemplate.opsForZSet()).willReturn(zSetOps);
+    given(zSetOps.add(eq(EXPIRES_KEY), eq("session-1"), anyDouble()))
+        .willReturn(Mono.just(true));
+    given(redisTemplate.opsForSet()).willReturn(setOps);
+    given(setOps.add(ACTIVE_PROJECTS_KEY, "project-1"))
+        .willReturn(Mono.just(1L));
+
+    StepVerifier.create(presenceStore.register("project-1", "session-1",
+        "user-1", "tester"))
+        .assertNext(session -> assertThat(session.sessionId())
+            .isEqualTo("session-1"))
+        .verifyComplete();
+
+    InOrder inOrder = inOrder(hashOps, zSetOps, setOps);
+    inOrder.verify(hashOps).get(PARTICIPANTS_KEY, "session-1");
+    inOrder.verify(hashOps).put(eq(PARTICIPANTS_KEY), eq("session-1"),
+        anyString());
+    inOrder.verify(zSetOps).add(eq(EXPIRES_KEY), eq("session-1"),
+        anyDouble());
+    inOrder.verify(setOps).add(ACTIVE_PROJECTS_KEY, "project-1");
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -64,18 +64,54 @@ class RedisProjectPresenceStoreTest {
   }
 
   @Test
-  @DisplayName("만료 후보가 heartbeat로 갱신되면 삭제 결과를 반환하지 않는다")
+  @DisplayName("만료 후보가 heartbeat로 갱신되면 결과 없이 빈 프로젝트 cleanup만 확인한다")
   void removeExpired_ignores_session_refreshed_after_candidate_scan() {
     given(redisTemplate.opsForZSet()).willReturn(zSetOps);
     given(zSetOps.rangeByScore(eq(EXPIRES_KEY), any(Range.class)))
         .willReturn(Flux.just("session-1"));
     given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
-        .willReturn(Flux.empty());
+        .willReturn(Flux.empty(), Flux.just(0L));
 
     StepVerifier.create(presenceStore.removeExpired("project-1"))
         .verifyComplete();
 
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
+        List.class);
+    ArgumentCaptor<List> argsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(redisTemplate, times(2)).execute(any(RedisScript.class),
+        keysCaptor.capture(), argsCaptor.capture());
+
+    assertThat(keysCaptor.getAllValues().get(0)).containsExactly(PARTICIPANTS_KEY,
+        EXPIRES_KEY);
+    assertThat(argsCaptor.getAllValues().get(0)).first().isEqualTo("session-1");
+    assertThat(keysCaptor.getAllValues().get(1)).containsExactly(
+        ACTIVE_PROJECTS_KEY, PARTICIPANTS_KEY, EXPIRES_KEY);
+    assertThat(argsCaptor.getAllValues().get(1)).first().isEqualTo("project-1");
+
     verify(zSetOps, never()).remove(EXPIRES_KEY, "session-1");
+  }
+
+  @Test
+  @DisplayName("만료 payload 역직렬화가 실패해도 빈 프로젝트 cleanup을 확인한다")
+  void removeExpired_checks_empty_project_when_expired_payload_is_invalid() {
+    given(redisTemplate.opsForZSet()).willReturn(zSetOps);
+    given(zSetOps.rangeByScore(eq(EXPIRES_KEY), any(Range.class)))
+        .willReturn(Flux.just("session-1"));
+    given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+        .willReturn(Flux.just("{"), Flux.just(0L));
+
+    StepVerifier.create(presenceStore.removeExpired("project-1"))
+        .verifyComplete();
+
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
+        List.class);
+    verify(redisTemplate, times(2)).execute(any(RedisScript.class),
+        keysCaptor.capture(), anyList());
+
+    assertThat(keysCaptor.getAllValues().get(0)).containsExactly(PARTICIPANTS_KEY,
+        EXPIRES_KEY);
+    assertThat(keysCaptor.getAllValues().get(1)).containsExactly(
+        ACTIVE_PROJECTS_KEY, PARTICIPANTS_KEY, EXPIRES_KEY);
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -151,6 +151,59 @@ class RedisProjectPresenceStoreTest {
   }
 
   @Test
+  @DisplayName("presence refresh는 Redis script 한 번으로 payload와 만료 score를 갱신한다")
+  void refresh_updates_presence_metadata_atomically() {
+    ProjectPresenceSession refreshed = new ProjectPresenceSession(
+        "session-1", "user-1", "tester", 1000L, 2000L);
+    String payload = jsonCodec.serialize(refreshed);
+
+    given(redisTemplate.execute(eq(ProjectPresenceRedisScripts.REFRESH_SESSION),
+        anyList(), anyList()))
+        .willReturn(Flux.just(payload));
+
+    StepVerifier.create(presenceStore.refresh("project-1", "session-1"))
+        .assertNext(session -> {
+          assertThat(session.sessionId()).isEqualTo("session-1");
+          assertThat(session.lastSeenAt()).isEqualTo(2000L);
+        })
+        .verifyComplete();
+
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
+        List.class);
+    ArgumentCaptor<List> argsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(redisTemplate).execute(eq(ProjectPresenceRedisScripts.REFRESH_SESSION),
+        keysCaptor.capture(), argsCaptor.capture());
+
+    assertThat(keysCaptor.getValue()).containsExactly(PARTICIPANTS_KEY,
+        EXPIRES_KEY, ACTIVE_PROJECTS_KEY);
+    assertThat(argsCaptor.getValue()).hasSize(4);
+    assertThat(argsCaptor.getValue().get(0)).isEqualTo("session-1");
+    long lastSeenAt = Long.parseLong((String) argsCaptor.getValue().get(1));
+    double expiresAt = Double.parseDouble((String) argsCaptor.getValue().get(2));
+    assertThat(expiresAt).isEqualTo(lastSeenAt + Duration.ofSeconds(90)
+        .toMillis());
+    assertThat(argsCaptor.getValue().get(3)).isEqualTo("project-1");
+
+    verify(redisTemplate, never()).opsForHash();
+    verify(redisTemplate, never()).opsForZSet();
+  }
+
+  @Test
+  @DisplayName("presence refresh가 세션을 찾지 못하면 재등록 경로를 위해 empty로 끝낸다")
+  void refresh_returns_empty_when_session_is_missing() {
+    given(redisTemplate.execute(eq(ProjectPresenceRedisScripts.REFRESH_SESSION),
+        anyList(), anyList()))
+        .willReturn(Flux.empty());
+
+    StepVerifier.create(presenceStore.refresh("project-1", "session-1"))
+        .verifyComplete();
+
+    verify(redisTemplate).execute(eq(ProjectPresenceRedisScripts.REFRESH_SESSION),
+        anyList(), anyList());
+    verify(redisTemplate, never()).opsForHash();
+  }
+
+  @Test
   @DisplayName("presence 등록은 참가자, 만료 score, active project marker를 원자적으로 기록한다")
   void register_writes_presence_metadata_atomically() {
     given(redisTemplate.<String, String>opsForHash()).willReturn(hashOps);
@@ -191,6 +244,8 @@ class RedisProjectPresenceStoreTest {
   void redisScripts_are_loaded_from_classpath_resources() {
     assertThat(ProjectPresenceRedisScripts.WRITE_SESSION.getScriptAsString())
         .contains("HSET", "ZADD", "SADD");
+    assertThat(ProjectPresenceRedisScripts.REFRESH_SESSION.getScriptAsString())
+        .contains("HGET", "HSET", "ZADD", "cjson.decode");
     assertThat(ProjectPresenceRedisScripts.REMOVE_EXPIRED_SESSION
         .getScriptAsString())
         .contains("ZSCORE", "HDEL", "ZREM");

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -1,0 +1,110 @@
+package com.schemafy.api.collaboration.service.presence;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.core.ReactiveHashOperations;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ReactiveZSetOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schemafy.core.common.json.JsonCodec;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisProjectPresenceStore 단위 테스트")
+@SuppressWarnings({ "unchecked", "rawtypes" })
+class RedisProjectPresenceStoreTest {
+
+  private static final String PARTICIPANTS_KEY = "collaboration:presence:project:project-1:participants";
+  private static final String EXPIRES_KEY = "collaboration:presence:project:project-1:expires";
+
+  @Mock
+  private ReactiveStringRedisTemplate redisTemplate;
+
+  @Mock
+  private ReactiveZSetOperations<String, String> zSetOps;
+
+  @Mock
+  private ReactiveHashOperations<String, Object, Object> hashOps;
+
+  private JsonCodec jsonCodec;
+  private RedisProjectPresenceStore presenceStore;
+
+  @BeforeEach
+  void setUp() {
+    jsonCodec = new JsonCodec(new ObjectMapper().findAndRegisterModules());
+    CollaborationPresenceProperties properties = new CollaborationPresenceProperties();
+    properties.setSessionTtl(Duration.ofSeconds(90));
+    presenceStore = new RedisProjectPresenceStore(redisTemplate, jsonCodec,
+        properties);
+  }
+
+  @Test
+  @DisplayName("만료 후보가 heartbeat로 갱신되면 삭제 결과를 반환하지 않는다")
+  void removeExpired_ignores_session_refreshed_after_candidate_scan() {
+    given(redisTemplate.opsForZSet()).willReturn(zSetOps);
+    given(zSetOps.rangeByScore(eq(EXPIRES_KEY), any(Range.class)))
+        .willReturn(Flux.just("session-1"));
+    given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+        .willReturn(Flux.empty());
+
+    StepVerifier.create(presenceStore.removeExpired("project-1"))
+        .verifyComplete();
+
+    verify(zSetOps, never()).remove(EXPIRES_KEY, "session-1");
+  }
+
+  @Test
+  @DisplayName("만료 세션은 현재 score 조건을 확인하는 Redis script로 삭제한다")
+  void removeExpired_deletes_session_with_guarded_script() {
+    ProjectPresenceSession expired = new ProjectPresenceSession(
+        "session-1", "user-1", "tester", 1000L, 1000L);
+    String payload = jsonCodec.serialize(expired);
+
+    given(redisTemplate.opsForZSet()).willReturn(zSetOps);
+    given(zSetOps.rangeByScore(eq(EXPIRES_KEY), any(Range.class)))
+        .willReturn(Flux.just("session-1"));
+    given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+        .willReturn(Flux.just(payload));
+    given(redisTemplate.opsForHash()).willReturn(hashOps);
+    given(hashOps.size(PARTICIPANTS_KEY)).willReturn(Mono.just(1L));
+
+    StepVerifier.create(presenceStore.removeExpired("project-1"))
+        .assertNext(session -> assertThat(session.sessionId())
+            .isEqualTo("session-1"))
+        .verifyComplete();
+
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
+        List.class);
+    ArgumentCaptor<List> argsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(redisTemplate).execute(any(RedisScript.class), keysCaptor.capture(),
+        argsCaptor.capture());
+
+    assertThat(keysCaptor.getValue()).containsExactly(PARTICIPANTS_KEY,
+        EXPIRES_KEY);
+    assertThat(argsCaptor.getValue()).first().isEqualTo("session-1");
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -150,4 +150,17 @@ class RedisProjectPresenceStoreTest {
     verify(redisTemplate, never()).opsForSet();
   }
 
+  @Test
+  @DisplayName("presence Redis script 리소스를 classpath에서 로드한다")
+  void redisScripts_are_loaded_from_classpath_resources() {
+    assertThat(ProjectPresenceRedisScripts.WRITE_SESSION.getScriptAsString())
+        .contains("HSET", "ZADD", "SADD");
+    assertThat(ProjectPresenceRedisScripts.REMOVE_EXPIRED_SESSION
+        .getScriptAsString())
+        .contains("ZSCORE", "HDEL", "ZREM");
+    assertThat(ProjectPresenceRedisScripts.CLEANUP_EMPTY_PROJECT
+        .getScriptAsString())
+        .contains("HLEN", "SREM", "DEL");
+  }
+
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStoreTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveHashOperations;
-import org.springframework.data.redis.core.ReactiveSetOperations;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.data.redis.core.ReactiveZSetOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -28,12 +26,9 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,9 +50,6 @@ class RedisProjectPresenceStoreTest {
 
   @Mock
   private ReactiveHashOperations<String, String, String> hashOps;
-
-  @Mock
-  private ReactiveSetOperations<String, String> setOps;
 
   private JsonCodec jsonCodec;
   private RedisProjectPresenceStore presenceStore;
@@ -123,19 +115,13 @@ class RedisProjectPresenceStoreTest {
   }
 
   @Test
-  @DisplayName("presence 등록은 참가자 저장 후 만료 score와 active project marker를 순서대로 기록한다")
-  void register_writes_presence_before_active_project_marker() {
+  @DisplayName("presence 등록은 참가자, 만료 score, active project marker를 원자적으로 기록한다")
+  void register_writes_presence_metadata_atomically() {
     given(redisTemplate.<String, String>opsForHash()).willReturn(hashOps);
     given(hashOps.get(PARTICIPANTS_KEY, "session-1"))
         .willReturn(Mono.empty());
-    given(hashOps.put(eq(PARTICIPANTS_KEY), eq("session-1"), anyString()))
-        .willReturn(Mono.just(true));
-    given(redisTemplate.opsForZSet()).willReturn(zSetOps);
-    given(zSetOps.add(eq(EXPIRES_KEY), eq("session-1"), anyDouble()))
-        .willReturn(Mono.just(true));
-    given(redisTemplate.opsForSet()).willReturn(setOps);
-    given(setOps.add(ACTIVE_PROJECTS_KEY, "project-1"))
-        .willReturn(Mono.just(1L));
+    given(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+        .willReturn(Flux.just(1L));
 
     StepVerifier.create(presenceStore.register("project-1", "session-1",
         "user-1", "tester"))
@@ -143,13 +129,25 @@ class RedisProjectPresenceStoreTest {
             .isEqualTo("session-1"))
         .verifyComplete();
 
-    InOrder inOrder = inOrder(hashOps, zSetOps, setOps);
-    inOrder.verify(hashOps).get(PARTICIPANTS_KEY, "session-1");
-    inOrder.verify(hashOps).put(eq(PARTICIPANTS_KEY), eq("session-1"),
-        anyString());
-    inOrder.verify(zSetOps).add(eq(EXPIRES_KEY), eq("session-1"),
-        anyDouble());
-    inOrder.verify(setOps).add(ACTIVE_PROJECTS_KEY, "project-1");
+    ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(
+        List.class);
+    ArgumentCaptor<List> argsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(redisTemplate).execute(any(RedisScript.class), keysCaptor.capture(),
+        argsCaptor.capture());
+
+    assertThat(keysCaptor.getValue()).containsExactly(PARTICIPANTS_KEY,
+        EXPIRES_KEY, ACTIVE_PROJECTS_KEY);
+    assertThat(argsCaptor.getValue()).hasSize(4);
+    assertThat(argsCaptor.getValue().get(0)).isEqualTo("session-1");
+    assertThat(argsCaptor.getValue().get(1)).asString()
+        .contains("\"sessionId\":\"session-1\"");
+    assertThat(argsCaptor.getValue().get(2)).asString()
+        .isNotBlank();
+    assertThat(argsCaptor.getValue().get(3)).isEqualTo("project-1");
+
+    verify(hashOps, never()).put(eq(PARTICIPANTS_KEY), eq("session-1"), any());
+    verify(redisTemplate, never()).opsForZSet();
+    verify(redisTemplate, never()).opsForSet();
   }
 
 }


### PR DESCRIPTION
## 개요

- 협업 WebSocket 세션 생성 직후 `SESSION_READY` 이벤트로 현재 프로젝트 참가자 목록을 내려주도록 변경
- 참가자 목록은 `sessionId`, `userId`, `userName`, `profileImageUrl`을 포함하는 session 단위 snapshot으로 제공
- WebSocket protocol `PING/PONG` 기반 heartbeat와 TTL cleanup으로 비정상 종료된 presence 세션을 정리하도록 처리

## 참고

- 같은 사용자가 여러 탭으로 접속한 경우에도 session 단위 참가자로 응답
- Redis Lua script로 presence 저장, 만료 삭제, 빈 프로젝트 cleanup 경로의 원자성 보완

## 테스트

- `./gradlew :api:spotlessCheck :api:test --tests 'com.schemafy.api.collaboration.service.presence.RedisProjectPresenceStoreTest' --tests '*collaboration*'`

## 이슈

- close #388
