### PR TITLE
feat(#425): bootstrap MCP module

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -28,6 +28,8 @@ jobs:
             path: apps/backend/api
           - name: core
             path: apps/backend/core
+          - name: mcp
+            path: apps/backend/mcp
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/backend/mcp/build.gradle
+++ b/apps/backend/mcp/build.gradle
@@ -1,0 +1,172 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.5'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.github.spotbugs' version '6.0.26'
+    id 'com.diffplug.spotless' version '6.25.0'
+}
+
+group = 'com.schemafy'
+version = '0.0.1-SNAPSHOT'
+description = 'mcp module of the backend application'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    withJavadocJar()
+    withSourcesJar()
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springAiVersion', '1.1.8')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
+}
+
+dependencies {
+    implementation project(':core')
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webflux'
+
+    runtimeOnly 'io.r2dbc:r2dbc-h2'
+    runtimeOnly 'org.mariadb:r2dbc-mariadb:1.4.0'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    spotbugs 'com.github.spotbugs:spotbugs:4.8.6'
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.13.0'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ["-parameters"]
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.named('bootJar') {
+    exclude('ddl/**')
+}
+
+tasks.named('bootRun') {
+    workingDir = rootProject.projectDir
+}
+
+spotbugs {
+    toolVersion = '4.8.6'
+    effort = 'max'
+    reportLevel = 'medium'
+    ignoreFailures = false
+    omitVisitors = ['FindReturnRef']
+}
+
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
+    enabled = true
+    classes = classes.filter {
+        !it.path.contains('/lombok/') && !it.path.contains('/grpc/')
+    }
+
+    jvmArgs = [
+        '-Dspotbugs.sf.comment=true',
+        '-Dfindbugs.verbose=true'
+    ]
+    maxHeapSize = '1024m'
+
+    reports {
+        html {
+            required = true
+            outputLocation = layout.buildDirectory.file('reports/spotbugs/main.html')
+            stylesheet = 'fancy-hist.xsl'
+        }
+        xml {
+            required = true
+            outputLocation = layout.buildDirectory.file('reports/spotbugs/main.xml')
+        }
+        sarif {
+            required = true
+            outputLocation = layout.buildDirectory.file('reports/spotbugs/main.sarif')
+        }
+    }
+}
+
+tasks.named('spotbugsTest') {
+    enabled = false
+}
+
+def formatterConfig = file("${projectDir}/../../../gradle/format/java-formatter.xml")
+
+spotless {
+    java {
+        target 'src/**/*.java'
+        eclipse().configFile(formatterConfig)
+        removeUnusedImports()
+        importOrder(
+                'java',
+                'jakarta',
+                'org.springframework',
+                'org',
+                'com',
+                '',
+                '\\#'
+        )
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.named('check') {
+    dependsOn 'spotlessCheck'
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir 'src/main/resources'
+            srcDir '../sql-resources'
+        }
+    }
+    test {
+        resources {
+            srcDir 'src/test/resources'
+            srcDir '../sql-resources'
+        }
+    }
+}
+
+tasks.named('processResources') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.named('processTestResources') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType(Jar).configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/apps/backend/mcp/settings.gradle
+++ b/apps/backend/mcp/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'mcp'
+include ':core'
+project(':core').projectDir = file('../core')

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/McpApplication.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/McpApplication.java
@@ -1,0 +1,24 @@
+package com.schemafy.mcp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {
+  "com.schemafy.mcp",
+  "com.schemafy.core",
+}, excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.schemafy\\.core\\.user\\.application\\.service\\.(LoginUserService|SignUpUserService)"))
+@ConfigurationPropertiesScan(basePackages = {
+  "com.schemafy.mcp",
+  "com.schemafy.core",
+})
+public class McpApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(McpApplication.class, args);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/config/R2dbcConfig.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/config/R2dbcConfig.java
@@ -1,0 +1,74 @@
+package com.schemafy.mcp.common.config;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.data.r2dbc.convert.R2dbcCustomConversions;
+import org.springframework.data.r2dbc.dialect.MySqlDialect;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.r2dbc.connection.R2dbcTransactionManager;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+@Configuration
+@EnableR2dbcAuditing
+@EnableR2dbcRepositories(basePackages = {
+  "com.schemafy.core"
+})
+public class R2dbcConfig {
+
+  @Bean
+  public R2dbcCustomConversions r2dbcCustomConversions() {
+    List<Object> converters = new ArrayList<>();
+    converters.add(new InstantToLocalDateTimeConverter());
+    converters.add(new LocalDateTimeToInstantConverter());
+
+    return R2dbcCustomConversions.of(MySqlDialect.INSTANCE, converters);
+  }
+
+  @Bean
+  public ReactiveTransactionManager transactionManager(
+      ConnectionFactory connectionFactory) {
+    return new R2dbcTransactionManager(connectionFactory);
+  }
+
+  @Bean
+  public TransactionalOperator transactionalOperator(
+      ReactiveTransactionManager transactionManager) {
+    return TransactionalOperator.create(transactionManager);
+  }
+
+  @WritingConverter
+  static class InstantToLocalDateTimeConverter
+      implements Converter<Instant, LocalDateTime> {
+
+    @Override
+    public LocalDateTime convert(Instant source) {
+      return LocalDateTime.ofInstant(source, ZoneOffset.UTC);
+    }
+
+  }
+
+  @ReadingConverter
+  static class LocalDateTimeToInstantConverter
+      implements Converter<LocalDateTime, Instant> {
+
+    @Override
+    public Instant convert(LocalDateTime source) {
+      return source.toInstant(ZoneOffset.UTC);
+    }
+
+  }
+
+}

--- a/apps/backend/mcp/src/main/resources/application-local.yml
+++ b/apps/backend/mcp/src/main/resources/application-local.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/apps/backend/mcp/src/main/resources/application-server.yml
+++ b/apps/backend/mcp/src/main/resources/application-server.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: server
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+      show-components: never

--- a/apps/backend/mcp/src/main/resources/application.yml
+++ b/apps/backend/mcp/src/main/resources/application.yml
@@ -1,0 +1,55 @@
+spring:
+  config:
+    import:
+      - "optional:file:.env[.properties]"
+
+  profiles:
+    active: local
+
+  application:
+    name: schemafy-mcp
+
+  ai:
+    mcp:
+      server:
+        name: schemafy-mcp
+        version: 0.0.1
+        protocol: STREAMABLE
+        type: ASYNC
+        annotation-scanner:
+          enabled: true
+
+  r2dbc:
+    url: r2dbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:schemafy}
+    username: ${DB_USER:schemafy}
+    password: ${DB_PASSWORD:schemafy}
+    pool:
+      enabled: true
+      initial-size: 5
+      max-size: 20
+
+  output:
+    ansi:
+      enabled: always
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:ddl/mariadb/**/*.sql
+
+server:
+  port: ${MCP_SERVER_PORT:8081}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+      show-components: always

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/McpApplicationTests.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/McpApplicationTests.java
@@ -1,0 +1,15 @@
+package com.schemafy.mcp;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import org.junit.jupiter.api.Test;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class McpApplicationTests {
+
+  @Test
+  void contextLoads() {}
+
+}

--- a/apps/backend/mcp/src/test/resources/application-test.yml
+++ b/apps/backend/mcp/src/test/resources/application-test.yml
@@ -1,0 +1,42 @@
+spring:
+  application:
+    name: schemafy-mcp-test
+
+  ai:
+    mcp:
+      server:
+        name: schemafy-mcp-test
+        version: 0.0.1
+        protocol: STREAMABLE
+        type: ASYNC
+        annotation-scanner:
+          enabled: true
+
+  r2dbc:
+    url: r2dbc:h2:mem:///schemafy-mcp;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    pool:
+      enabled: true
+      initial-size: 1
+      max-size: 5
+
+  sql:
+    init:
+      schema-locations: classpath:ddl/h2/**/*.sql
+      mode: always
+
+server:
+  port: 0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "build": "cd ../.. && ./gradlew :api:build :core:build",
+    "build": "cd ../.. && ./gradlew :api:build :core:build :mcp:build",
     "dev": "cd ../.. && ./gradlew :api:bootRun",
     "lint": "echo 'No linter configured for backend'",
-    "format": "cd ../.. && ./gradlew :api:spotlessApply :core:spotlessApply",
-    "format:check": "cd ../.. && ./gradlew :api:spotlessCheck :core:spotlessCheck",
-    "test": "cd ../.. && ./gradlew :api:test :core:test"
+    "format": "cd ../.. && ./gradlew :api:spotlessApply :core:spotlessApply :mcp:spotlessApply",
+    "format:check": "cd ../.. && ./gradlew :api:spotlessCheck :core:spotlessCheck :mcp:spotlessCheck",
+    "test": "cd ../.. && ./gradlew :api:test :core:test :mcp:test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:frontend": "cd apps/frontend && pnpm run build",
-    "build:backend": "./gradlew :core:build :api:build",
+    "build:backend": "./gradlew :core:build :api:build :mcp:build",
     "infra": "podman compose up -d mariadb redis || true",
     "dev": "pnpm run infra && turbo run dev --parallel",
     "dev:frontend": "cd apps/frontend && pnpm run dev",

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'schemafy'
 
-include ':core', ':api'
+include ':core', ':api', ':mcp'
 project(':core').projectDir = file('apps/backend/core')
 project(':api').projectDir = file('apps/backend/api')
+project(':mcp').projectDir = file('apps/backend/mcp')


### PR DESCRIPTION
## 개요

- `apps/backend/mcp`에 Spring Boot 기반 MCP 서버 모듈 추가
- `:mcp`가 `:core`만 의존하도록 Gradle 모듈 및 빌드 설정 구성
- MCP Streamable HTTP 서버 설정, local/server/test profile, R2DBC config와 context smoke test 추가
- backend build/test/format 및 SpotBugs matrix에 `:mcp` 포함

## 참고

- 인증, resource, tool 구현은 후속 이슈 범위
- 현재 범위는 빈 MCP 서버가 독립 실행되고 initialize handshake 가능한 기반까지

## 이슈

- close #425
