### PR TITLE
fix(#406): fix the invitation target details in notifications

### DIFF
--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/MyInvitationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/MyInvitationResponse.java
@@ -26,10 +26,14 @@ public record MyInvitationResponse(
         invitation.targetDescription(),
         invitation.invitedEmail(),
         invitation.invitedRole(),
-        invitation.invitedBy(),
+        displayInvitedBy(invitation.invitedBy()),
         invitation.status(),
         invitation.expiresAt(),
         invitation.createdAt());
+  }
+
+  private static String displayInvitedBy(String invitedBy) {
+    return invitedBy == null ? "Unknown" : invitedBy;
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/ProjectInvitationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/ProjectInvitationResponse.java
@@ -2,12 +2,14 @@ package com.schemafy.api.project.controller.dto.response;
 
 import java.time.Instant;
 
-import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 
 public record ProjectInvitationResponse(
     String id,
-    String workspaceId,
-    String projectId,
+    String type,
+    String targetId,
+    String targetName,
+    String targetDescription,
     String invitedEmail,
     String invitedRole,
     String invitedBy,
@@ -16,18 +18,24 @@ public record ProjectInvitationResponse(
     Instant resolvedAt,
     Instant createdAt) {
 
-  public static ProjectInvitationResponse of(Invitation invitation) {
+  public static ProjectInvitationResponse of(InvitationSummary invitation) {
     return new ProjectInvitationResponse(
-        invitation.getId(),
-        invitation.getParentId(),
-        invitation.getTargetId(),
-        invitation.getInvitedEmail(),
-        invitation.getInvitedRole(),
-        invitation.getInvitedBy(),
-        invitation.getStatus(),
-        invitation.getExpiresAt(),
-        invitation.getResolvedAt(),
-        invitation.getCreatedAt());
+        invitation.id(),
+        invitation.targetType(),
+        invitation.targetId(),
+        invitation.targetName(),
+        invitation.targetDescription(),
+        invitation.invitedEmail(),
+        invitation.invitedRole(),
+        displayInvitedBy(invitation.invitedBy()),
+        invitation.status(),
+        invitation.expiresAt(),
+        invitation.resolvedAt(),
+        invitation.createdAt());
+  }
+
+  private static String displayInvitedBy(String invitedBy) {
+    return invitedBy == null ? "Unknown" : invitedBy;
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/WorkspaceInvitationResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/WorkspaceInvitationResponse.java
@@ -2,11 +2,14 @@ package com.schemafy.api.project.controller.dto.response;
 
 import java.time.Instant;
 
-import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 
 public record WorkspaceInvitationResponse(
     String id,
-    String workspaceId,
+    String type,
+    String targetId,
+    String targetName,
+    String targetDescription,
     String invitedEmail,
     String invitedRole,
     String invitedBy,
@@ -15,17 +18,24 @@ public record WorkspaceInvitationResponse(
     Instant resolvedAt,
     Instant createdAt) {
 
-  public static WorkspaceInvitationResponse of(Invitation invitation) {
+  public static WorkspaceInvitationResponse of(InvitationSummary invitation) {
     return new WorkspaceInvitationResponse(
-        invitation.getId(),
-        invitation.getWorkspaceId(),
-        invitation.getInvitedEmail(),
-        invitation.getInvitedRole(),
-        invitation.getInvitedBy(),
-        invitation.getStatus(),
-        invitation.getExpiresAt(),
-        invitation.getResolvedAt(),
-        invitation.getCreatedAt());
+        invitation.id(),
+        invitation.targetType(),
+        invitation.targetId(),
+        invitation.targetName(),
+        invitation.targetDescription(),
+        invitation.invitedEmail(),
+        invitation.invitedRole(),
+        displayInvitedBy(invitation.invitedBy()),
+        invitation.status(),
+        invitation.expiresAt(),
+        invitation.resolvedAt(),
+        invitation.createdAt());
+  }
+
+  private static String displayInvitedBy(String invitedBy) {
+    return invitedBy == null ? "Unknown" : invitedBy;
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/InvitationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/InvitationControllerTest.java
@@ -104,15 +104,37 @@ class InvitationControllerTest extends ProjectHttpTestSupport {
           .jsonPath("$.content[0].targetName").isEqualTo(testProject.getName())
           .jsonPath("$.content[0].targetDescription")
           .isEqualTo(testProject.getDescription())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Admin")
           .jsonPath("$.content[1].id").isEqualTo(workspaceInvitation.getId())
           .jsonPath("$.content[1].type").isEqualTo("WORKSPACE")
           .jsonPath("$.content[1].targetId").isEqualTo(testWorkspace.getId())
           .jsonPath("$.content[1].targetName").isEqualTo(testWorkspace.getName())
           .jsonPath("$.content[1].targetDescription")
           .isEqualTo(testWorkspace.getDescription())
+          .jsonPath("$.content[1].invitedBy").isEqualTo("Admin")
           .jsonPath("$.size").isEqualTo(10)
           .jsonPath("$.hasNext").isEqualTo(false)
           .jsonPath("$.nextCursorId").value(value -> assertThat(value).isNull());
+    }
+
+    @Test
+    @DisplayName("초대한 사용자가 삭제됐으면 invitedBy를 Unknown으로 반환한다")
+    void getMyInvitations_DeletedInviter_ReturnsUnknownInvitedBy() {
+      User invitee = getUser(inviteeUserId);
+      Invitation invitation = saveWorkspaceInvitation(
+          testWorkspace.getId(), invitee.email(), WorkspaceRole.MEMBER,
+          adminUserId);
+      softDeleteUser(adminUserId);
+
+      webTestClient.get()
+          .uri(API_BASE + "/users/me/invitations?size=10")
+          .header("Authorization", "Bearer " + inviteeToken)
+          .exchange()
+          .expectStatus().isOk()
+          .expectBody()
+          .jsonPath("$.content.length()").isEqualTo(1)
+          .jsonPath("$.content[0].id").isEqualTo(invitation.getId())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Unknown");
     }
 
     @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java
@@ -211,6 +211,10 @@ class ProjectInvitationControllerTest extends ProjectHttpTestSupport {
               ProjectInvitationApiSnippets.listInvitationsResponseHeaders(),
               ProjectInvitationApiSnippets.listInvitationsResponse()))
           .jsonPath("$.content.length()").isEqualTo(2)
+          .jsonPath("$.content[0].type").isEqualTo("PROJECT")
+          .jsonPath("$.content[0].targetId").isEqualTo(testProject.getId())
+          .jsonPath("$.content[0].targetName").isEqualTo(testProject.getName())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Admin")
           .jsonPath("$.totalElements").isEqualTo(2)
           .jsonPath("$.page").isEqualTo(0)
           .jsonPath("$.size").isEqualTo(10);
@@ -303,7 +307,13 @@ class ProjectInvitationControllerTest extends ProjectHttpTestSupport {
               ProjectInvitationApiSnippets.listMyInvitationsResponse()))
           .jsonPath("$.content.length()").isEqualTo(2)
           .jsonPath("$.totalElements").isEqualTo(2)
+          .jsonPath("$.content[0].type").isEqualTo("PROJECT")
+          .jsonPath("$.content[0].targetName").isEqualTo(project2.getName())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Admin")
           .jsonPath("$.content[0].invitedEmail").isEqualTo(outsiderUser.email())
+          .jsonPath("$.content[1].type").isEqualTo("PROJECT")
+          .jsonPath("$.content[1].targetName").isEqualTo(testProject.getName())
+          .jsonPath("$.content[1].invitedBy").isEqualTo("Admin")
           .jsonPath("$.content[1].invitedEmail").isEqualTo(outsiderUser.email());
     }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java
@@ -212,6 +212,10 @@ class WorkspaceInvitationControllerTest extends ProjectHttpTestSupport {
               WorkspaceInvitationApiSnippets.listInvitationsResponseHeaders(),
               WorkspaceInvitationApiSnippets.listInvitationsResponse()))
           .jsonPath("$.content.length()").isEqualTo(2)
+          .jsonPath("$.content[0].type").isEqualTo("WORKSPACE")
+          .jsonPath("$.content[0].targetId").isEqualTo(testWorkspace.getId())
+          .jsonPath("$.content[0].targetName").isEqualTo(testWorkspace.getName())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Admin")
           .jsonPath("$.totalElements").isEqualTo(2)
           .jsonPath("$.page").isEqualTo(0)
           .jsonPath("$.size").isEqualTo(10);
@@ -305,7 +309,13 @@ class WorkspaceInvitationControllerTest extends ProjectHttpTestSupport {
               WorkspaceInvitationApiSnippets.listMyInvitationsResponse()))
           .jsonPath("$.content.length()").isEqualTo(2)
           .jsonPath("$.totalElements").isEqualTo(2)
+          .jsonPath("$.content[0].type").isEqualTo("WORKSPACE")
+          .jsonPath("$.content[0].targetName").isEqualTo(workspace2.getName())
+          .jsonPath("$.content[0].invitedBy").isEqualTo("Admin")
           .jsonPath("$.content[0].invitedEmail").isEqualTo(invited.email())
+          .jsonPath("$.content[1].type").isEqualTo("WORKSPACE")
+          .jsonPath("$.content[1].targetName").isEqualTo(testWorkspace.getName())
+          .jsonPath("$.content[1].invitedBy").isEqualTo("Admin")
           .jsonPath("$.content[1].invitedEmail").isEqualTo(invited.email());
     }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/docs/MyInvitationApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/docs/MyInvitationApiSnippets.java
@@ -29,7 +29,7 @@ public class MyInvitationApiSnippets extends RestDocsSnippets {
       fieldWithPath(prefix + "invitedRole").type(JsonFieldType.STRING)
           .description("초대된 역할"),
       fieldWithPath(prefix + "invitedBy").type(JsonFieldType.STRING)
-          .description("초대한 사용자 ID"),
+          .description("초대한 사용자 이름"),
       fieldWithPath(prefix + "status").type(JsonFieldType.STRING)
           .description("초대 상태 (PENDING만 반환)"),
       fieldWithPath(prefix + "expiresAt").type(JsonFieldType.STRING)

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectInvitationApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/docs/ProjectInvitationApiSnippets.java
@@ -46,16 +46,20 @@ public class ProjectInvitationApiSnippets extends RestDocsSnippets {
     return new FieldDescriptor[] {
       fieldWithPath(prefix + "id").type(JsonFieldType.STRING)
           .description("초대 고유 ID"),
-      fieldWithPath(prefix + "workspaceId").type(JsonFieldType.STRING)
-          .description("워크스페이스 ID"),
-      fieldWithPath(prefix + "projectId").type(JsonFieldType.STRING)
-          .description("프로젝트 ID"),
+      fieldWithPath(prefix + "type").type(JsonFieldType.STRING)
+          .description("초대 대상 타입 (WORKSPACE/PROJECT)"),
+      fieldWithPath(prefix + "targetId").type(JsonFieldType.STRING)
+          .description("초대 대상 ID"),
+      fieldWithPath(prefix + "targetName").type(JsonFieldType.STRING)
+          .description("초대 대상 이름"),
+      fieldWithPath(prefix + "targetDescription").type(JsonFieldType.VARIES)
+          .description("초대 대상 설명 (nullable)"),
       fieldWithPath(prefix + "invitedEmail").type(JsonFieldType.STRING)
           .description("초대된 사용자 이메일"),
       fieldWithPath(prefix + "invitedRole").type(JsonFieldType.STRING)
           .description("초대된 역할 (admin/editor/viewer)"),
       fieldWithPath(prefix + "invitedBy").type(JsonFieldType.STRING)
-          .description("초대한 사용자 ID"),
+          .description("초대한 사용자 이름"),
       fieldWithPath(prefix + "status").type(JsonFieldType.STRING)
           .description("초대 상태 (pending/accepted/rejected)"),
       fieldWithPath(prefix + "expiresAt").type(JsonFieldType.STRING)

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceInvitationApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/docs/WorkspaceInvitationApiSnippets.java
@@ -44,14 +44,20 @@ public class WorkspaceInvitationApiSnippets extends RestDocsSnippets {
     return new FieldDescriptor[] {
       fieldWithPath(prefix + "id").type(JsonFieldType.STRING)
           .description("초대 고유 ID"),
-      fieldWithPath(prefix + "workspaceId").type(JsonFieldType.STRING)
-          .description("워크스페이스 ID"),
+      fieldWithPath(prefix + "type").type(JsonFieldType.STRING)
+          .description("초대 대상 타입 (WORKSPACE/PROJECT)"),
+      fieldWithPath(prefix + "targetId").type(JsonFieldType.STRING)
+          .description("초대 대상 ID"),
+      fieldWithPath(prefix + "targetName").type(JsonFieldType.STRING)
+          .description("초대 대상 이름"),
+      fieldWithPath(prefix + "targetDescription").type(JsonFieldType.VARIES)
+          .description("초대 대상 설명 (nullable)"),
       fieldWithPath(prefix + "invitedEmail").type(JsonFieldType.STRING)
           .description("초대된 사용자 이메일"),
       fieldWithPath(prefix + "invitedRole").type(JsonFieldType.STRING)
           .description("초대된 역할 (admin/member)"),
       fieldWithPath(prefix + "invitedBy").type(JsonFieldType.STRING)
-          .description("초대한 사용자 ID"),
+          .description("초대한 사용자 이름"),
       fieldWithPath(prefix + "status").type(JsonFieldType.STRING)
           .description("초대 상태 (pending/accepted/rejected)"),
       fieldWithPath(prefix + "expiresAt").type(JsonFieldType.STRING)

--- a/apps/backend/api/src/test/java/com/schemafy/api/testsupport/user/UserHttpTestSupport.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/testsupport/user/UserHttpTestSupport.java
@@ -18,6 +18,8 @@ import com.schemafy.core.user.domain.UserAuthProvider;
 
 import reactor.core.publisher.Mono;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public abstract class UserHttpTestSupport {
 
   @Autowired
@@ -86,6 +88,16 @@ public abstract class UserHttpTestSupport {
 
   protected User getUserByEmail(String email) {
     return findUserByEmailPort.findUserByEmail(email).block();
+  }
+
+  protected void softDeleteUser(String userId) {
+    Long rowsUpdated = databaseClient.sql(
+        "UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE id = :id")
+        .bind("id", userId)
+        .fetch()
+        .rowsUpdated()
+        .block();
+    assertThat(rowsUpdated).isEqualTo(1);
   }
 
   protected String generateAccessToken(String userId) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.out.InvitationPort;
 import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.InvitationStatus;
+import com.schemafy.core.project.domain.InvitationType;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
@@ -27,10 +28,14 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   }
 
   @Override
-  public Flux<Invitation> findInvitationsByTargetAndId(String targetType,
+  public Flux<InvitationSummary> findInvitationSummariesByTargetAndId(String targetType,
       String targetId, int limit, int offset) {
-    return invitationRepository.findInvitationsByTargetAndId(targetType,
-        targetId, limit, offset);
+    return switch (InvitationType.fromString(targetType)) {
+      case WORKSPACE -> invitationRepository
+          .findWorkspaceInvitationSummariesByTargetId(targetId, limit, offset);
+      case PROJECT -> invitationRepository
+          .findProjectInvitationSummariesByTargetId(targetId, limit, offset);
+    };
   }
 
   @Override
@@ -46,10 +51,16 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   }
 
   @Override
-  public Flux<Invitation> findByEmailAndTypeAndStatus(String email,
+  public Flux<InvitationSummary> findInvitationSummariesByEmailAndTypeAndStatus(String email,
       String targetType, String status, int limit, int offset) {
-    return invitationRepository.findByEmailAndTypeAndStatus(email, targetType,
-        status, limit, offset);
+    return switch (InvitationType.fromString(targetType)) {
+      case WORKSPACE -> invitationRepository
+          .findWorkspaceInvitationSummariesByEmailAndStatus(email, status, limit,
+              offset);
+      case PROJECT -> invitationRepository
+          .findProjectInvitationSummariesByEmailAndStatus(email, status, limit,
+              offset);
+    };
   }
 
   @Override
@@ -67,8 +78,12 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   @Override
   public Mono<Long> countByEmailAndTypeAndStatus(String email,
       String targetType, String status) {
-    return invitationRepository.countByEmailAndTypeAndStatus(email, targetType,
-        status);
+    return switch (InvitationType.fromString(targetType)) {
+      case WORKSPACE -> invitationRepository.countWorkspaceByEmailAndStatus(
+          email, status);
+      case PROJECT -> invitationRepository.countProjectByEmailAndStatus(email,
+          status);
+    };
   }
 
   @Override

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationPersistenceAdapter.java
@@ -31,10 +31,10 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   public Flux<InvitationSummary> findInvitationSummariesByTargetAndId(String targetType,
       String targetId, int limit, int offset) {
     return switch (InvitationType.fromString(targetType)) {
-      case WORKSPACE -> invitationRepository
-          .findWorkspaceInvitationSummariesByTargetId(targetId, limit, offset);
-      case PROJECT -> invitationRepository
-          .findProjectInvitationSummariesByTargetId(targetId, limit, offset);
+    case WORKSPACE -> invitationRepository
+        .findWorkspaceInvitationSummariesByTargetId(targetId, limit, offset);
+    case PROJECT -> invitationRepository
+        .findProjectInvitationSummariesByTargetId(targetId, limit, offset);
     };
   }
 
@@ -54,12 +54,12 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   public Flux<InvitationSummary> findInvitationSummariesByEmailAndTypeAndStatus(String email,
       String targetType, String status, int limit, int offset) {
     return switch (InvitationType.fromString(targetType)) {
-      case WORKSPACE -> invitationRepository
-          .findWorkspaceInvitationSummariesByEmailAndStatus(email, status, limit,
-              offset);
-      case PROJECT -> invitationRepository
-          .findProjectInvitationSummariesByEmailAndStatus(email, status, limit,
-              offset);
+    case WORKSPACE -> invitationRepository
+        .findWorkspaceInvitationSummariesByEmailAndStatus(email, status, limit,
+            offset);
+    case PROJECT -> invitationRepository
+        .findProjectInvitationSummariesByEmailAndStatus(email, status, limit,
+            offset);
     };
   }
 
@@ -79,10 +79,10 @@ public class InvitationPersistenceAdapter implements InvitationPort {
   public Mono<Long> countByEmailAndTypeAndStatus(String email,
       String targetType, String status) {
     return switch (InvitationType.fromString(targetType)) {
-      case WORKSPACE -> invitationRepository.countWorkspaceByEmailAndStatus(
-          email, status);
-      case PROJECT -> invitationRepository.countProjectByEmailAndStatus(email,
-          status);
+    case WORKSPACE -> invitationRepository.countWorkspaceByEmailAndStatus(
+        email, status);
+    case PROJECT -> invitationRepository.countProjectByEmailAndStatus(email,
+        status);
     };
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/InvitationRepository.java
@@ -21,15 +21,68 @@ public interface InvitationRepository
   Mono<Invitation> findByIdAndNotDeleted(String invitationId);
 
   @Query("""
-      SELECT * FROM invitations
-      WHERE target_type = :targetType
-        AND target_id = :targetId
-        AND deleted_at IS NULL
-      ORDER BY created_at DESC
+      SELECT
+        i.id AS id,
+        i.target_type AS target_type,
+        i.target_id AS target_id,
+        w.name AS target_name,
+        w.description AS target_description,
+        i.invited_email AS invited_email,
+        i.invited_role AS invited_role,
+        u.name AS invited_by,
+        i.status AS status,
+        i.expires_at AS expires_at,
+        i.resolved_at AS resolved_at,
+        i.created_at AS created_at
+      FROM invitations i
+      JOIN workspaces w
+        ON i.target_id = w.id
+       AND w.deleted_at IS NULL
+      LEFT JOIN users u
+        ON i.invited_by = u.id
+       AND u.deleted_at IS NULL
+      WHERE i.target_type = 'WORKSPACE'
+        AND i.target_id = :targetId
+        AND i.deleted_at IS NULL
+      ORDER BY i.created_at DESC
       LIMIT :limit OFFSET :offset
       """)
-  Flux<Invitation> findInvitationsByTargetAndId(
-      String targetType,
+  Flux<InvitationSummary> findWorkspaceInvitationSummariesByTargetId(
+      String targetId,
+      int limit,
+      int offset);
+
+  @Query("""
+      SELECT
+        i.id AS id,
+        i.target_type AS target_type,
+        i.target_id AS target_id,
+        p.name AS target_name,
+        p.description AS target_description,
+        i.invited_email AS invited_email,
+        i.invited_role AS invited_role,
+        u.name AS invited_by,
+        i.status AS status,
+        i.expires_at AS expires_at,
+        i.resolved_at AS resolved_at,
+        i.created_at AS created_at
+      FROM invitations i
+      JOIN projects p
+        ON i.target_id = p.id
+       AND p.deleted_at IS NULL
+      JOIN workspaces w
+        ON i.parent_id = w.id
+       AND w.deleted_at IS NULL
+      LEFT JOIN users u
+        ON i.invited_by = u.id
+       AND u.deleted_at IS NULL
+      WHERE i.target_type = 'PROJECT'
+        AND i.target_id = :targetId
+        AND i.deleted_at IS NULL
+      ORDER BY i.created_at DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<InvitationSummary> findProjectInvitationSummariesByTargetId(
       String targetId,
       int limit,
       int offset);
@@ -60,18 +113,74 @@ public interface InvitationRepository
       String status);
 
   @Query("""
-      SELECT * FROM invitations
-      WHERE target_type = :targetType
-        AND invited_email = :email
-        AND status = :status
-        AND deleted_at IS NULL
-        AND expires_at > NOW()
-      ORDER BY created_at DESC
+      SELECT
+        i.id AS id,
+        i.target_type AS target_type,
+        i.target_id AS target_id,
+        w.name AS target_name,
+        w.description AS target_description,
+        i.invited_email AS invited_email,
+        i.invited_role AS invited_role,
+        u.name AS invited_by,
+        i.status AS status,
+        i.expires_at AS expires_at,
+        i.resolved_at AS resolved_at,
+        i.created_at AS created_at
+      FROM invitations i
+      JOIN workspaces w
+        ON i.target_id = w.id
+       AND w.deleted_at IS NULL
+      LEFT JOIN users u
+        ON i.invited_by = u.id
+       AND u.deleted_at IS NULL
+      WHERE i.target_type = 'WORKSPACE'
+        AND i.invited_email = :email
+        AND i.status = :status
+        AND i.deleted_at IS NULL
+        AND i.expires_at > NOW()
+      ORDER BY i.created_at DESC
       LIMIT :limit OFFSET :offset
       """)
-  Flux<Invitation> findByEmailAndTypeAndStatus(
+  Flux<InvitationSummary> findWorkspaceInvitationSummariesByEmailAndStatus(
       String email,
-      String targetType,
+      String status,
+      int limit,
+      int offset);
+
+  @Query("""
+      SELECT
+        i.id AS id,
+        i.target_type AS target_type,
+        i.target_id AS target_id,
+        p.name AS target_name,
+        p.description AS target_description,
+        i.invited_email AS invited_email,
+        i.invited_role AS invited_role,
+        u.name AS invited_by,
+        i.status AS status,
+        i.expires_at AS expires_at,
+        i.resolved_at AS resolved_at,
+        i.created_at AS created_at
+      FROM invitations i
+      JOIN projects p
+        ON i.target_id = p.id
+       AND p.deleted_at IS NULL
+      JOIN workspaces w
+        ON i.parent_id = w.id
+       AND w.deleted_at IS NULL
+      LEFT JOIN users u
+        ON i.invited_by = u.id
+       AND u.deleted_at IS NULL
+      WHERE i.target_type = 'PROJECT'
+        AND i.invited_email = :email
+        AND i.status = :status
+        AND i.deleted_at IS NULL
+        AND i.expires_at > NOW()
+      ORDER BY i.created_at DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<InvitationSummary> findProjectInvitationSummariesByEmailAndStatus(
+      String email,
       String status,
       int limit,
       int offset);
@@ -88,15 +197,19 @@ public interface InvitationRepository
             w.description AS target_description,
             i.invited_email AS invited_email,
             i.invited_role AS invited_role,
-            i.invited_by AS invited_by,
+            u.name AS invited_by,
             i.status AS status,
             i.expires_at AS expires_at,
+            i.resolved_at AS resolved_at,
             i.created_at AS created_at
           FROM invitations i
           JOIN workspaces w
             ON i.target_type = 'WORKSPACE'
            AND i.target_id = w.id
            AND w.deleted_at IS NULL
+          LEFT JOIN users u
+            ON i.invited_by = u.id
+           AND u.deleted_at IS NULL
           WHERE i.invited_email = :email
             AND i.status = :status
             AND i.deleted_at IS NULL
@@ -114,15 +227,22 @@ public interface InvitationRepository
             p.description AS target_description,
             i.invited_email AS invited_email,
             i.invited_role AS invited_role,
-            i.invited_by AS invited_by,
+            u.name AS invited_by,
             i.status AS status,
             i.expires_at AS expires_at,
+            i.resolved_at AS resolved_at,
             i.created_at AS created_at
           FROM invitations i
           JOIN projects p
             ON i.target_type = 'PROJECT'
            AND i.target_id = p.id
            AND p.deleted_at IS NULL
+          JOIN workspaces w
+            ON i.parent_id = w.id
+           AND w.deleted_at IS NULL
+          LEFT JOIN users u
+            ON i.invited_by = u.id
+           AND u.deleted_at IS NULL
           WHERE i.invited_email = :email
             AND i.status = :status
             AND i.deleted_at IS NULL
@@ -151,15 +271,19 @@ public interface InvitationRepository
             w.description AS target_description,
             i.invited_email AS invited_email,
             i.invited_role AS invited_role,
-            i.invited_by AS invited_by,
+            u.name AS invited_by,
             i.status AS status,
             i.expires_at AS expires_at,
+            i.resolved_at AS resolved_at,
             i.created_at AS created_at
           FROM invitations i
           JOIN workspaces w
             ON i.target_type = 'WORKSPACE'
            AND i.target_id = w.id
            AND w.deleted_at IS NULL
+          LEFT JOIN users u
+            ON i.invited_by = u.id
+           AND u.deleted_at IS NULL
           WHERE i.invited_email = :email
             AND i.status = :status
             AND i.deleted_at IS NULL
@@ -178,15 +302,22 @@ public interface InvitationRepository
             p.description AS target_description,
             i.invited_email AS invited_email,
             i.invited_role AS invited_role,
-            i.invited_by AS invited_by,
+            u.name AS invited_by,
             i.status AS status,
             i.expires_at AS expires_at,
+            i.resolved_at AS resolved_at,
             i.created_at AS created_at
           FROM invitations i
           JOIN projects p
             ON i.target_type = 'PROJECT'
            AND i.target_id = p.id
            AND p.deleted_at IS NULL
+          JOIN workspaces w
+            ON i.parent_id = w.id
+           AND w.deleted_at IS NULL
+          LEFT JOIN users u
+            ON i.invited_by = u.id
+           AND u.deleted_at IS NULL
           WHERE i.invited_email = :email
             AND i.status = :status
             AND i.deleted_at IS NULL
@@ -206,16 +337,38 @@ public interface InvitationRepository
       int limit);
 
   @Query("""
-      SELECT COUNT(*) FROM invitations
-      WHERE target_type = :targetType
-        AND invited_email = :email
-        AND status = :status
-        AND deleted_at IS NULL
-        AND expires_at > NOW()
+      SELECT COUNT(*)
+      FROM invitations i
+      JOIN workspaces w
+        ON i.target_id = w.id
+       AND w.deleted_at IS NULL
+      WHERE i.target_type = 'WORKSPACE'
+        AND i.invited_email = :email
+        AND i.status = :status
+        AND i.deleted_at IS NULL
+        AND i.expires_at > NOW()
       """)
-  Mono<Long> countByEmailAndTypeAndStatus(
+  Mono<Long> countWorkspaceByEmailAndStatus(
       String email,
-      String targetType,
+      String status);
+
+  @Query("""
+      SELECT COUNT(*)
+      FROM invitations i
+      JOIN projects p
+        ON i.target_id = p.id
+       AND p.deleted_at IS NULL
+      JOIN workspaces w
+        ON i.parent_id = w.id
+       AND w.deleted_at IS NULL
+      WHERE i.target_type = 'PROJECT'
+        AND i.invited_email = :email
+        AND i.status = :status
+        AND i.deleted_at IS NULL
+        AND i.expires_at > NOW()
+      """)
+  Mono<Long> countProjectByEmailAndStatus(
+      String email,
       String status);
 
   @Modifying

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMyProjectInvitationsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMyProjectInvitationsUseCase.java
@@ -1,13 +1,12 @@
 package com.schemafy.core.project.application.port.in;
 
 import com.schemafy.core.common.PageResult;
-import com.schemafy.core.project.domain.Invitation;
 
 import reactor.core.publisher.Mono;
 
 public interface GetMyProjectInvitationsUseCase {
 
-  Mono<PageResult<Invitation>> getMyProjectInvitations(
+  Mono<PageResult<InvitationSummary>> getMyProjectInvitations(
       GetMyProjectInvitationsQuery query);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMyWorkspaceInvitationsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetMyWorkspaceInvitationsUseCase.java
@@ -1,13 +1,12 @@
 package com.schemafy.core.project.application.port.in;
 
 import com.schemafy.core.common.PageResult;
-import com.schemafy.core.project.domain.Invitation;
 
 import reactor.core.publisher.Mono;
 
 public interface GetMyWorkspaceInvitationsUseCase {
 
-  Mono<PageResult<Invitation>> getMyWorkspaceInvitations(
+  Mono<PageResult<InvitationSummary>> getMyWorkspaceInvitations(
       GetMyWorkspaceInvitationsQuery query);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetProjectInvitationsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetProjectInvitationsUseCase.java
@@ -1,13 +1,12 @@
 package com.schemafy.core.project.application.port.in;
 
 import com.schemafy.core.common.PageResult;
-import com.schemafy.core.project.domain.Invitation;
 
 import reactor.core.publisher.Mono;
 
 public interface GetProjectInvitationsUseCase {
 
-  Mono<PageResult<Invitation>> getProjectInvitations(
+  Mono<PageResult<InvitationSummary>> getProjectInvitations(
       GetProjectInvitationsQuery query);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetWorkspaceInvitationsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/GetWorkspaceInvitationsUseCase.java
@@ -1,13 +1,12 @@
 package com.schemafy.core.project.application.port.in;
 
 import com.schemafy.core.common.PageResult;
-import com.schemafy.core.project.domain.Invitation;
 
 import reactor.core.publisher.Mono;
 
 public interface GetWorkspaceInvitationsUseCase {
 
-  Mono<PageResult<Invitation>> getWorkspaceInvitations(
+  Mono<PageResult<InvitationSummary>> getWorkspaceInvitations(
       GetWorkspaceInvitationsQuery query);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/InvitationSummary.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/InvitationSummary.java
@@ -13,5 +13,6 @@ public record InvitationSummary(
     String invitedBy,
     String status,
     Instant expiresAt,
+    Instant resolvedAt,
     Instant createdAt) {
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/InvitationPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/InvitationPort.java
@@ -12,7 +12,7 @@ public interface InvitationPort {
 
   Mono<Invitation> findByIdAndNotDeleted(String invitationId);
 
-  Flux<Invitation> findInvitationsByTargetAndId(
+  Flux<InvitationSummary> findInvitationSummariesByTargetAndId(
       String targetType,
       String targetId,
       int limit,
@@ -26,7 +26,7 @@ public interface InvitationPort {
       String email,
       String status);
 
-  Flux<Invitation> findByEmailAndTypeAndStatus(
+  Flux<InvitationSummary> findInvitationSummariesByEmailAndTypeAndStatus(
       String email,
       String targetType,
       String status,

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMyProjectInvitationsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMyProjectInvitationsService.java
@@ -6,8 +6,8 @@ import com.schemafy.core.common.PageResult;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.port.in.GetMyProjectInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetMyProjectInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.out.InvitationPort;
-import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.InvitationStatus;
 import com.schemafy.core.project.domain.InvitationType;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
@@ -25,7 +25,7 @@ class GetMyProjectInvitationsService
   private final FindUserByIdPort findUserByIdPort;
 
   @Override
-  public Mono<PageResult<Invitation>> getMyProjectInvitations(
+  public Mono<PageResult<InvitationSummary>> getMyProjectInvitations(
       GetMyProjectInvitationsQuery query) {
     return findUserByIdPort.findUserById(query.requesterId())
         .switchIfEmpty(Mono.error(new DomainException(UserErrorCode.NOT_FOUND)))
@@ -34,7 +34,7 @@ class GetMyProjectInvitationsService
             InvitationType.PROJECT.name(),
             InvitationStatus.PENDING.name())
             .flatMap(totalElements -> invitationPort
-                .findByEmailAndTypeAndStatus(
+                .findInvitationSummariesByEmailAndTypeAndStatus(
                     user.email(),
                     InvitationType.PROJECT.name(),
                     InvitationStatus.PENDING.name(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMyWorkspaceInvitationsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetMyWorkspaceInvitationsService.java
@@ -6,8 +6,8 @@ import com.schemafy.core.common.PageResult;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.port.in.GetMyWorkspaceInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetMyWorkspaceInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.out.InvitationPort;
-import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.InvitationStatus;
 import com.schemafy.core.project.domain.InvitationType;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
@@ -25,7 +25,7 @@ class GetMyWorkspaceInvitationsService
   private final FindUserByIdPort findUserByIdPort;
 
   @Override
-  public Mono<PageResult<Invitation>> getMyWorkspaceInvitations(
+  public Mono<PageResult<InvitationSummary>> getMyWorkspaceInvitations(
       GetMyWorkspaceInvitationsQuery query) {
     return findUserByIdPort.findUserById(query.requesterId())
         .switchIfEmpty(Mono.error(
@@ -35,7 +35,7 @@ class GetMyWorkspaceInvitationsService
             InvitationType.WORKSPACE.name(),
             InvitationStatus.PENDING.name())
             .flatMap(totalElements -> invitationPort
-                .findByEmailAndTypeAndStatus(
+                .findInvitationSummariesByEmailAndTypeAndStatus(
                     user.email(),
                     InvitationType.WORKSPACE.name(),
                     InvitationStatus.PENDING.name(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectInvitationsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetProjectInvitationsService.java
@@ -6,8 +6,8 @@ import com.schemafy.core.common.PageResult;
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.GetProjectInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetProjectInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.out.InvitationPort;
-import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.InvitationType;
 import com.schemafy.core.project.domain.ProjectRole;
 
@@ -22,13 +22,13 @@ class GetProjectInvitationsService implements GetProjectInvitationsUseCase {
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
-  public Mono<PageResult<Invitation>> getProjectInvitations(
+  public Mono<PageResult<InvitationSummary>> getProjectInvitations(
       GetProjectInvitationsQuery query) {
     String targetType = InvitationType.PROJECT.name();
 
     return invitationPort.countByTarget(targetType, query.projectId())
         .flatMap(totalElements -> invitationPort
-            .findInvitationsByTargetAndId(targetType, query.projectId(),
+            .findInvitationSummariesByTargetAndId(targetType, query.projectId(),
                 query.size(), query.page() * query.size())
             .collectList()
             .map(invitations -> PageResult.of(invitations, query.page(),

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetWorkspaceInvitationsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/GetWorkspaceInvitationsService.java
@@ -6,8 +6,8 @@ import com.schemafy.core.common.PageResult;
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.GetWorkspaceInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetWorkspaceInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.out.InvitationPort;
-import com.schemafy.core.project.domain.Invitation;
 import com.schemafy.core.project.domain.InvitationType;
 import com.schemafy.core.project.domain.WorkspaceRole;
 
@@ -22,13 +22,13 @@ class GetWorkspaceInvitationsService implements GetWorkspaceInvitationsUseCase {
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
-  public Mono<PageResult<Invitation>> getWorkspaceInvitations(
+  public Mono<PageResult<InvitationSummary>> getWorkspaceInvitations(
       GetWorkspaceInvitationsQuery query) {
     String targetType = InvitationType.WORKSPACE.name();
 
     return invitationPort.countByTarget(targetType, query.workspaceId())
         .flatMap(totalElements -> invitationPort
-            .findInvitationsByTargetAndId(targetType, query.workspaceId(),
+            .findInvitationSummariesByTargetAndId(targetType, query.workspaceId(),
                 query.size(), query.page() * query.size())
             .collectList()
             .map(invitations -> PageResult.of(invitations, query.page(),

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationUseCaseIntegrationTest.java
@@ -15,6 +15,7 @@ import com.schemafy.core.project.application.port.in.GetMyProjectInvitationsQuer
 import com.schemafy.core.project.application.port.in.GetMyProjectInvitationsUseCase;
 import com.schemafy.core.project.application.port.in.GetProjectInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetProjectInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.in.RejectProjectInvitationCommand;
 import com.schemafy.core.project.application.port.in.RejectProjectInvitationUseCase;
 import com.schemafy.core.project.domain.Invitation;
@@ -63,18 +64,26 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
             admin.id()))
         .block();
 
-    PageResult<Invitation> targetInvitations = getProjectInvitationsUseCase.getProjectInvitations(
+    PageResult<InvitationSummary> targetInvitations = getProjectInvitationsUseCase.getProjectInvitations(
         new GetProjectInvitationsQuery(project.getId(), admin.id(), 0, 10))
         .block();
-    PageResult<Invitation> myInvitations = getMyProjectInvitationsUseCase.getMyProjectInvitations(
+    PageResult<InvitationSummary> myInvitations = getMyProjectInvitationsUseCase.getMyProjectInvitations(
         new GetMyProjectInvitationsQuery(invitee.id(), 0, 10))
         .block();
 
     assertThat(invitation).isNotNull();
-    assertThat(targetInvitations.content()).extracting(Invitation::getId)
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::id)
         .contains(invitation.getId());
-    assertThat(myInvitations.content()).extracting(Invitation::getId)
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::targetName)
+        .contains(project.getName());
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::invitedBy)
+        .contains(admin.name());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::id)
         .contains(invitation.getId());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::targetName)
+        .contains(project.getName());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::invitedBy)
+        .contains(admin.name());
   }
 
   @Test
@@ -154,6 +163,37 @@ class ProjectInvitationUseCaseIntegrationTest extends ProjectDomainIntegrationSu
         new GetProjectInvitationsQuery(project.getId(), viewer.id(), 0, 10)))
         .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
         .verify();
+  }
+
+  @Test
+  @DisplayName("내 프로젝트 초대 목록은 삭제된 프로젝트 초대를 totalElements에서도 제외한다")
+  void getMyProjectInvitations_excludesDeletedProjectFromTotalElements() {
+    User admin = signUpUser("admin-pi-deleted-total@test.com", "Admin");
+    User invitee = signUpUser("invitee-pi-deleted-total@test.com", "Invitee");
+    var workspace = saveWorkspace("Project Invitation Total WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, invitee, WorkspaceRole.MEMBER);
+
+    var activeProject = saveProject(workspace, "Active Invitation Project");
+    saveProjectMember(activeProject, admin, ProjectRole.ADMIN);
+    Invitation activeInvitation = saveProjectInvitation(activeProject,
+        workspace, invitee.email(), ProjectRole.EDITOR, admin);
+
+    var deletedProject = saveProject(workspace, "Deleted Invitation Project");
+    saveProjectMember(deletedProject, admin, ProjectRole.ADMIN);
+    saveProjectInvitation(deletedProject, workspace, invitee.email(),
+        ProjectRole.VIEWER, admin);
+    softDeleteProject(deletedProject.getId());
+
+    PageResult<InvitationSummary> result = getMyProjectInvitationsUseCase
+        .getMyProjectInvitations(new GetMyProjectInvitationsQuery(
+            invitee.id(), 0, 10))
+        .block();
+
+    assertThat(result.content()).extracting(InvitationSummary::id)
+        .containsExactly(activeInvitation.getId());
+    assertThat(result.totalElements()).isEqualTo(1);
+    assertThat(result.totalPages()).isEqualTo(1);
   }
 
   @Test

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
@@ -15,6 +15,7 @@ import com.schemafy.core.project.application.port.in.GetMyWorkspaceInvitationsQu
 import com.schemafy.core.project.application.port.in.GetMyWorkspaceInvitationsUseCase;
 import com.schemafy.core.project.application.port.in.GetWorkspaceInvitationsQuery;
 import com.schemafy.core.project.application.port.in.GetWorkspaceInvitationsUseCase;
+import com.schemafy.core.project.application.port.in.InvitationSummary;
 import com.schemafy.core.project.application.port.in.RejectWorkspaceInvitationCommand;
 import com.schemafy.core.project.application.port.in.RejectWorkspaceInvitationUseCase;
 import com.schemafy.core.project.domain.Invitation;
@@ -64,18 +65,26 @@ class WorkspaceInvitationUseCaseIntegrationTest
             admin.id()))
         .block();
 
-    PageResult<Invitation> targetInvitations = getWorkspaceInvitationsUseCase.getWorkspaceInvitations(
+    PageResult<InvitationSummary> targetInvitations = getWorkspaceInvitationsUseCase.getWorkspaceInvitations(
         new GetWorkspaceInvitationsQuery(workspace.getId(), admin.id(), 0, 10))
         .block();
-    PageResult<Invitation> myInvitations = getMyWorkspaceInvitationsUseCase.getMyWorkspaceInvitations(
+    PageResult<InvitationSummary> myInvitations = getMyWorkspaceInvitationsUseCase.getMyWorkspaceInvitations(
         new GetMyWorkspaceInvitationsQuery(invitee.id(), 0, 10))
         .block();
 
     assertThat(invitation).isNotNull();
-    assertThat(targetInvitations.content()).extracting(Invitation::getId)
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::id)
         .contains(invitation.getId());
-    assertThat(myInvitations.content()).extracting(Invitation::getId)
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::targetName)
+        .contains(workspace.getName());
+    assertThat(targetInvitations.content()).extracting(InvitationSummary::invitedBy)
+        .contains(admin.name());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::id)
         .contains(invitation.getId());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::targetName)
+        .contains(workspace.getName());
+    assertThat(myInvitations.content()).extracting(InvitationSummary::invitedBy)
+        .contains(admin.name());
   }
 
   @Test
@@ -142,6 +151,33 @@ class WorkspaceInvitationUseCaseIntegrationTest
         new GetWorkspaceInvitationsQuery(workspace.getId(), requester.id(), 0, 10)))
         .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
         .verify();
+  }
+
+  @Test
+  @DisplayName("내 워크스페이스 초대 목록은 삭제된 워크스페이스 초대를 totalElements에서도 제외한다")
+  void getMyWorkspaceInvitations_excludesDeletedWorkspaceFromTotalElements() {
+    User admin = signUpUser("admin-wi-deleted-total@test.com", "Admin");
+    User invitee = signUpUser("invitee-wi-deleted-total@test.com", "Invitee");
+    var activeWorkspace = saveWorkspace("Active Invitation WS", "Description");
+    saveWorkspaceMember(activeWorkspace, admin, WorkspaceRole.ADMIN);
+    Invitation activeInvitation = saveWorkspaceInvitation(activeWorkspace,
+        invitee.email(), WorkspaceRole.MEMBER, admin);
+
+    var deletedWorkspace = saveWorkspace("Deleted Invitation WS", "Description");
+    saveWorkspaceMember(deletedWorkspace, admin, WorkspaceRole.ADMIN);
+    saveWorkspaceInvitation(deletedWorkspace, invitee.email(),
+        WorkspaceRole.MEMBER, admin);
+    softDeleteWorkspace(deletedWorkspace.getId());
+
+    PageResult<InvitationSummary> result = getMyWorkspaceInvitationsUseCase
+        .getMyWorkspaceInvitations(new GetMyWorkspaceInvitationsQuery(
+            invitee.id(), 0, 10))
+        .block();
+
+    assertThat(result.content()).extracting(InvitationSummary::id)
+        .containsExactly(activeInvitation.getId());
+    assertThat(result.totalElements()).isEqualTo(1);
+    assertThat(result.totalPages()).isEqualTo(1);
   }
 
   @Test

--- a/apps/bff/src/project/project.types.ts
+++ b/apps/bff/src/project/project.types.ts
@@ -29,8 +29,10 @@ export type ProjectMemberResponse = {
 
 export type ProjectInvitationResponse = {
   id: string;
-  workspaceId: string;
-  projectId: string;
+  type: string;
+  targetId: string;
+  targetName: string;
+  targetDescription?: string;
   invitedEmail: string;
   invitedRole: string;
   invitedBy: string;

--- a/apps/bff/src/workspace/workspace.types.ts
+++ b/apps/bff/src/workspace/workspace.types.ts
@@ -27,7 +27,10 @@ export type WorkspaceMemberResponse = {
 
 export type WorkspaceInvitationResponse = {
   id: string;
-  workspaceId: string;
+  type: string;
+  targetId: string;
+  targetName: string;
+  targetDescription?: string;
   invitedEmail: string;
   invitedRole: string;
   invitedBy: string;

--- a/apps/frontend/src/components/Header/contents/NotificationContents.tsx
+++ b/apps/frontend/src/components/Header/contents/NotificationContents.tsx
@@ -151,8 +151,7 @@ const NotificationItem = ({
           <span className="break-words font-semibold">
             {invitation.targetName}
           </span>{' '}
-          as{' '}
-          <span className="font-semibold">{invitation.invitedRole}</span>
+          as <span className="font-semibold">{invitation.invitedRole}</span>
         </div>
       </div>
       <Button

--- a/apps/frontend/src/components/Header/contents/NotificationContents.tsx
+++ b/apps/frontend/src/components/Header/contents/NotificationContents.tsx
@@ -13,6 +13,7 @@ type UnifiedInvitation =
       type: 'workspace';
       id: string;
       invitedBy: string;
+      targetName: string;
       invitedRole: string;
       createdAt: string;
     }
@@ -20,6 +21,7 @@ type UnifiedInvitation =
       type: 'project';
       id: string;
       invitedBy: string;
+      targetName: string;
       invitedRole: string;
       createdAt: string;
     };
@@ -53,6 +55,7 @@ export const NotificationContents = () => {
         type: 'workspace' as const,
         id: inv.id,
         invitedBy: inv.invitedBy,
+        targetName: inv.targetName,
         invitedRole: inv.invitedRole,
         createdAt: inv.createdAt,
       })),
@@ -62,6 +65,7 @@ export const NotificationContents = () => {
         type: 'project' as const,
         id: inv.id,
         invitedBy: inv.invitedBy,
+        targetName: inv.targetName,
         invitedRole: inv.invitedRole,
         createdAt: inv.createdAt,
       })),
@@ -134,13 +138,22 @@ const NotificationItem = ({
   onAccept,
   onReject,
 }: NotificationItemProps) => {
+  const invitedBy = invitation.invitedBy || 'Unknown';
+  const targetTypeLabel =
+    invitation.type === 'workspace' ? 'Workspace' : 'Project';
+
   return (
     <div className="flex gap-2.5 items-center">
       <Avatar size={'dropdown'} src="https://picsum.photos/200/300?random=1" />
-      <div className="max-w-[10rem] font-body-xs text-schemafy-text">
-        {invitation.invitedBy} invited you to{' '}
-        <span className="font-semibold">{invitation.type}</span> as{' '}
-        <span className="font-semibold">{invitation.invitedRole}</span>
+      <div className="min-w-0 max-w-[11.5rem] font-body-xs text-schemafy-text">
+        <div className="break-words">
+          {invitedBy} invited you to {targetTypeLabel}{' '}
+          <span className="break-words font-semibold">
+            {invitation.targetName}
+          </span>{' '}
+          as{' '}
+          <span className="font-semibold">{invitation.invitedRole}</span>
+        </div>
       </div>
       <Button
         size={'sm'}

--- a/apps/frontend/src/features/project/api/types.ts
+++ b/apps/frontend/src/features/project/api/types.ts
@@ -29,8 +29,10 @@ export type ProjectMemberResponse = {
 
 export type ProjectInvitationResponse = {
   id: string;
-  workspaceId: string;
-  projectId: string;
+  type: string;
+  targetId: string;
+  targetName: string;
+  targetDescription?: string;
   invitedEmail: string;
   invitedRole: string;
   invitedBy: string;

--- a/apps/frontend/src/features/workspace/api/types.ts
+++ b/apps/frontend/src/features/workspace/api/types.ts
@@ -27,7 +27,10 @@ export type WorkspaceMemberResponse = {
 
 export type WorkspaceInvitationResponse = {
   id: string;
-  workspaceId: string;
+  type: string;
+  targetId: string;
+  targetName: string;
+  targetDescription?: string;
   invitedEmail: string;
   invitedRole: string;
   invitedBy: string;


### PR DESCRIPTION
## 개요
- 초대 목록 응답을 `InvitationSummary` 기반으로 확장해 초대 대상의 `type`, `targetId`, `targetName`, `targetDescription`을 반환하도록 변경
- `invitedBy`를 초대한 사용자 ID가 아니라 표시용 사용자 이름으로 내려주도록 변경하고, 초대한 사용자가 삭제된 경우 `Unknown`으로 응답
- 워크스페이스/프로젝트 초대 조회 SQL을 대상별 쿼리로 분리해 삭제된 대상 초대를 목록과 `totalElements`에서 제외
- BFF/Frontend 초대 응답 타입을 API 계약에 맞게 갱신하고, 헤더 알림에서 `Workspace/Project + 대상 이름 + 역할`이 보이도록 UI 반영

## 이슈


- close #406