### PR TITLE
fix(#401): fix collaborative cursor behavior during canvas viewport changes

### DIFF
--- a/apps/frontend/src/features/collaboration/components/RemoteCursors.tsx
+++ b/apps/frontend/src/features/collaboration/components/RemoteCursors.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import { useReactFlow } from '@xyflow/react';
+import { useReactFlow, useViewport } from '@xyflow/react';
 import { collaborationStore } from '@/store/collaboration.store';
 import { useChatMessages } from '@/hooks';
 import { CURSOR_TRANSITION_MS, getCursorColor } from '../utils';
@@ -15,6 +15,7 @@ const RemoteCursor = observer(({ sessionId }: RemoteCursorProps) => {
   const cursor = collaborationStore.cursors.get(sessionId);
   const activeMessage = collaborationStore.activeChatMessages.get(sessionId);
   const { flowToScreenPosition } = useReactFlow();
+  useViewport();
   const color = getCursorColor(sessionId);
 
   if (!cursor) return null;

--- a/apps/frontend/src/features/drawing/hooks/useCanvasController.ts
+++ b/apps/frontend/src/features/drawing/hooks/useCanvasController.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useReactFlow } from '@xyflow/react';
+import { useKeyPress, useReactFlow } from '@xyflow/react';
 import { useRelationships } from './useRelationships';
 import { useTables } from './useTables';
 import { useViewport } from './useViewport';
@@ -36,6 +36,7 @@ export const useCanvasController = () => {
   tempMemoPositionRef.current = tempMemoPosition;
   const chat = useChatInputAnchor();
   const [isShortcutPanelOpen, setIsShortcutPanelOpen] = useState(false);
+  const isSpacePanKeyPressed = useKeyPress('Space');
 
   useEffect(() => {
     collaborationStore.connect(projectId);
@@ -140,9 +141,12 @@ export const useCanvasController = () => {
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
       mousePositionRef.current = { x: e.clientX, y: e.clientY };
+      if ((activeTool === 'hand' || isSpacePanKeyPressed) && e.buttons === 1)
+        return;
+
       sendCursorThrottled(e.clientX, e.clientY);
     },
-    [sendCursorThrottled],
+    [activeTool, isSpacePanKeyPressed, sendCursorThrottled],
   );
 
   return {


### PR DESCRIPTION
## 개요
- 캔버스 화면을 움직일 때 팀원들의 커서가 안움직이는 버그 수정
- 캔버스 툴이 hand이거나, 스페이스바 키를 통해 캔버스 화면을 움직일 때 커서 이동이 감지되지 않도록 수정


- close #401