### PR TITLE
refactor(#324): centralize nested ERD mutation execution

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/PkCascadeHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/constraint/application/service/PkCascadeHelper.java
@@ -24,7 +24,7 @@ import com.schemafy.core.erd.constraint.application.port.out.GetConstraintsByTab
 import com.schemafy.core.erd.constraint.domain.Constraint;
 import com.schemafy.core.erd.constraint.domain.ConstraintColumn;
 import com.schemafy.core.erd.constraint.domain.type.ConstraintKind;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.relationship.application.port.out.CreateRelationshipColumnPort;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipColumnPort;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipColumnsByRelationshipIdPort;
@@ -277,9 +277,8 @@ public class PkCascadeHelper {
           }
 
           Mono<Void> deleteFkColumns = Flux.fromIterable(fkColumnIds)
-              .concatMap(fkColumnId -> deleteColumnUseCase.deleteColumn(
-                  new DeleteColumnCommand(fkColumnId))
-                  .contextWrite(ErdOperationContexts.suppressNestedMutation())
+              .concatMap(fkColumnId -> NestedErdMutations.run(
+                  deleteColumnUseCase.deleteColumn(new DeleteColumnCommand(fkColumnId)))
                   .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                   .then())
               .then();

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/NestedErdMutations.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/application/service/NestedErdMutations.java
@@ -1,0 +1,18 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import java.util.Objects;
+
+import com.schemafy.core.erd.operation.ErdOperationContexts;
+
+import reactor.core.publisher.Mono;
+
+public final class NestedErdMutations {
+
+  private NestedErdMutations() {}
+
+  public static <T> Mono<T> run(Mono<T> nestedMutation) {
+    Objects.requireNonNull(nestedMutation, "nestedMutation");
+    return nestedMutation.contextWrite(ErdOperationContexts.suppressNestedMutation());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/DeleteRelationshipService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/DeleteRelationshipService.java
@@ -15,6 +15,7 @@ import com.schemafy.core.erd.column.application.port.in.DeleteColumnUseCase;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.application.inverse.DeleteRelationshipInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.in.DeleteRelationshipCommand;
@@ -98,9 +99,8 @@ public class DeleteRelationshipService implements DeleteRelationshipUseCase {
                 return deleteRelationshipColumnsPort.deleteByRelationshipId(relationshipId)
                     .then(deleteRelationshipPort.deleteRelationship(relationshipId))
                     .thenMany(Flux.fromIterable(fkColumnIds))
-                    .concatMap(fkColumnId -> deleteColumnUseCase.deleteColumn(
-                        new DeleteColumnCommand(fkColumnId))
-                        .contextWrite(ErdOperationContexts.suppressNestedMutation())
+                    .concatMap(fkColumnId -> NestedErdMutations.run(deleteColumnUseCase.deleteColumn(
+                        new DeleteColumnCommand(fkColumnId)))
                         .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                         .then())
                     .then()

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/RemoveRelationshipColumnService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/relationship/application/service/RemoveRelationshipColumnService.java
@@ -13,9 +13,9 @@ import com.schemafy.core.common.MutationResult;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.erd.column.application.port.in.DeleteColumnCommand;
 import com.schemafy.core.erd.column.application.port.in.DeleteColumnUseCase;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.application.inverse.RemoveRelationshipColumnInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.in.RemoveRelationshipColumnCommand;
@@ -91,8 +91,8 @@ public class RemoveRelationshipColumnService implements RemoveRelationshipColumn
               return deleteRelationshipColumnPort
                   .deleteRelationshipColumn(relationshipColumn.id())
                   .then(handleRemainingColumns(relationship.id()))
-                  .then(deleteColumnUseCase.deleteColumn(new DeleteColumnCommand(fkColumnId))
-                      .contextWrite(ErdOperationContexts.suppressNestedMutation()))
+                  .then(NestedErdMutations.run(deleteColumnUseCase.deleteColumn(
+                      new DeleteColumnCommand(fkColumnId))))
                   .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                   .then(Mono.fromCallable(() -> MutationResult.<Void>of(null, affectedTableIds)));
             }));

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/DeleteSchemaService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/application/service/DeleteSchemaService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.MutationResult;
 import com.schemafy.core.common.exception.DomainException;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaCommand;
 import com.schemafy.core.erd.schema.application.port.in.DeleteSchemaUseCase;
@@ -60,8 +60,7 @@ public class DeleteSchemaService implements DeleteSchemaUseCase {
         .flatMapMany(Flux::fromIterable)
         .concatMap(table -> {
           affectedTableIds.add(table.id());
-          return deleteTableUseCase.deleteTable(new DeleteTableCommand(table.id()))
-              .contextWrite(ErdOperationContexts.suppressNestedMutation())
+          return NestedErdMutations.run(deleteTableUseCase.deleteTable(new DeleteTableCommand(table.id())))
               .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
               .then();
         })

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/DeleteTableService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/application/service/DeleteTableService.java
@@ -16,6 +16,7 @@ import com.schemafy.core.erd.column.application.port.out.GetColumnsByTableIdPort
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.application.inverse.DeleteTableInverse;
 import com.schemafy.core.erd.operation.application.service.ErdMutationCoordinator;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.operation.domain.ErdOperationType;
 import com.schemafy.core.erd.relationship.application.port.in.DeleteRelationshipCommand;
@@ -96,9 +97,8 @@ public class DeleteTableService implements DeleteTableUseCase {
                 affectedTableIds))
             .then(Mono.defer(() -> getColumnsByTableIdPort.findColumnsByTableId(tableId)))
             .flatMapMany(Flux::fromIterable)
-            .concatMap(column -> deleteColumnUseCase.deleteColumn(
-                new DeleteColumnCommand(column.id()))
-                .contextWrite(ErdOperationContexts.suppressNestedMutation())
+            .concatMap(column -> NestedErdMutations.run(
+                deleteColumnUseCase.deleteColumn(new DeleteColumnCommand(column.id())))
                 .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
                 .then())
             .then(Mono.defer(() -> deleteTablePort.deleteTable(tableId)))
@@ -108,8 +108,8 @@ public class DeleteTableService implements DeleteTableUseCase {
   private Mono<Void> deleteRelationshipIgnoringAlreadyDeleted(
       String relationshipId,
       Set<String> affectedTableIds) {
-    return deleteRelationshipUseCase.deleteRelationship(new DeleteRelationshipCommand(relationshipId))
-        .contextWrite(ErdOperationContexts.suppressNestedMutation())
+    return NestedErdMutations.run(deleteRelationshipUseCase.deleteRelationship(
+        new DeleteRelationshipCommand(relationshipId)))
         .doOnNext(result -> affectedTableIds.addAll(result.affectedTableIds()))
         .then()
         .onErrorResume(DomainException.class, ex -> ex.getErrorCode() == RelationshipErrorCode.NOT_FOUND

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/column/application/service/DeleteColumnServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/column/application/service/DeleteColumnServiceTest.java
@@ -32,7 +32,7 @@ import com.schemafy.core.erd.index.application.port.out.GetIndexColumnsByColumnI
 import com.schemafy.core.erd.index.application.port.out.GetIndexColumnsByIndexIdPort;
 import com.schemafy.core.erd.index.domain.IndexColumn;
 import com.schemafy.core.erd.index.domain.type.SortDirection;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipColumnPort;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipColumnsByColumnIdPort;
@@ -153,7 +153,7 @@ class DeleteColumnServiceTest {
     }
 
     @Test
-    @DisplayName("nested mutation suppress context에서는 snapshot 없이 컬럼을 삭제한다")
+    @DisplayName("nested mutation runner로 실행하면 snapshot 없이 컬럼을 삭제한다")
     void skipsSnapshotsWhenNestedMutationSuppressed() {
       var command = ColumnFixture.deleteCommand();
 
@@ -167,8 +167,7 @@ class DeleteColumnServiceTest {
       given(deleteColumnPort.deleteColumn(any()))
           .willReturn(Mono.empty());
 
-      StepVerifier.create(sut.deleteColumn(command)
-          .contextWrite(ErdOperationContexts.suppressNestedMutation()))
+      StepVerifier.create(NestedErdMutations.run(sut.deleteColumn(command)))
           .expectNextCount(1)
           .verifyComplete();
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/application/service/NestedErdMutationsTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/application/service/NestedErdMutationsTest.java
@@ -1,0 +1,49 @@
+package com.schemafy.core.erd.operation.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.ErdOperationMetadata;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NestedErdMutations")
+class NestedErdMutationsTest {
+
+  @Test
+  @DisplayName("nested mutation suppression flag를 붙여 실행한다")
+  void runsWithNestedMutationSuppression() {
+    StepVerifier.create(NestedErdMutations.run(Mono.deferContextual(contextView -> Mono.just(
+        ErdOperationContexts.isNestedMutationSuppressed(contextView)))))
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("기존 operation metadata를 유지한다")
+  void keepsExistingOperationMetadata() {
+    StepVerifier.create(NestedErdMutations.run(Mono.deferContextual(contextView -> Mono.just(new ContextSnapshot(
+        ErdOperationContexts.metadata(contextView),
+        ErdOperationContexts.isNestedMutationSuppressed(contextView)))))
+        .contextWrite(ErdOperationContexts.withSessionId("session-1")))
+        .assertNext(snapshot -> {
+          assertThat(snapshot.metadata()).isEqualTo(new ErdOperationMetadata(
+              "session-1",
+              null,
+              null,
+              null));
+          assertThat(snapshot.suppressed()).isTrue();
+        })
+        .verifyComplete();
+  }
+
+  private record ContextSnapshot(
+      ErdOperationMetadata metadata,
+      boolean suppressed) {
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/relationship/application/service/DeleteRelationshipServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/relationship/application/service/DeleteRelationshipServiceTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.schemafy.core.erd.column.application.port.in.DeleteColumnCommand;
 import com.schemafy.core.erd.column.application.port.in.DeleteColumnUseCase;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipColumnsByRelationshipIdPort;
 import com.schemafy.core.erd.relationship.application.port.out.DeleteRelationshipPort;
@@ -130,7 +130,7 @@ class DeleteRelationshipServiceTest {
     }
 
     @Test
-    @DisplayName("nested mutation suppress context에서는 snapshot 없이 관계를 삭제한다")
+    @DisplayName("nested mutation runner로 실행하면 snapshot 없이 관계를 삭제한다")
     void skipsSnapshotsWhenNestedMutationSuppressed() {
       var command = RelationshipFixture.deleteCommand();
 
@@ -144,8 +144,7 @@ class DeleteRelationshipServiceTest {
       given(deleteRelationshipPort.deleteRelationship(eq(RelationshipFixture.DEFAULT_ID)))
           .willReturn(Mono.empty());
 
-      StepVerifier.create(sut.deleteRelationship(command)
-          .contextWrite(ErdOperationContexts.suppressNestedMutation()))
+      StepVerifier.create(NestedErdMutations.run(sut.deleteRelationship(command)))
           .expectNextCount(1)
           .verifyComplete();
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/DeleteTableServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/table/application/service/DeleteTableServiceTest.java
@@ -20,7 +20,7 @@ import com.schemafy.core.erd.column.application.port.in.DeleteColumnCommand;
 import com.schemafy.core.erd.column.application.port.in.DeleteColumnUseCase;
 import com.schemafy.core.erd.column.application.port.out.GetColumnsByTableIdPort;
 import com.schemafy.core.erd.column.fixture.ColumnFixture;
-import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.erd.operation.application.service.NestedErdMutations;
 import com.schemafy.core.erd.operation.application.service.StructuralSnapshotService;
 import com.schemafy.core.erd.relationship.application.port.in.DeleteRelationshipCommand;
 import com.schemafy.core.erd.relationship.application.port.in.DeleteRelationshipUseCase;
@@ -160,7 +160,7 @@ class DeleteTableServiceTest {
       }
 
       @Test
-      @DisplayName("nested mutation suppress context에서는 snapshot 없이 테이블을 삭제한다")
+      @DisplayName("nested mutation runner로 실행하면 snapshot 없이 테이블을 삭제한다")
       void skipsSnapshotsWhenNestedMutationSuppressed() {
         var command = TableFixture.deleteCommand();
 
@@ -175,8 +175,7 @@ class DeleteTableServiceTest {
         given(transactionalOperator.transactional(any(Mono.class)))
             .willAnswer(invocation -> invocation.getArgument(0));
 
-        StepVerifier.create(sut.deleteTable(command)
-            .contextWrite(ErdOperationContexts.suppressNestedMutation()))
+        StepVerifier.create(NestedErdMutations.run(sut.deleteTable(command)))
             .expectNextCount(1)
             .verifyComplete();
 


### PR DESCRIPTION
## 개요

- ERD cascade 경로에서 직접 사용하던 `ErdOperationContexts.suppressNestedMutation()` 설정의 `NestedErdMutations.run(...)` 통합

## 이슈

- close #324
