### PR TITLE
feat(#426): secure MCP token authentication

### DIFF
--- a/apps/backend/api/src/docs/asciidoc/api-guide.adoc
+++ b/apps/backend/api/src/docs/asciidoc/api-guide.adoc
@@ -3802,6 +3802,64 @@ include::{snippets}/oauth-github-authorize/http-response.adoc[]
 
 ---
 
+== MCP Token API
+
+MCP 서버에 연결할 때 사용할 MCP 전용 Bearer 토큰을 발급하고 폐기합니다. 이 토큰은 Schemafy API용 JWT와 별도로 사용되며, MCP 클라이언트는 `/mcp` 요청마다 `Authorization: Bearer {mcpToken}` 헤더로 전달해야 합니다.
+
+=== MCP 토큰 발급
+
+로그인된 사용자에게 MCP 서버 접근용 Bearer 토큰을 발급합니다. 응답으로 받은 토큰 값은 MCP 요청의 `Authorization` 헤더에 사용합니다.
+
+[source]
+----
+POST /api/v1.0/mcp/tokens
+----
+
+[discrete]
+==== 요청
+
+include::{snippets}/mcp-token-issue/http-request.adoc[]
+include::{snippets}/mcp-token-issue/request-headers.adoc[]
+include::{snippets}/mcp-token-issue/curl-request.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/mcp-token-issue/response-headers.adoc[]
+include::{snippets}/mcp-token-issue/response-body.adoc[]
+include::{snippets}/mcp-token-issue/http-response.adoc[]
+
+[discrete]
+==== 응답 필드
+
+include::{snippets}/mcp-token-issue/response-fields.adoc[]
+
+---
+
+=== MCP 토큰 폐기
+
+사용자 자신의 MCP 토큰을 폐기합니다. 폐기된 토큰은 이후 MCP 요청 인증에 사용할 수 없습니다.
+
+[source]
+----
+POST /api/v1.0/mcp/tokens/revoke
+----
+
+[discrete]
+==== 요청
+
+include::{snippets}/mcp-token-revoke/http-request.adoc[]
+include::{snippets}/mcp-token-revoke/request-headers.adoc[]
+include::{snippets}/mcp-token-revoke/request-fields.adoc[]
+include::{snippets}/mcp-token-revoke/curl-request.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/mcp-token-revoke/http-response.adoc[]
+
+---
+
 == WebSocket API
 
 실시간 기능을 위한 WebSocket API입니다.

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/config/McpTokenConfig.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/config/McpTokenConfig.java
@@ -1,0 +1,22 @@
+package com.schemafy.api.mcp.config;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.schemafy.api.mcp.service.McpTokenProperties;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration(proxyBeanMethods = false)
+public class McpTokenConfig {
+
+  @Bean
+  SecretKey mcpTokenSecretKey(McpTokenProperties properties) {
+    return Keys.hmacShaKeyFor(
+        properties.getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/McpTokenController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/McpTokenController.java
@@ -1,0 +1,44 @@
+package com.schemafy.api.mcp.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.schemafy.api.common.constant.ApiPath;
+import com.schemafy.api.common.security.principal.AuthenticatedUser;
+import com.schemafy.api.mcp.controller.dto.request.McpTokenRevokeRequest;
+import com.schemafy.api.mcp.controller.dto.response.McpTokenIssueResponse;
+import com.schemafy.api.mcp.service.McpTokenService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping(ApiPath.API)
+@RequiredArgsConstructor
+public class McpTokenController {
+
+  private final McpTokenService mcpTokenService;
+
+  @PostMapping("/mcp/tokens")
+  public Mono<ResponseEntity<McpTokenIssueResponse>> issue(
+      @AuthenticationPrincipal AuthenticatedUser user) {
+    return mcpTokenService.issue(user.userId())
+        .map(McpTokenIssueResponse::from)
+        .map(ResponseEntity::ok);
+  }
+
+  @PostMapping("/mcp/tokens/revoke")
+  public Mono<ResponseEntity<Void>> revoke(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @Valid @RequestBody McpTokenRevokeRequest request) {
+    return mcpTokenService.revoke(user.userId(), request.token())
+        .thenReturn(ResponseEntity.noContent().build());
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/dto/request/McpTokenRevokeRequest.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/dto/request/McpTokenRevokeRequest.java
@@ -1,0 +1,7 @@
+package com.schemafy.api.mcp.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record McpTokenRevokeRequest(
+    @NotBlank String token) {
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/dto/response/McpTokenIssueResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/controller/dto/response/McpTokenIssueResponse.java
@@ -1,0 +1,17 @@
+package com.schemafy.api.mcp.controller.dto.response;
+
+import com.schemafy.api.mcp.service.McpTokenIssueResult;
+
+public record McpTokenIssueResponse(
+    String token,
+    String tokenType,
+    long expiresInSeconds) {
+
+  public static McpTokenIssueResponse from(McpTokenIssueResult result) {
+    return new McpTokenIssueResponse(
+        result.token(),
+        "Bearer",
+        result.expiresInSeconds());
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/exception/McpTokenErrorCode.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/exception/McpTokenErrorCode.java
@@ -1,0 +1,21 @@
+package com.schemafy.api.mcp.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.schemafy.core.common.exception.DomainErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum McpTokenErrorCode implements DomainErrorCode {
+
+  INVALID(HttpStatus.UNAUTHORIZED),
+  OWNER_MISMATCH(HttpStatus.FORBIDDEN),
+  REVOCATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE),
+  REGISTRY_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE);
+
+  private final HttpStatus status;
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenIssueResult.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenIssueResult.java
@@ -1,0 +1,12 @@
+package com.schemafy.api.mcp.service;
+
+import java.time.Instant;
+
+public record McpTokenIssueResult(
+    String token,
+    String tokenId,
+    String scope,
+    Instant issuedAt,
+    Instant expiresAt,
+    long expiresInSeconds) {
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
@@ -1,0 +1,47 @@
+package com.schemafy.api.mcp.service;
+
+import java.time.Duration;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "mcp.security.token")
+public class McpTokenProperties {
+
+  @NotBlank
+  @Size(min = 32)
+  private String secret = "schemafy-mcp-local-secret-minimum-256-bit-key-value";
+
+  @NotBlank
+  private String issuer = "schemafy-mcp";
+
+  @NotBlank
+  private String audience = "schemafy-mcp";
+
+  @NotBlank
+  private String tokenType = "MCP";
+
+  @NotBlank
+  private String requiredScope = "mcp";
+
+  @NotBlank
+  private String revocationKeyPrefix = "mcp:token:revoked:";
+
+  @NotNull
+  private Duration expiresIn = Duration.ofMinutes(15);
+
+  @PositiveOrZero
+  private long clockSkewSeconds = 30;
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
@@ -38,6 +38,6 @@ public class McpTokenProperties {
   private String revocationKeyPrefix = "mcp:token:revoked:";
 
   @NotNull
-  private Duration expiresIn = Duration.ofMinutes(15);
+  private Duration expiresIn = Duration.ofDays(7);
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenProperties.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -40,8 +39,5 @@ public class McpTokenProperties {
 
   @NotNull
   private Duration expiresIn = Duration.ofMinutes(15);
-
-  @PositiveOrZero
-  private long clockSkewSeconds = 30;
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenRevocationCache.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenRevocationCache.java
@@ -4,8 +4,8 @@ import java.time.Duration;
 
 import reactor.core.publisher.Mono;
 
-public interface McpTokenRevocationStore {
+public interface McpTokenRevocationCache {
 
-  Mono<Void> revoke(String tokenId, Duration ttl);
+  Mono<Void> cacheRevocation(String tokenId, Duration ttl);
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenRevocationStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenRevocationStore.java
@@ -1,0 +1,11 @@
+package com.schemafy.api.mcp.service;
+
+import java.time.Duration;
+
+import reactor.core.publisher.Mono;
+
+public interface McpTokenRevocationStore {
+
+  Mono<Void> revoke(String tokenId, Duration ttl);
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
@@ -4,12 +4,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Predicate;
 import javax.crypto.SecretKey;
 
@@ -23,6 +19,7 @@ import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenCommand;
 import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenUseCase;
 import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
 import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenUseCase;
+import com.schemafy.core.mcp.domain.McpTokenClaimSupport;
 import com.schemafy.core.ulid.application.service.UlidGenerator;
 
 import io.jsonwebtoken.Claims;
@@ -37,14 +34,9 @@ import reactor.core.publisher.Mono;
 @Service
 public class McpTokenService {
 
-  private static final String CLAIM_TYPE = "type";
-  private static final String CLAIM_SCOPE = "scope";
-  private static final String CLAIM_SCOPES = "scopes";
-  private static final String CLAIM_SCP = "scp";
-
   private final McpTokenProperties properties;
   @Nullable
-  private final McpTokenRevocationStore revocationStore;
+  private final McpTokenRevocationCache revocationCache;
   private final RegisterMcpTokenUseCase registerMcpTokenUseCase;
   private final RevokeMcpTokenUseCase revokeMcpTokenUseCase;
   private final Clock clock;
@@ -52,12 +44,12 @@ public class McpTokenService {
 
   public McpTokenService(
       McpTokenProperties properties,
-      @Nullable McpTokenRevocationStore revocationStore,
+      @Nullable McpTokenRevocationCache revocationCache,
       RegisterMcpTokenUseCase registerMcpTokenUseCase,
       RevokeMcpTokenUseCase revokeMcpTokenUseCase,
       Clock clock) {
     this.properties = properties;
-    this.revocationStore = revocationStore;
+    this.revocationCache = revocationCache;
     this.registerMcpTokenUseCase = registerMcpTokenUseCase;
     this.revokeMcpTokenUseCase = revokeMcpTokenUseCase;
     this.clock = clock;
@@ -78,8 +70,8 @@ public class McpTokenService {
         .audience().add(properties.getAudience()).and()
         .issuedAt(Date.from(issuedAt))
         .expiration(Date.from(expiresAt))
-        .claim(CLAIM_TYPE, properties.getTokenType())
-        .claim(CLAIM_SCOPE, scope)
+        .claim(McpTokenClaimSupport.TYPE, properties.getTokenType())
+        .claim(McpTokenClaimSupport.SCOPE, scope)
         .signWith(secretKey)
         .compact();
 
@@ -151,10 +143,11 @@ public class McpTokenService {
         || claims.getAudience() == null
         || !claims.getAudience().contains(properties.getAudience())
         || !Objects.equals(properties.getTokenType(),
-            claims.get(CLAIM_TYPE, String.class))
+            claims.get(McpTokenClaimSupport.TYPE, String.class))
         || !StringUtils.hasText(claims.getId())
         || claims.getExpiration() == null
-        || !extractScopes(claims).contains(properties.getRequiredScope())) {
+        || !McpTokenClaimSupport.extractScopes(claims::get)
+            .contains(properties.getRequiredScope())) {
       throw new DomainException(McpTokenErrorCode.INVALID,
           "MCP token is invalid");
     }
@@ -165,10 +158,10 @@ public class McpTokenService {
   }
 
   private Mono<Void> cacheRevocation(String tokenId, Duration ttl) {
-    if (revocationStore == null) {
+    if (revocationCache == null) {
       return Mono.empty();
     }
-    return revocationStore.revoke(tokenId, ttl)
+    return revocationCache.cacheRevocation(tokenId, ttl)
         .onErrorResume(error -> {
           log.warn("Failed to cache MCP token revocation: tokenId={}", tokenId,
               error);
@@ -178,30 +171,6 @@ public class McpTokenService {
 
   private Predicate<Throwable> notDomainException() {
     return error -> !(error instanceof DomainException);
-  }
-
-  private Set<String> extractScopes(Claims claims) {
-    Set<String> scopes = new LinkedHashSet<>();
-    addScopes(scopes, claims.get(CLAIM_SCOPE));
-    addScopes(scopes, claims.get(CLAIM_SCOPES));
-    addScopes(scopes, claims.get(CLAIM_SCP));
-    return scopes;
-  }
-
-  private void addScopes(Set<String> scopes, Object value) {
-    if (value instanceof String stringValue) {
-      Arrays.stream(stringValue.split("[\\s,]+"))
-          .filter(StringUtils::hasText)
-          .forEach(scopes::add);
-      return;
-    }
-    if (value instanceof Collection<?> values) {
-      values.stream()
-          .filter(Objects::nonNull)
-          .map(Object::toString)
-          .filter(StringUtils::hasText)
-          .forEach(scopes::add);
-    }
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
@@ -1,6 +1,5 @@
 package com.schemafy.api.mcp.service;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -9,6 +8,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -26,7 +26,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -47,14 +46,14 @@ public class McpTokenService {
       @Nullable McpTokenRevocationCache revocationCache,
       RegisterMcpTokenUseCase registerMcpTokenUseCase,
       RevokeMcpTokenUseCase revokeMcpTokenUseCase,
-      Clock clock) {
+      Clock clock,
+      @Qualifier("mcpTokenSecretKey") SecretKey secretKey) {
     this.properties = properties;
     this.revocationCache = revocationCache;
     this.registerMcpTokenUseCase = registerMcpTokenUseCase;
     this.revokeMcpTokenUseCase = revokeMcpTokenUseCase;
     this.clock = clock;
-    this.secretKey = Keys.hmacShaKeyFor(
-        properties.getSecret().getBytes(StandardCharsets.UTF_8));
+    this.secretKey = secretKey;
   }
 
   public Mono<McpTokenIssueResult> issue(String userId) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
@@ -1,0 +1,208 @@
+package com.schemafy.api.mcp.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.crypto.SecretKey;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.schemafy.api.mcp.exception.McpTokenErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenUseCase;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenUseCase;
+import com.schemafy.core.ulid.application.service.UlidGenerator;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class McpTokenService {
+
+  private static final String CLAIM_TYPE = "type";
+  private static final String CLAIM_SCOPE = "scope";
+  private static final String CLAIM_SCOPES = "scopes";
+  private static final String CLAIM_SCP = "scp";
+
+  private final McpTokenProperties properties;
+  @Nullable
+  private final McpTokenRevocationStore revocationStore;
+  private final RegisterMcpTokenUseCase registerMcpTokenUseCase;
+  private final RevokeMcpTokenUseCase revokeMcpTokenUseCase;
+  private final Clock clock;
+  private final SecretKey secretKey;
+
+  public McpTokenService(
+      McpTokenProperties properties,
+      @Nullable McpTokenRevocationStore revocationStore,
+      RegisterMcpTokenUseCase registerMcpTokenUseCase,
+      RevokeMcpTokenUseCase revokeMcpTokenUseCase,
+      Clock clock) {
+    this.properties = properties;
+    this.revocationStore = revocationStore;
+    this.registerMcpTokenUseCase = registerMcpTokenUseCase;
+    this.revokeMcpTokenUseCase = revokeMcpTokenUseCase;
+    this.clock = clock;
+    this.secretKey = Keys.hmacShaKeyFor(
+        properties.getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+  public Mono<McpTokenIssueResult> issue(String userId) {
+    Instant issuedAt = clock.instant();
+    Instant expiresAt = issuedAt.plus(properties.getExpiresIn());
+    String tokenId = UlidGenerator.generate();
+    String scope = properties.getRequiredScope();
+
+    String token = Jwts.builder()
+        .id(tokenId)
+        .subject(userId)
+        .issuer(properties.getIssuer())
+        .audience().add(properties.getAudience()).and()
+        .issuedAt(Date.from(issuedAt))
+        .expiration(Date.from(expiresAt))
+        .claim(CLAIM_TYPE, properties.getTokenType())
+        .claim(CLAIM_SCOPE, scope)
+        .signWith(secretKey)
+        .compact();
+
+    McpTokenIssueResult result = new McpTokenIssueResult(
+        token,
+        tokenId,
+        scope,
+        issuedAt,
+        expiresAt,
+        properties.getExpiresIn().toSeconds());
+    return registerMcpTokenUseCase.registerMcpToken(new RegisterMcpTokenCommand(
+        tokenId,
+        userId,
+        scope,
+        issuedAt,
+        expiresAt))
+        .thenReturn(result)
+        .onErrorMap(notDomainException(), error -> new DomainException(
+            McpTokenErrorCode.REGISTRY_UNAVAILABLE,
+            "MCP token registry is temporarily unavailable"));
+  }
+
+  public Mono<Void> revoke(String userId, String token) {
+    return Mono.defer(() -> {
+      Claims claims = parseClaims(token);
+      validateRevocableClaims(userId, claims);
+
+      Instant revokedAt = clock.instant();
+      Instant expiresAt = claims.getExpiration().toInstant();
+      Duration ttl = Duration.between(revokedAt, expiresAt);
+      if (ttl.isZero() || ttl.isNegative()) {
+        return Mono.empty();
+      }
+
+      return revokeMcpTokenUseCase.revokeMcpToken(new RevokeMcpTokenCommand(
+          claims.getId(), userId, revokedAt))
+          .flatMap(registered -> registered
+              ? cacheRevocation(claims.getId(), ttl)
+              : Mono.error(new DomainException(McpTokenErrorCode.INVALID,
+                  "MCP token is not registered")));
+    })
+        .onErrorMap(notDomainException(), error -> new DomainException(
+            McpTokenErrorCode.REGISTRY_UNAVAILABLE,
+            "MCP token registry is temporarily unavailable"));
+  }
+
+  private Claims parseClaims(String token) {
+    if (!StringUtils.hasText(token)) {
+      throw new DomainException(McpTokenErrorCode.INVALID,
+          "MCP token is required");
+    }
+    try {
+      return Jwts.parser()
+          .verifyWith(secretKey)
+          .clock(() -> Date.from(clock.instant()))
+          .clockSkewSeconds(properties.getClockSkewSeconds())
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    } catch (JwtException | IllegalArgumentException e) {
+      throw new DomainException(McpTokenErrorCode.INVALID,
+          "MCP token is invalid");
+    }
+  }
+
+  private void validateRevocableClaims(String userId, Claims claims) {
+    if (!Objects.equals(properties.getIssuer(), claims.getIssuer())
+        || claims.getAudience() == null
+        || !claims.getAudience().contains(properties.getAudience())
+        || !Objects.equals(properties.getTokenType(),
+            claims.get(CLAIM_TYPE, String.class))
+        || !StringUtils.hasText(claims.getId())
+        || claims.getExpiration() == null
+        || !extractScopes(claims).contains(properties.getRequiredScope())) {
+      throw new DomainException(McpTokenErrorCode.INVALID,
+          "MCP token is invalid");
+    }
+    if (!Objects.equals(userId, claims.getSubject())) {
+      throw new DomainException(McpTokenErrorCode.OWNER_MISMATCH,
+          "MCP token belongs to another user");
+    }
+  }
+
+  private Mono<Void> cacheRevocation(String tokenId, Duration ttl) {
+    if (revocationStore == null) {
+      return Mono.empty();
+    }
+    return revocationStore.revoke(tokenId, ttl)
+        .onErrorResume(error -> {
+          log.warn("Failed to cache MCP token revocation: tokenId={}", tokenId,
+              error);
+          return Mono.empty();
+        });
+  }
+
+  private Predicate<Throwable> notDomainException() {
+    return error -> !(error instanceof DomainException);
+  }
+
+  private Set<String> extractScopes(Claims claims) {
+    Set<String> scopes = new LinkedHashSet<>();
+    addScopes(scopes, claims.get(CLAIM_SCOPE));
+    addScopes(scopes, claims.get(CLAIM_SCOPES));
+    addScopes(scopes, claims.get(CLAIM_SCP));
+    return scopes;
+  }
+
+  private void addScopes(Set<String> scopes, Object value) {
+    if (value instanceof String stringValue) {
+      Arrays.stream(stringValue.split("[\\s,]+"))
+          .filter(StringUtils::hasText)
+          .forEach(scopes::add);
+      return;
+    }
+    if (value instanceof Collection<?> values) {
+      values.stream()
+          .filter(Objects::nonNull)
+          .map(Object::toString)
+          .filter(StringUtils::hasText)
+          .forEach(scopes::add);
+    }
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/McpTokenService.java
@@ -135,7 +135,6 @@ public class McpTokenService {
       return Jwts.parser()
           .verifyWith(secretKey)
           .clock(() -> Date.from(clock.instant()))
-          .clockSkewSeconds(properties.getClockSkewSeconds())
           .build()
           .parseSignedClaims(token)
           .getPayload();

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationCache.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationCache.java
@@ -13,13 +13,13 @@ import reactor.core.publisher.Mono;
 @Service
 @ConditionalOnRedisEnabled
 @RequiredArgsConstructor
-public class RedisMcpTokenRevocationStore implements McpTokenRevocationStore {
+public class RedisMcpTokenRevocationCache implements McpTokenRevocationCache {
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final McpTokenProperties properties;
 
   @Override
-  public Mono<Void> revoke(String tokenId, Duration ttl) {
+  public Mono<Void> cacheRevocation(String tokenId, Duration ttl) {
     return redisTemplate.opsForValue()
         .set(properties.getRevocationKeyPrefix() + tokenId, "1", ttl)
         .then();

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationStore.java
@@ -1,0 +1,28 @@
+package com.schemafy.api.mcp.service;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@ConditionalOnRedisEnabled
+@RequiredArgsConstructor
+public class RedisMcpTokenRevocationStore implements McpTokenRevocationStore {
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final McpTokenProperties properties;
+
+  @Override
+  public Mono<Void> revoke(String tokenId, Duration ttl) {
+    return redisTemplate.opsForValue()
+        .set(properties.getRevocationKeyPrefix() + tokenId, "1", ttl)
+        .then();
+  }
+
+}

--- a/apps/backend/api/src/main/resources/application-server.yml
+++ b/apps/backend/api/src/main/resources/application-server.yml
@@ -12,6 +12,11 @@ jwt:
   cookie:
     secure: true
 
+mcp:
+  security:
+    token:
+      secret: ${MCP_TOKEN_SECRET}
+
 cors:
   allowed-origins: ${JWT_ALLOWED_ORIGINS:http://localhost:3000}
 

--- a/apps/backend/api/src/main/resources/application.yml
+++ b/apps/backend/api/src/main/resources/application.yml
@@ -79,7 +79,7 @@ mcp:
       token-type: ${MCP_TOKEN_TYPE:MCP}
       required-scope: ${MCP_TOKEN_REQUIRED_SCOPE:mcp}
       revocation-key-prefix: "${MCP_TOKEN_REVOCATION_KEY_PREFIX:mcp:token:revoked:}"
-      expires-in: ${MCP_TOKEN_EXPIRES_IN:15m}
+      expires-in: ${MCP_TOKEN_EXPIRES_IN:7d}
 
 management:
   endpoints:

--- a/apps/backend/api/src/main/resources/application.yml
+++ b/apps/backend/api/src/main/resources/application.yml
@@ -70,6 +70,18 @@ oauth:
 sharelink:
   pepper: ${SHARELINK_PEPPER:default-pepper}
 
+mcp:
+  security:
+    token:
+      secret: ${MCP_TOKEN_SECRET:schemafy-mcp-local-secret-minimum-256-bit-key-value}
+      issuer: ${MCP_TOKEN_ISSUER:schemafy-mcp}
+      audience: ${MCP_TOKEN_AUDIENCE:schemafy-mcp}
+      token-type: ${MCP_TOKEN_TYPE:MCP}
+      required-scope: ${MCP_TOKEN_REQUIRED_SCOPE:mcp}
+      revocation-key-prefix: "${MCP_TOKEN_REVOCATION_KEY_PREFIX:mcp:token:revoked:}"
+      expires-in: ${MCP_TOKEN_EXPIRES_IN:15m}
+      clock-skew-seconds: ${MCP_TOKEN_CLOCK_SKEW_SECONDS:30}
+
 management:
   endpoints:
     web:

--- a/apps/backend/api/src/main/resources/application.yml
+++ b/apps/backend/api/src/main/resources/application.yml
@@ -80,7 +80,6 @@ mcp:
       required-scope: ${MCP_TOKEN_REQUIRED_SCOPE:mcp}
       revocation-key-prefix: "${MCP_TOKEN_REVOCATION_KEY_PREFIX:mcp:token:revoked:}"
       expires-in: ${MCP_TOKEN_EXPIRES_IN:15m}
-      clock-skew-seconds: ${MCP_TOKEN_CLOCK_SKEW_SECONDS:30}
 
 management:
   endpoints:

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/exception/DomainErrorCodeUniquenessTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/exception/DomainErrorCodeUniquenessTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import com.schemafy.api.mcp.exception.McpTokenErrorCode;
 import com.schemafy.core.common.exception.DomainErrorCode;
 import com.schemafy.core.erd.column.domain.exception.ColumnErrorCode;
 import com.schemafy.core.erd.constraint.domain.exception.ConstraintErrorCode;
@@ -32,6 +33,7 @@ class DomainErrorCodeUniquenessTest {
       OAuthErrorCode.class,
       ValidationErrorCode.class,
       HmacErrorCode.class,
+      McpTokenErrorCode.class,
       UserErrorCode.class,
       WorkspaceErrorCode.class,
       ProjectErrorCode.class,

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
@@ -1,0 +1,237 @@
+package com.schemafy.api.mcp.controller;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.jayway.jsonpath.JsonPath;
+import com.schemafy.api.common.constant.ApiPath;
+import com.schemafy.api.mcp.docs.McpTokenApiSnippets;
+import com.schemafy.api.mcp.exception.McpTokenErrorCode;
+import com.schemafy.api.mcp.service.McpTokenRevocationStore;
+import com.schemafy.api.testsupport.user.UserHttpTestSupport;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureWebTestClient
+@AutoConfigureRestDocs
+@DisplayName("McpTokenController 통합 테스트")
+class McpTokenControllerTest extends UserHttpTestSupport {
+
+  private static final String API_BASE_PATH = ApiPath.API.replace("{version}",
+      "v1.0");
+
+  @Autowired
+  WebTestClient webTestClient;
+
+  @Autowired
+  TestMcpTokenRevocationStore revocationStore;
+
+  @BeforeEach
+  void setUp() {
+    databaseClient.sql("DELETE FROM mcp_tokens")
+        .fetch()
+        .rowsUpdated()
+        .then(cleanupUserFixtures())
+        .block();
+    revocationStore.clear();
+  }
+
+  @Test
+  @DisplayName("인증된 사용자는 MCP 토큰을 발급받는다")
+  void issuesMcpToken() {
+    User user = createUser("mcp-issue@example.com", "MCP User");
+    String accessToken = generateAccessToken(user.id());
+
+    EntityExchangeResult<byte[]> result = webTestClient.post()
+        .uri(API_BASE_PATH + "/mcp/tokens")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .consumeWith(document("mcp-token-issue",
+            McpTokenApiSnippets.issueMcpTokenRequestHeaders(),
+            McpTokenApiSnippets.issueMcpTokenResponseHeaders(),
+            McpTokenApiSnippets.issueMcpTokenResponse()))
+        .jsonPath("$.token").isNotEmpty()
+        .jsonPath("$.tokenType").isEqualTo("Bearer")
+        .jsonPath("$.expiresInSeconds").isEqualTo(900)
+        .jsonPath("$.tokenId").doesNotExist()
+        .jsonPath("$.scope").doesNotExist()
+        .jsonPath("$.issuedAt").doesNotExist()
+        .jsonPath("$.expiresAt").doesNotExist()
+        .returnResult();
+
+    McpTokenRow tokenRow = findTokenRowByUserId(user.id());
+    assertThat(tokenRow.userId()).isEqualTo(user.id());
+    assertThat(tokenRow.scope()).isEqualTo("mcp");
+    assertThat(tokenRow.revokedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자는 MCP 토큰을 발급받을 수 없다")
+  void rejectsIssueWhenUnauthenticated() {
+    webTestClient.post()
+        .uri(API_BASE_PATH + "/mcp/tokens")
+        .exchange()
+        .expectStatus().isUnauthorized();
+  }
+
+  @Test
+  @DisplayName("사용자 자신의 MCP 토큰을 revoke한다")
+  void revokesOwnMcpToken() {
+    User user = createUser("mcp-revoke@example.com", "MCP Revoke User");
+    String accessToken = generateAccessToken(user.id());
+    EntityExchangeResult<byte[]> issueResult = issueToken(accessToken);
+    String responseBody = new String(issueResult.getResponseBody());
+    String token = JsonPath.read(responseBody, "$.token");
+    McpTokenRow issuedTokenRow = findTokenRowByUserId(user.id());
+
+    webTestClient.post()
+        .uri(API_BASE_PATH + "/mcp/tokens/revoke")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(Map.of("token", token))
+        .exchange()
+        .expectStatus().isNoContent()
+        .expectBody()
+        .consumeWith(document("mcp-token-revoke",
+            McpTokenApiSnippets.revokeMcpTokenRequestHeaders(),
+            McpTokenApiSnippets.revokeMcpTokenRequest()))
+        .isEmpty();
+
+    assertThat(revocationStore.revokedTokens())
+        .singleElement()
+        .satisfies(revoked -> assertThat(revoked.tokenId()).isEqualTo(issuedTokenRow.id()));
+    assertThat(findTokenRow(issuedTokenRow.id()).revokedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 MCP 토큰 revoke는 거부한다")
+  void rejectsRevokingAnotherUsersToken() {
+    User userA = createUser("mcp-owner-a@example.com", "MCP Owner A");
+    User userB = createUser("mcp-owner-b@example.com", "MCP Owner B");
+    String userAToken = generateAccessToken(userA.id());
+    String userBToken = generateAccessToken(userB.id());
+    EntityExchangeResult<byte[]> issueResult = issueToken(userAToken);
+    String mcpToken = JsonPath.read(new String(issueResult.getResponseBody()),
+        "$.token");
+
+    webTestClient.post()
+        .uri(API_BASE_PATH + "/mcp/tokens/revoke")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + userBToken)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(Map.of("token", mcpToken))
+        .exchange()
+        .expectStatus().isForbidden()
+        .expectBody()
+        .jsonPath("$.reason")
+        .isEqualTo(McpTokenErrorCode.OWNER_MISMATCH.code());
+
+    assertThat(revocationStore.revokedTokens()).isEmpty();
+  }
+
+  private EntityExchangeResult<byte[]> issueToken(String accessToken) {
+    return webTestClient.post()
+        .uri(API_BASE_PATH + "/mcp/tokens")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .returnResult();
+  }
+
+  private McpTokenRow findTokenRow(String tokenId) {
+    return databaseClient.sql("""
+        SELECT id, user_id, scope, revoked_at
+        FROM mcp_tokens
+        WHERE id = :tokenId
+        """)
+        .bind("tokenId", tokenId)
+        .map((row, metadata) -> new McpTokenRow(
+            row.get("id", String.class),
+            row.get("user_id", String.class),
+            row.get("scope", String.class),
+            row.get("revoked_at")))
+        .one()
+        .block();
+  }
+
+  private McpTokenRow findTokenRowByUserId(String userId) {
+    return databaseClient.sql("""
+        SELECT id, user_id, scope, revoked_at
+        FROM mcp_tokens
+        WHERE user_id = :userId
+        """)
+        .bind("userId", userId)
+        .map((row, metadata) -> new McpTokenRow(
+            row.get("id", String.class),
+            row.get("user_id", String.class),
+            row.get("scope", String.class),
+            row.get("revoked_at")))
+        .one()
+        .block();
+  }
+
+  @TestConfiguration
+  static class McpTokenControllerTestConfig {
+
+    @Bean
+    TestMcpTokenRevocationStore testMcpTokenRevocationStore() {
+      return new TestMcpTokenRevocationStore();
+    }
+
+  }
+
+  static class TestMcpTokenRevocationStore
+      implements McpTokenRevocationStore {
+
+    private final List<RevokedToken> revokedTokens = new ArrayList<>();
+
+    @Override
+    public Mono<Void> revoke(String tokenId, Duration ttl) {
+      revokedTokens.add(new RevokedToken(tokenId, ttl));
+      return Mono.empty();
+    }
+
+    List<RevokedToken> revokedTokens() {
+      return revokedTokens;
+    }
+
+    void clear() {
+      revokedTokens.clear();
+    }
+
+  }
+
+  record RevokedToken(String tokenId, Duration ttl) {
+  }
+
+  record McpTokenRow(String id, String userId, String scope, Object revokedAt) {
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
@@ -79,7 +79,7 @@ class McpTokenControllerTest extends UserHttpTestSupport {
             McpTokenApiSnippets.issueMcpTokenResponse()))
         .jsonPath("$.token").isNotEmpty()
         .jsonPath("$.tokenType").isEqualTo("Bearer")
-        .jsonPath("$.expiresInSeconds").isEqualTo(900)
+        .jsonPath("$.expiresInSeconds").isEqualTo(604800)
         .jsonPath("$.tokenId").doesNotExist()
         .jsonPath("$.scope").doesNotExist()
         .jsonPath("$.issuedAt").doesNotExist()

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/controller/McpTokenControllerTest.java
@@ -25,7 +25,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.mcp.docs.McpTokenApiSnippets;
 import com.schemafy.api.mcp.exception.McpTokenErrorCode;
-import com.schemafy.api.mcp.service.McpTokenRevocationStore;
+import com.schemafy.api.mcp.service.McpTokenRevocationCache;
 import com.schemafy.api.testsupport.user.UserHttpTestSupport;
 import com.schemafy.core.user.domain.User;
 
@@ -48,7 +48,7 @@ class McpTokenControllerTest extends UserHttpTestSupport {
   WebTestClient webTestClient;
 
   @Autowired
-  TestMcpTokenRevocationStore revocationStore;
+  TestMcpTokenRevocationCache revocationCache;
 
   @BeforeEach
   void setUp() {
@@ -57,7 +57,7 @@ class McpTokenControllerTest extends UserHttpTestSupport {
         .rowsUpdated()
         .then(cleanupUserFixtures())
         .block();
-    revocationStore.clear();
+    revocationCache.clear();
   }
 
   @Test
@@ -124,7 +124,7 @@ class McpTokenControllerTest extends UserHttpTestSupport {
             McpTokenApiSnippets.revokeMcpTokenRequest()))
         .isEmpty();
 
-    assertThat(revocationStore.revokedTokens())
+    assertThat(revocationCache.revokedTokens())
         .singleElement()
         .satisfies(revoked -> assertThat(revoked.tokenId()).isEqualTo(issuedTokenRow.id()));
     assertThat(findTokenRow(issuedTokenRow.id()).revokedAt()).isNotNull();
@@ -152,7 +152,7 @@ class McpTokenControllerTest extends UserHttpTestSupport {
         .jsonPath("$.reason")
         .isEqualTo(McpTokenErrorCode.OWNER_MISMATCH.code());
 
-    assertThat(revocationStore.revokedTokens()).isEmpty();
+    assertThat(revocationCache.revokedTokens()).isEmpty();
   }
 
   private EntityExchangeResult<byte[]> issueToken(String accessToken) {
@@ -201,19 +201,19 @@ class McpTokenControllerTest extends UserHttpTestSupport {
   static class McpTokenControllerTestConfig {
 
     @Bean
-    TestMcpTokenRevocationStore testMcpTokenRevocationStore() {
-      return new TestMcpTokenRevocationStore();
+    TestMcpTokenRevocationCache testMcpTokenRevocationCache() {
+      return new TestMcpTokenRevocationCache();
     }
 
   }
 
-  static class TestMcpTokenRevocationStore
-      implements McpTokenRevocationStore {
+  static class TestMcpTokenRevocationCache
+      implements McpTokenRevocationCache {
 
     private final List<RevokedToken> revokedTokens = new ArrayList<>();
 
     @Override
-    public Mono<Void> revoke(String tokenId, Duration ttl) {
+    public Mono<Void> cacheRevocation(String tokenId, Duration ttl) {
       revokedTokens.add(new RevokedToken(tokenId, ttl));
       return Mono.empty();
     }

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/docs/McpTokenApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/docs/McpTokenApiSnippets.java
@@ -1,0 +1,42 @@
+package com.schemafy.api.mcp.docs;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import com.schemafy.api.common.docs.RestDocsSnippets;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+/** MCP Token API 문서화를 위한 스니펫 제공 클래스 */
+public class McpTokenApiSnippets extends RestDocsSnippets {
+
+  public static Snippet issueMcpTokenRequestHeaders() {
+    return createRequestHeadersSnippet(authorizationHeader());
+  }
+
+  public static Snippet issueMcpTokenResponseHeaders() {
+    return createResponseHeadersSnippet(commonResponseHeaders());
+  }
+
+  public static Snippet issueMcpTokenResponse() {
+    return createResponseFieldsSnippet(
+        fieldWithPath("token").type(JsonFieldType.STRING)
+            .description("MCP 서버 요청에 사용할 Bearer 토큰"),
+        fieldWithPath("tokenType").type(JsonFieldType.STRING)
+            .description("토큰 타입 (고정값: Bearer)"),
+        fieldWithPath("expiresInSeconds").type(JsonFieldType.NUMBER)
+            .description("토큰 만료까지 남은 시간(초)"));
+  }
+
+  public static Snippet revokeMcpTokenRequestHeaders() {
+    return createRequestHeadersSnippet(authorizationHeader());
+  }
+
+  public static Snippet revokeMcpTokenRequest() {
+    return requestFields(
+        fieldWithPath("token").type(JsonFieldType.STRING)
+            .description("폐기할 MCP Bearer 토큰"));
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
@@ -46,7 +46,6 @@ class McpTokenServiceTest {
     properties.setIssuer("schemafy-mcp-test");
     properties.setAudience("schemafy-mcp-test");
     properties.setExpiresIn(Duration.ofMinutes(15));
-    properties.setClockSkewSeconds(0);
     revocationStore = new FakeMcpTokenRevocationStore();
     mcpTokenUseCase = new FakeMcpTokenUseCase();
     tokenService = new McpTokenService(

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
@@ -46,7 +46,7 @@ class McpTokenServiceTest {
     properties.setSecret("test-schemafy-mcp-secret-minimum-256-bit-key-value");
     properties.setIssuer("schemafy-mcp-test");
     properties.setAudience("schemafy-mcp-test");
-    properties.setExpiresIn(Duration.ofMinutes(15));
+    properties.setExpiresIn(Duration.ofDays(7));
     revocationCache = new FakeMcpTokenRevocationCache();
     mcpTokenUseCase = new FakeMcpTokenUseCase();
     tokenService = new McpTokenService(
@@ -67,8 +67,8 @@ class McpTokenServiceTest {
     assertThat(result.tokenId()).isEqualTo(claims.getId());
     assertThat(result.scope()).isEqualTo("mcp");
     assertThat(result.issuedAt()).isEqualTo(NOW);
-    assertThat(result.expiresAt()).isEqualTo(NOW.plus(Duration.ofMinutes(15)));
-    assertThat(result.expiresInSeconds()).isEqualTo(900);
+    assertThat(result.expiresAt()).isEqualTo(NOW.plus(Duration.ofDays(7)));
+    assertThat(result.expiresInSeconds()).isEqualTo(604800);
     assertThat(claims.getSubject()).isEqualTo("user-1");
     assertThat(claims.getIssuer()).isEqualTo("schemafy-mcp-test");
     assertThat(claims.getAudience()).contains("schemafy-mcp-test");
@@ -82,7 +82,7 @@ class McpTokenServiceTest {
           assertThat(savedToken.getScope()).isEqualTo("mcp");
           assertThat(savedToken.getIssuedAt()).isEqualTo(NOW);
           assertThat(savedToken.getExpiresAt())
-              .isEqualTo(NOW.plus(Duration.ofMinutes(15)));
+              .isEqualTo(NOW.plus(Duration.ofDays(7)));
         });
   }
 
@@ -105,7 +105,7 @@ class McpTokenServiceTest {
         .singleElement()
         .satisfies(revoked -> {
           assertThat(revoked.tokenId()).isEqualTo(result.tokenId());
-          assertThat(revoked.ttl()).isEqualTo(Duration.ofMinutes(15));
+          assertThat(revoked.ttl()).isEqualTo(Duration.ofDays(7));
         });
   }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
@@ -38,6 +38,7 @@ class McpTokenServiceTest {
   McpTokenProperties properties;
   FakeMcpTokenRevocationCache revocationCache;
   FakeMcpTokenUseCase mcpTokenUseCase;
+  SecretKey secretKey;
   McpTokenService tokenService;
 
   @BeforeEach
@@ -47,6 +48,8 @@ class McpTokenServiceTest {
     properties.setIssuer("schemafy-mcp-test");
     properties.setAudience("schemafy-mcp-test");
     properties.setExpiresIn(Duration.ofDays(7));
+    secretKey = Keys.hmacShaKeyFor(
+        properties.getSecret().getBytes(StandardCharsets.UTF_8));
     revocationCache = new FakeMcpTokenRevocationCache();
     mcpTokenUseCase = new FakeMcpTokenUseCase();
     tokenService = new McpTokenService(
@@ -54,7 +57,8 @@ class McpTokenServiceTest {
         revocationCache,
         mcpTokenUseCase,
         mcpTokenUseCase,
-        Clock.fixed(NOW, ZoneOffset.UTC));
+        Clock.fixed(NOW, ZoneOffset.UTC),
+        secretKey);
   }
 
   @Test
@@ -162,7 +166,8 @@ class McpTokenServiceTest {
         null,
         mcpTokenUseCase,
         mcpTokenUseCase,
-        Clock.fixed(NOW, ZoneOffset.UTC));
+        Clock.fixed(NOW, ZoneOffset.UTC),
+        secretKey);
     McpTokenIssueResult result = serviceWithoutCache.issue("user-1").block();
 
     StepVerifier.create(serviceWithoutCache.revoke("user-1", result.token()))
@@ -174,8 +179,6 @@ class McpTokenServiceTest {
   }
 
   private Claims parseClaims(String token) {
-    SecretKey secretKey = Keys.hmacShaKeyFor(
-        properties.getSecret().getBytes(StandardCharsets.UTF_8));
     return Jwts.parser()
         .verifyWith(secretKey)
         .clock(() -> Date.from(NOW))

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
@@ -21,6 +21,7 @@ import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenUseCase;
 import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
 import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenUseCase;
 import com.schemafy.core.mcp.domain.McpToken;
+import com.schemafy.core.mcp.domain.McpTokenClaimSupport;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -35,7 +36,7 @@ class McpTokenServiceTest {
   private static final Instant NOW = Instant.parse("2026-06-27T00:00:00Z");
 
   McpTokenProperties properties;
-  FakeMcpTokenRevocationStore revocationStore;
+  FakeMcpTokenRevocationCache revocationCache;
   FakeMcpTokenUseCase mcpTokenUseCase;
   McpTokenService tokenService;
 
@@ -46,11 +47,11 @@ class McpTokenServiceTest {
     properties.setIssuer("schemafy-mcp-test");
     properties.setAudience("schemafy-mcp-test");
     properties.setExpiresIn(Duration.ofMinutes(15));
-    revocationStore = new FakeMcpTokenRevocationStore();
+    revocationCache = new FakeMcpTokenRevocationCache();
     mcpTokenUseCase = new FakeMcpTokenUseCase();
     tokenService = new McpTokenService(
         properties,
-        revocationStore,
+        revocationCache,
         mcpTokenUseCase,
         mcpTokenUseCase,
         Clock.fixed(NOW, ZoneOffset.UTC));
@@ -71,8 +72,8 @@ class McpTokenServiceTest {
     assertThat(claims.getSubject()).isEqualTo("user-1");
     assertThat(claims.getIssuer()).isEqualTo("schemafy-mcp-test");
     assertThat(claims.getAudience()).contains("schemafy-mcp-test");
-    assertThat(claims.get("type", String.class)).isEqualTo("MCP");
-    assertThat(claims.get("scope", String.class)).isEqualTo("mcp");
+    assertThat(claims.get(McpTokenClaimSupport.TYPE, String.class)).isEqualTo("MCP");
+    assertThat(claims.get(McpTokenClaimSupport.SCOPE, String.class)).isEqualTo("mcp");
     assertThat(mcpTokenUseCase.savedTokens())
         .singleElement()
         .satisfies(savedToken -> {
@@ -100,7 +101,7 @@ class McpTokenServiceTest {
           assertThat(revoked.userId()).isEqualTo("user-1");
           assertThat(revoked.revokedAt()).isEqualTo(NOW);
         });
-    assertThat(revocationStore.revokedTokens())
+    assertThat(revocationCache.revokedTokens())
         .singleElement()
         .satisfies(revoked -> {
           assertThat(revoked.tokenId()).isEqualTo(result.tokenId());
@@ -121,7 +122,7 @@ class McpTokenServiceTest {
         })
         .verify();
     assertThat(mcpTokenUseCase.revokedTokens()).isEmpty();
-    assertThat(revocationStore.revokedTokens()).isEmpty();
+    assertThat(revocationCache.revokedTokens()).isEmpty();
   }
 
   @Test
@@ -156,15 +157,15 @@ class McpTokenServiceTest {
   @Test
   @DisplayName("Redis revocation cache가 없어도 DB registry에 revoke를 저장한다")
   void revokesWhenRevocationCacheUnavailable() {
-    McpTokenService serviceWithoutStore = new McpTokenService(
+    McpTokenService serviceWithoutCache = new McpTokenService(
         properties,
         null,
         mcpTokenUseCase,
         mcpTokenUseCase,
         Clock.fixed(NOW, ZoneOffset.UTC));
-    McpTokenIssueResult result = serviceWithoutStore.issue("user-1").block();
+    McpTokenIssueResult result = serviceWithoutCache.issue("user-1").block();
 
-    StepVerifier.create(serviceWithoutStore.revoke("user-1", result.token()))
+    StepVerifier.create(serviceWithoutCache.revoke("user-1", result.token()))
         .verifyComplete();
     assertThat(mcpTokenUseCase.revokedTokens())
         .singleElement()
@@ -183,13 +184,13 @@ class McpTokenServiceTest {
         .getPayload();
   }
 
-  private static class FakeMcpTokenRevocationStore
-      implements McpTokenRevocationStore {
+  private static class FakeMcpTokenRevocationCache
+      implements McpTokenRevocationCache {
 
     private final List<RevokedToken> revokedTokens = new ArrayList<>();
 
     @Override
-    public Mono<Void> revoke(String tokenId, Duration ttl) {
+    public Mono<Void> cacheRevocation(String tokenId, Duration ttl) {
       revokedTokens.add(new RevokedToken(tokenId, ttl));
       return Mono.empty();
     }

--- a/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/mcp/service/McpTokenServiceTest.java
@@ -1,0 +1,267 @@
+package com.schemafy.api.mcp.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.api.mcp.exception.McpTokenErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenUseCase;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenUseCase;
+import com.schemafy.core.mcp.domain.McpToken;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpTokenServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-06-27T00:00:00Z");
+
+  McpTokenProperties properties;
+  FakeMcpTokenRevocationStore revocationStore;
+  FakeMcpTokenUseCase mcpTokenUseCase;
+  McpTokenService tokenService;
+
+  @BeforeEach
+  void setUp() {
+    properties = new McpTokenProperties();
+    properties.setSecret("test-schemafy-mcp-secret-minimum-256-bit-key-value");
+    properties.setIssuer("schemafy-mcp-test");
+    properties.setAudience("schemafy-mcp-test");
+    properties.setExpiresIn(Duration.ofMinutes(15));
+    properties.setClockSkewSeconds(0);
+    revocationStore = new FakeMcpTokenRevocationStore();
+    mcpTokenUseCase = new FakeMcpTokenUseCase();
+    tokenService = new McpTokenService(
+        properties,
+        revocationStore,
+        mcpTokenUseCase,
+        mcpTokenUseCase,
+        Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  @Test
+  @DisplayName("MCP 서버가 검증할 수 있는 claim으로 토큰을 발급한다")
+  void issuesMcpTokenClaims() {
+    McpTokenIssueResult result = tokenService.issue("user-1").block();
+
+    Claims claims = parseClaims(result.token());
+    assertThat(result.token()).isNotBlank();
+    assertThat(result.tokenId()).isEqualTo(claims.getId());
+    assertThat(result.scope()).isEqualTo("mcp");
+    assertThat(result.issuedAt()).isEqualTo(NOW);
+    assertThat(result.expiresAt()).isEqualTo(NOW.plus(Duration.ofMinutes(15)));
+    assertThat(result.expiresInSeconds()).isEqualTo(900);
+    assertThat(claims.getSubject()).isEqualTo("user-1");
+    assertThat(claims.getIssuer()).isEqualTo("schemafy-mcp-test");
+    assertThat(claims.getAudience()).contains("schemafy-mcp-test");
+    assertThat(claims.get("type", String.class)).isEqualTo("MCP");
+    assertThat(claims.get("scope", String.class)).isEqualTo("mcp");
+    assertThat(mcpTokenUseCase.savedTokens())
+        .singleElement()
+        .satisfies(savedToken -> {
+          assertThat(savedToken.getId()).isEqualTo(result.tokenId());
+          assertThat(savedToken.getUserId()).isEqualTo("user-1");
+          assertThat(savedToken.getScope()).isEqualTo("mcp");
+          assertThat(savedToken.getIssuedAt()).isEqualTo(NOW);
+          assertThat(savedToken.getExpiresAt())
+              .isEqualTo(NOW.plus(Duration.ofMinutes(15)));
+        });
+  }
+
+  @Test
+  @DisplayName("사용자 자신의 MCP 토큰을 revoke하면 DB와 Redis cache에 폐기 상태를 저장한다")
+  void revokesOwnMcpToken() {
+    McpTokenIssueResult result = tokenService.issue("user-1").block();
+
+    StepVerifier.create(tokenService.revoke("user-1", result.token()))
+        .verifyComplete();
+
+    assertThat(mcpTokenUseCase.revokedTokens())
+        .singleElement()
+        .satisfies(revoked -> {
+          assertThat(revoked.tokenId()).isEqualTo(result.tokenId());
+          assertThat(revoked.userId()).isEqualTo("user-1");
+          assertThat(revoked.revokedAt()).isEqualTo(NOW);
+        });
+    assertThat(revocationStore.revokedTokens())
+        .singleElement()
+        .satisfies(revoked -> {
+          assertThat(revoked.tokenId()).isEqualTo(result.tokenId());
+          assertThat(revoked.ttl()).isEqualTo(Duration.ofMinutes(15));
+        });
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 MCP 토큰은 revoke할 수 없다")
+  void rejectsRevokingAnotherUsersToken() {
+    McpTokenIssueResult result = tokenService.issue("user-1").block();
+
+    StepVerifier.create(tokenService.revoke("user-2", result.token()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(McpTokenErrorCode.OWNER_MISMATCH);
+        })
+        .verify();
+    assertThat(mcpTokenUseCase.revokedTokens()).isEmpty();
+    assertThat(revocationStore.revokedTokens()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("DB token registry에 발급 상태를 저장할 수 없으면 발급을 거부한다")
+  void rejectsIssueWhenTokenRegistryUnavailable() {
+    mcpTokenUseCase.failSave();
+
+    StepVerifier.create(tokenService.issue("user-1"))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(McpTokenErrorCode.REGISTRY_UNAVAILABLE);
+        })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("DB token registry에 폐기 상태를 저장할 수 없으면 revoke를 거부한다")
+  void rejectsRevokeWhenTokenRegistryUnavailable() {
+    McpTokenIssueResult result = tokenService.issue("user-1").block();
+    mcpTokenUseCase.failRevoke();
+
+    StepVerifier.create(tokenService.revoke("user-1", result.token()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(McpTokenErrorCode.REGISTRY_UNAVAILABLE);
+        })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("Redis revocation cache가 없어도 DB registry에 revoke를 저장한다")
+  void revokesWhenRevocationCacheUnavailable() {
+    McpTokenService serviceWithoutStore = new McpTokenService(
+        properties,
+        null,
+        mcpTokenUseCase,
+        mcpTokenUseCase,
+        Clock.fixed(NOW, ZoneOffset.UTC));
+    McpTokenIssueResult result = serviceWithoutStore.issue("user-1").block();
+
+    StepVerifier.create(serviceWithoutStore.revoke("user-1", result.token()))
+        .verifyComplete();
+    assertThat(mcpTokenUseCase.revokedTokens())
+        .singleElement()
+        .satisfies(revoked -> assertThat(revoked.tokenId())
+            .isEqualTo(result.tokenId()));
+  }
+
+  private Claims parseClaims(String token) {
+    SecretKey secretKey = Keys.hmacShaKeyFor(
+        properties.getSecret().getBytes(StandardCharsets.UTF_8));
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .clock(() -> Date.from(NOW))
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  private static class FakeMcpTokenRevocationStore
+      implements McpTokenRevocationStore {
+
+    private final List<RevokedToken> revokedTokens = new ArrayList<>();
+
+    @Override
+    public Mono<Void> revoke(String tokenId, Duration ttl) {
+      revokedTokens.add(new RevokedToken(tokenId, ttl));
+      return Mono.empty();
+    }
+
+    List<RevokedToken> revokedTokens() {
+      return revokedTokens;
+    }
+
+  }
+
+  private static class FakeMcpTokenUseCase implements
+      RegisterMcpTokenUseCase,
+      RevokeMcpTokenUseCase {
+
+    private final List<McpToken> savedTokens = new ArrayList<>();
+    private final List<RevokedTokenRecord> revokedTokens = new ArrayList<>();
+    private boolean failSave;
+    private boolean failRevoke;
+
+    @Override
+    public Mono<McpToken> registerMcpToken(RegisterMcpTokenCommand command) {
+      if (failSave) {
+        return Mono.error(new IllegalStateException("Token registry unavailable"));
+      }
+      McpToken token = McpToken.issue(
+          command.tokenId(),
+          command.userId(),
+          command.scope(),
+          command.issuedAt(),
+          command.expiresAt());
+      savedTokens.add(token);
+      return Mono.just(token);
+    }
+
+    @Override
+    public Mono<Boolean> revokeMcpToken(RevokeMcpTokenCommand command) {
+      if (failRevoke) {
+        return Mono.error(new IllegalStateException("Token registry unavailable"));
+      }
+      revokedTokens.add(new RevokedTokenRecord(
+          command.tokenId(),
+          command.userId(),
+          command.revokedAt()));
+      return Mono.just(true);
+    }
+
+    List<McpToken> savedTokens() {
+      return savedTokens;
+    }
+
+    List<RevokedTokenRecord> revokedTokens() {
+      return revokedTokens;
+    }
+
+    void failSave() {
+      this.failSave = true;
+    }
+
+    void failRevoke() {
+      this.failRevoke = true;
+    }
+
+  }
+
+  private record RevokedToken(String tokenId, Duration ttl) {
+  }
+
+  private record RevokedTokenRecord(
+      String tokenId,
+      String userId,
+      Instant revokedAt) {
+  }
+
+}

--- a/apps/backend/api/src/test/resources/application.yml
+++ b/apps/backend/api/src/test/resources/application.yml
@@ -73,6 +73,18 @@ cache:
 sharelink:
   pepper: test-pepper-value
 
+mcp:
+  security:
+    token:
+      secret: test-schemafy-mcp-secret-minimum-256-bit-key-value
+      issuer: schemafy-mcp-test
+      audience: schemafy-mcp-test
+      token-type: MCP
+      required-scope: mcp
+      revocation-key-prefix: "mcp:token:revoked:"
+      expires-in: 15m
+      clock-skew-seconds: 0
+
 logging:
   level:
     com:

--- a/apps/backend/api/src/test/resources/application.yml
+++ b/apps/backend/api/src/test/resources/application.yml
@@ -83,7 +83,6 @@ mcp:
       required-scope: mcp
       revocation-key-prefix: "mcp:token:revoked:"
       expires-in: 15m
-      clock-skew-seconds: 0
 
 logging:
   level:

--- a/apps/backend/api/src/test/resources/application.yml
+++ b/apps/backend/api/src/test/resources/application.yml
@@ -82,7 +82,7 @@ mcp:
       token-type: MCP
       required-scope: mcp
       revocation-key-prefix: "mcp:token:revoked:"
-      expires-in: 15m
+      expires-in: 7d
 
 logging:
   level:

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/config/ClockConfig.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/config/ClockConfig.java
@@ -1,0 +1,16 @@
+package com.schemafy.core.common.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenPersistenceAdapter.java
@@ -1,0 +1,49 @@
+package com.schemafy.core.mcp.adapter.out.persistence;
+
+import java.time.Instant;
+
+import com.schemafy.core.common.PersistenceAdapter;
+import com.schemafy.core.mcp.application.port.out.FindMcpTokenByIdPort;
+import com.schemafy.core.mcp.application.port.out.RegisterMcpTokenPort;
+import com.schemafy.core.mcp.application.port.out.RevokeMcpTokenPort;
+import com.schemafy.core.mcp.domain.McpToken;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+class McpTokenPersistenceAdapter implements
+    RegisterMcpTokenPort,
+    FindMcpTokenByIdPort,
+    RevokeMcpTokenPort {
+
+  private final McpTokenRepository mcpTokenRepository;
+
+  @Override
+  public Mono<McpToken> registerMcpToken(McpToken token) {
+    return mcpTokenRepository.save(token);
+  }
+
+  @Override
+  public Mono<McpToken> findMcpTokenById(String tokenId) {
+    return mcpTokenRepository.findById(tokenId);
+  }
+
+  @Override
+  public Mono<Boolean> revokeMcpToken(
+      String tokenId,
+      String userId,
+      Instant revokedAt) {
+    return mcpTokenRepository.findByIdAndUserIdAndDeletedAtIsNull(tokenId, userId)
+        .flatMap(token -> {
+          if (token.isRevoked()) {
+            return Mono.just(true);
+          }
+          token.revoke(revokedAt);
+          return mcpTokenRepository.save(token).thenReturn(true);
+        })
+        .defaultIfEmpty(false);
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenRepository.java
@@ -1,0 +1,15 @@
+package com.schemafy.core.mcp.adapter.out.persistence;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+
+interface McpTokenRepository extends ReactiveCrudRepository<McpToken, String> {
+
+  Mono<McpToken> findByIdAndUserIdAndDeletedAtIsNull(
+      String id,
+      String userId);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/GetMcpTokenQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/GetMcpTokenQuery.java
@@ -1,0 +1,4 @@
+package com.schemafy.core.mcp.application.port.in;
+
+public record GetMcpTokenQuery(String tokenId) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/GetMcpTokenUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/GetMcpTokenUseCase.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.in;
+
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+
+public interface GetMcpTokenUseCase {
+
+  Mono<McpToken> getMcpToken(GetMcpTokenQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RegisterMcpTokenCommand.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RegisterMcpTokenCommand.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.in;
+
+import java.time.Instant;
+
+public record RegisterMcpTokenCommand(
+    String tokenId,
+    String userId,
+    String scope,
+    Instant issuedAt,
+    Instant expiresAt) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RegisterMcpTokenUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RegisterMcpTokenUseCase.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.in;
+
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+
+public interface RegisterMcpTokenUseCase {
+
+  Mono<McpToken> registerMcpToken(RegisterMcpTokenCommand command);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RevokeMcpTokenCommand.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RevokeMcpTokenCommand.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.mcp.application.port.in;
+
+import java.time.Instant;
+
+public record RevokeMcpTokenCommand(
+    String tokenId,
+    String userId,
+    Instant revokedAt) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RevokeMcpTokenUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/in/RevokeMcpTokenUseCase.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.mcp.application.port.in;
+
+import reactor.core.publisher.Mono;
+
+public interface RevokeMcpTokenUseCase {
+
+  Mono<Boolean> revokeMcpToken(RevokeMcpTokenCommand command);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/FindMcpTokenByIdPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/FindMcpTokenByIdPort.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.out;
+
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+
+public interface FindMcpTokenByIdPort {
+
+  Mono<McpToken> findMcpTokenById(String tokenId);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/RegisterMcpTokenPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/RegisterMcpTokenPort.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.out;
+
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+
+public interface RegisterMcpTokenPort {
+
+  Mono<McpToken> registerMcpToken(McpToken token);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/RevokeMcpTokenPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/port/out/RevokeMcpTokenPort.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.mcp.application.port.out;
+
+import java.time.Instant;
+
+import reactor.core.publisher.Mono;
+
+public interface RevokeMcpTokenPort {
+
+  Mono<Boolean> revokeMcpToken(String tokenId, String userId, Instant revokedAt);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/service/McpTokenRegistryService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/application/service/McpTokenRegistryService.java
@@ -1,0 +1,53 @@
+package com.schemafy.core.mcp.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenUseCase;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenUseCase;
+import com.schemafy.core.mcp.application.port.out.FindMcpTokenByIdPort;
+import com.schemafy.core.mcp.application.port.out.RegisterMcpTokenPort;
+import com.schemafy.core.mcp.application.port.out.RevokeMcpTokenPort;
+import com.schemafy.core.mcp.domain.McpToken;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class McpTokenRegistryService implements
+    RegisterMcpTokenUseCase,
+    RevokeMcpTokenUseCase,
+    GetMcpTokenUseCase {
+
+  private final RegisterMcpTokenPort registerMcpTokenPort;
+  private final RevokeMcpTokenPort revokeMcpTokenPort;
+  private final FindMcpTokenByIdPort findMcpTokenByIdPort;
+
+  @Override
+  public Mono<McpToken> registerMcpToken(RegisterMcpTokenCommand command) {
+    return registerMcpTokenPort.registerMcpToken(McpToken.issue(
+        command.tokenId(),
+        command.userId(),
+        command.scope(),
+        command.issuedAt(),
+        command.expiresAt()));
+  }
+
+  @Override
+  public Mono<Boolean> revokeMcpToken(RevokeMcpTokenCommand command) {
+    return revokeMcpTokenPort.revokeMcpToken(
+        command.tokenId(),
+        command.userId(),
+        command.revokedAt());
+  }
+
+  @Override
+  public Mono<McpToken> getMcpToken(GetMcpTokenQuery query) {
+    return findMcpTokenByIdPort.findMcpTokenById(query.tokenId());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/domain/McpToken.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/domain/McpToken.java
@@ -1,0 +1,64 @@
+package com.schemafy.core.mcp.domain;
+
+import java.time.Instant;
+
+import org.springframework.data.relational.core.mapping.Table;
+
+import com.schemafy.core.common.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table("mcp_tokens")
+public class McpToken extends BaseEntity {
+
+  private String userId;
+  private String scope;
+  private Instant issuedAt;
+  private Instant expiresAt;
+  private Instant revokedAt;
+  private Instant lastUsedAt;
+
+  public static McpToken issue(
+      String tokenId,
+      String userId,
+      String scope,
+      Instant issuedAt,
+      Instant expiresAt) {
+    McpToken token = new McpToken(
+        userId,
+        scope,
+        issuedAt,
+        expiresAt,
+        null,
+        null);
+    token.setId(tokenId);
+    return token;
+  }
+
+  public boolean belongsTo(String userId) {
+    return this.userId != null && this.userId.equals(userId);
+  }
+
+  public boolean hasScope(String scope) {
+    return this.scope != null && this.scope.equals(scope);
+  }
+
+  public boolean isExpiredAt(Instant now) {
+    return expiresAt == null || !expiresAt.isAfter(now);
+  }
+
+  public boolean isRevoked() { return revokedAt != null; }
+
+  public void revoke(Instant revokedAt) {
+    if (this.revokedAt == null) {
+      this.revokedAt = revokedAt;
+    }
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/mcp/domain/McpTokenClaimSupport.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/mcp/domain/McpTokenClaimSupport.java
@@ -1,0 +1,55 @@
+package com.schemafy.core.mcp.domain;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+public final class McpTokenClaimSupport {
+
+  public static final String TYPE = "type";
+  public static final String SCOPE = "scope";
+  public static final String SCOPES = "scopes";
+  public static final String SCP = "scp";
+
+  private McpTokenClaimSupport() {}
+
+  public static Set<String> extractScopes(
+      Function<String, Object> claimResolver) {
+    Objects.requireNonNull(claimResolver, "claimResolver must not be null");
+    return scopesFrom(
+        claimResolver.apply(SCOPE),
+        claimResolver.apply(SCOPES),
+        claimResolver.apply(SCP));
+  }
+
+  public static Set<String> scopesFrom(Object... values) {
+    Set<String> scopes = new LinkedHashSet<>();
+    if (values == null) {
+      return scopes;
+    }
+    for (Object value : values) {
+      addScopes(scopes, value);
+    }
+    return scopes;
+  }
+
+  private static void addScopes(Set<String> scopes, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection<?> values) {
+      values.forEach(item -> addScopes(scopes, item));
+      return;
+    }
+    String stringValue = value.toString();
+    for (String scope : stringValue.split("[\\s,]+")) {
+      String normalizedScope = scope.trim();
+      if (!normalizedScope.isBlank()) {
+        scopes.add(normalizedScope);
+      }
+    }
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/mcp/adapter/out/persistence/McpTokenPersistenceAdapterTest.java
@@ -1,0 +1,140 @@
+package com.schemafy.core.mcp.adapter.out.persistence;
+
+import java.time.Instant;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.context.annotation.Import;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.config.R2dbcTestConfiguration;
+import com.schemafy.core.mcp.domain.McpToken;
+import com.schemafy.core.ulid.application.service.UlidGenerator;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataR2dbcTest
+@Import({ McpTokenPersistenceAdapter.class, R2dbcTestConfiguration.class })
+@DisplayName("McpTokenPersistenceAdapter")
+class McpTokenPersistenceAdapterTest {
+
+  @Autowired
+  McpTokenPersistenceAdapter sut;
+
+  @Autowired
+  McpTokenRepository mcpTokenRepository;
+
+  @BeforeEach
+  void setUp() {
+    mcpTokenRepository.deleteAll().block();
+  }
+
+  @Test
+  @DisplayName("registerMcpToken/findMcpTokenById: MCP 토큰 발급 상태를 저장하고 조회한다")
+  void registerMcpTokenAndFindMcpTokenById() {
+    Instant issuedAt = Instant.parse("2026-06-27T00:00:00Z");
+    Instant expiresAt = issuedAt.plusSeconds(900);
+    String userId = UlidGenerator.generate();
+    McpToken token = McpToken.issue(
+        UlidGenerator.generate(),
+        userId,
+        "mcp",
+        issuedAt,
+        expiresAt);
+
+    StepVerifier.create(sut.registerMcpToken(token))
+        .assertNext(saved -> {
+          assertThat(saved.getId()).isEqualTo(token.getId());
+          assertThat(saved.getUserId()).isEqualTo(userId);
+          assertThat(saved.getScope()).isEqualTo("mcp");
+          assertThat(saved.getIssuedAt()).isEqualTo(issuedAt);
+          assertThat(saved.getExpiresAt()).isEqualTo(expiresAt);
+          assertThat(saved.getRevokedAt()).isNull();
+          assertThat(saved.getCreatedAt()).isNotNull();
+        })
+        .verifyComplete();
+
+    StepVerifier.create(sut.findMcpTokenById(token.getId()))
+        .assertNext(found -> assertThat(found.getUserId()).isEqualTo(userId))
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("revoke: 사용자 자신의 MCP 토큰에 revoked_at을 기록한다")
+  void revokeOwnToken() {
+    Instant issuedAt = Instant.parse("2026-06-27T00:00:00Z");
+    Instant revokedAt = issuedAt.plusSeconds(60);
+    String userId = UlidGenerator.generate();
+    McpToken token = sut.registerMcpToken(McpToken.issue(
+        UlidGenerator.generate(),
+        userId,
+        "mcp",
+        issuedAt,
+        issuedAt.plusSeconds(900))).block();
+
+    StepVerifier.create(sut.revokeMcpToken(token.getId(), userId, revokedAt))
+        .expectNext(true)
+        .verifyComplete();
+
+    StepVerifier.create(sut.findMcpTokenById(token.getId()))
+        .assertNext(found -> assertThat(found.getRevokedAt()).isEqualTo(revokedAt))
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("revoke: 다른 사용자의 MCP 토큰이면 갱신하지 않는다")
+  void revokeAnotherUsersTokenReturnsFalse() {
+    Instant issuedAt = Instant.parse("2026-06-27T00:00:00Z");
+    String userId = UlidGenerator.generate();
+    McpToken token = sut.registerMcpToken(McpToken.issue(
+        UlidGenerator.generate(),
+        userId,
+        "mcp",
+        issuedAt,
+        issuedAt.plusSeconds(900))).block();
+
+    StepVerifier.create(sut.revokeMcpToken(
+        token.getId(),
+        "user-2",
+        issuedAt.plusSeconds(60)))
+        .expectNext(false)
+        .verifyComplete();
+
+    StepVerifier.create(sut.findMcpTokenById(token.getId()))
+        .assertNext(found -> assertThat(found.getRevokedAt()).isNull())
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("revoke: 이미 폐기된 MCP 토큰이면 revoked_at을 덮어쓰지 않고 성공 처리한다")
+  void revokeAlreadyRevokedTokenReturnsTrueWithoutOverwritingRevokedAt() {
+    Instant issuedAt = Instant.parse("2026-06-27T00:00:00Z");
+    Instant firstRevokedAt = issuedAt.plusSeconds(60);
+    Instant secondRevokedAt = issuedAt.plusSeconds(120);
+    String userId = UlidGenerator.generate();
+    McpToken token = sut.registerMcpToken(McpToken.issue(
+        UlidGenerator.generate(),
+        userId,
+        "mcp",
+        issuedAt,
+        issuedAt.plusSeconds(900))).block();
+
+    StepVerifier.create(sut.revokeMcpToken(token.getId(), userId, firstRevokedAt))
+        .expectNext(true)
+        .verifyComplete();
+
+    StepVerifier.create(sut.revokeMcpToken(token.getId(), userId, secondRevokedAt))
+        .expectNext(true)
+        .verifyComplete();
+
+    StepVerifier.create(sut.findMcpTokenById(token.getId()))
+        .assertNext(found -> assertThat(found.getRevokedAt()).isEqualTo(firstRevokedAt))
+        .verifyComplete();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/mcp/application/service/McpTokenRegistryServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/mcp/application/service/McpTokenRegistryServiceTest.java
@@ -1,0 +1,99 @@
+package com.schemafy.core.mcp.application.service;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
+import com.schemafy.core.mcp.application.port.in.RegisterMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.in.RevokeMcpTokenCommand;
+import com.schemafy.core.mcp.application.port.out.FindMcpTokenByIdPort;
+import com.schemafy.core.mcp.application.port.out.RegisterMcpTokenPort;
+import com.schemafy.core.mcp.application.port.out.RevokeMcpTokenPort;
+import com.schemafy.core.mcp.domain.McpToken;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("McpTokenRegistryService")
+class McpTokenRegistryServiceTest {
+
+  @Mock
+  RegisterMcpTokenPort registerMcpTokenPort;
+
+  @Mock
+  RevokeMcpTokenPort revokeMcpTokenPort;
+
+  @Mock
+  FindMcpTokenByIdPort findMcpTokenByIdPort;
+
+  @InjectMocks
+  McpTokenRegistryService sut;
+
+  @Test
+  @DisplayName("registerMcpToken: MCP 토큰 도메인을 생성해 저장한다")
+  void registerMcpToken() {
+    Instant issuedAt = Instant.parse("2026-06-27T00:00:00Z");
+    Instant expiresAt = issuedAt.plusSeconds(900);
+    given(registerMcpTokenPort.registerMcpToken(any(McpToken.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+    StepVerifier.create(sut.registerMcpToken(new RegisterMcpTokenCommand(
+        "token-1",
+        "user-1",
+        "mcp",
+        issuedAt,
+        expiresAt)))
+        .assertNext(token -> {
+          assertThat(token.getId()).isEqualTo("token-1");
+          assertThat(token.getUserId()).isEqualTo("user-1");
+          assertThat(token.getScope()).isEqualTo("mcp");
+          assertThat(token.getIssuedAt()).isEqualTo(issuedAt);
+          assertThat(token.getExpiresAt()).isEqualTo(expiresAt);
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("revokeMcpToken: revoke 결과를 반환한다")
+  void revokeMcpToken() {
+    Instant revokedAt = Instant.parse("2026-06-27T00:01:00Z");
+    given(revokeMcpTokenPort.revokeMcpToken("token-1", "user-1", revokedAt))
+        .willReturn(Mono.just(true));
+
+    StepVerifier.create(sut.revokeMcpToken(new RevokeMcpTokenCommand(
+        "token-1",
+        "user-1",
+        revokedAt)))
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getMcpToken: tokenId로 MCP 토큰을 조회한다")
+  void getMcpToken() {
+    McpToken token = McpToken.issue(
+        "token-1",
+        "user-1",
+        "mcp",
+        Instant.parse("2026-06-27T00:00:00Z"),
+        Instant.parse("2026-06-27T00:15:00Z"));
+    given(findMcpTokenByIdPort.findMcpTokenById("token-1"))
+        .willReturn(Mono.just(token));
+
+    StepVerifier.create(sut.getMcpToken(new GetMcpTokenQuery("token-1")))
+        .expectNext(token)
+        .verifyComplete();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/mcp/domain/McpTokenClaimSupportTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/mcp/domain/McpTokenClaimSupportTest.java
@@ -1,0 +1,34 @@
+package com.schemafy.core.mcp.domain;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("McpTokenClaimSupport")
+class McpTokenClaimSupportTest {
+
+  @Test
+  @DisplayName("scope/scopes/scp 값을 공백, 콤마, 컬렉션 형식에서 추출한다")
+  void extractsScopesFromSupportedClaims() {
+    Map<String, Object> claims = Map.of(
+        McpTokenClaimSupport.SCOPE, "mcp schema:read",
+        McpTokenClaimSupport.SCOPES, "schema:write,mcp",
+        McpTokenClaimSupport.SCP, List.of("project:read", " project:write "));
+
+    assertThat(McpTokenClaimSupport.extractScopes(claims::get))
+        .containsExactly("mcp", "schema:read", "schema:write",
+            "project:read", "project:write");
+  }
+
+  @Test
+  @DisplayName("blank scope 값은 무시한다")
+  void ignoresBlankScopes() {
+    assertThat(McpTokenClaimSupport.scopesFrom("  ", List.of("", "mcp")))
+        .containsExactly("mcp");
+  }
+
+}

--- a/apps/backend/mcp/build.gradle
+++ b/apps/backend/mcp/build.gradle
@@ -42,13 +42,18 @@ dependencies {
     implementation project(':core')
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webflux'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 
     runtimeOnly 'io.r2dbc:r2dbc-h2'
     runtimeOnly 'org.mariadb:r2dbc-mariadb:1.4.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -56,6 +61,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     spotbugs 'com.github.spotbugs:spotbugs:4.8.6'

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAccessDeniedHandler.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.server.authorization.ServerAccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class McpAccessDeniedHandler implements ServerAccessDeniedHandler {
+
+  private final McpSecurityErrorWriter errorWriter;
+
+  public McpAccessDeniedHandler(McpSecurityErrorWriter errorWriter) {
+    this.errorWriter = errorWriter;
+  }
+
+  @Override
+  public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
+    return errorWriter.write(exchange, McpSecurityError.INSUFFICIENT_SCOPE);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticatedPrincipal.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticatedPrincipal.java
@@ -1,0 +1,14 @@
+package com.schemafy.mcp.common.security;
+
+import java.security.Principal;
+import java.util.Set;
+
+public record McpAuthenticatedPrincipal(
+    String userId,
+    Set<String> scopes,
+    String tokenId) implements Principal {
+
+  @Override
+  public String getName() { return userId; }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticationEntryPoint.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.server.ServerAuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class McpAuthenticationEntryPoint implements ServerAuthenticationEntryPoint {
+
+  private final McpSecurityErrorWriter errorWriter;
+
+  public McpAuthenticationEntryPoint(McpSecurityErrorWriter errorWriter) {
+    this.errorWriter = errorWriter;
+  }
+
+  @Override
+  public Mono<Void> commence(ServerWebExchange exchange, AuthenticationException ex) {
+    return errorWriter.write(exchange, McpSecurityError.TOKEN_MISSING);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticationWebFilter.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpAuthenticationWebFilter.java
@@ -1,0 +1,102 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.project.application.access.ProjectAccessRequesterContext;
+
+import reactor.core.publisher.Mono;
+
+public class McpAuthenticationWebFilter implements WebFilter {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final McpTokenValidator tokenValidator;
+  private final McpRateLimiter rateLimiter;
+  private final McpSecurityErrorWriter errorWriter;
+  private final McpSecurityAuditLogger auditLogger;
+
+  public McpAuthenticationWebFilter(
+      McpTokenValidator tokenValidator,
+      McpRateLimiter rateLimiter,
+      McpSecurityErrorWriter errorWriter,
+      McpSecurityAuditLogger auditLogger) {
+    this.tokenValidator = tokenValidator;
+    this.rateLimiter = rateLimiter;
+    this.errorWriter = errorWriter;
+    this.auditLogger = auditLogger;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    if (!requiresMcpSecurity(exchange.getRequest())) {
+      return chain.filter(exchange);
+    }
+
+    String token = extractBearerToken(exchange.getRequest());
+    return tokenValidator.validate(token)
+        .flatMap(result -> {
+          if (!result.valid()) {
+            auditLogger.authenticationFailed(exchange, result.error());
+            return errorWriter.write(exchange, result.error());
+          }
+          McpTokenClaims claims = result.claims();
+          return rateLimiter.tryAcquire(claims)
+              .flatMap(allowed -> {
+                if (!allowed) {
+                  auditLogger.rateLimited(exchange, claims);
+                  return errorWriter.write(exchange,
+                      McpSecurityError.RATE_LIMIT_EXCEEDED);
+                }
+                UsernamePasswordAuthenticationToken authentication = createAuthentication(claims);
+                auditLogger.authenticationSucceeded(exchange, claims);
+                return chain.filter(exchange)
+                    .contextWrite(context -> ErdOperationContexts.withActorUserId(claims.userId())
+                        .apply(context
+                            .putAll(ReactiveSecurityContextHolder
+                                .withAuthentication(authentication)
+                                .readOnly())
+                            .putAll(ProjectAccessRequesterContext
+                                .withRequesterId(claims.userId())
+                                .readOnly())));
+              });
+        });
+  }
+
+  private boolean requiresMcpSecurity(ServerHttpRequest request) {
+    String path = request.getPath().pathWithinApplication().value();
+    return "/mcp".equals(path) || path.startsWith("/mcp/");
+  }
+
+  private String extractBearerToken(ServerHttpRequest request) {
+    String authorization = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+    if (StringUtils.hasText(authorization)
+        && authorization.regionMatches(true, 0, BEARER_PREFIX, 0,
+            BEARER_PREFIX.length())) {
+      return authorization.substring(BEARER_PREFIX.length());
+    }
+    return null;
+  }
+
+  private UsernamePasswordAuthenticationToken createAuthentication(McpTokenClaims claims) {
+    McpAuthenticatedPrincipal principal = new McpAuthenticatedPrincipal(
+        claims.userId(),
+        claims.scopes(),
+        claims.tokenId());
+    List<SimpleGrantedAuthority> authorities = claims.scopes().stream()
+        .map(scope -> new SimpleGrantedAuthority("SCOPE_" + scope))
+        .toList();
+    return new UsernamePasswordAuthenticationToken(principal, null, authorities);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpProblemProperties.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpProblemProperties.java
@@ -1,0 +1,14 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "problem")
+public class McpProblemProperties {
+
+  private String typeBaseUri = "about:blank";
+
+  public String getTypeBaseUri() { return typeBaseUri; }
+
+  public void setTypeBaseUri(String typeBaseUri) { this.typeBaseUri = typeBaseUri; }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpRateLimiter.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpRateLimiter.java
@@ -1,0 +1,9 @@
+package com.schemafy.mcp.common.security;
+
+import reactor.core.publisher.Mono;
+
+public interface McpRateLimiter {
+
+  Mono<Boolean> tryAcquire(McpTokenClaims claims);
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityAuditLogger.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityAuditLogger.java
@@ -1,0 +1,38 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component
+public class McpSecurityAuditLogger {
+
+  private static final Logger log = LoggerFactory.getLogger(McpSecurityAuditLogger.class);
+
+  public void authenticationSucceeded(ServerWebExchange exchange, McpTokenClaims claims) {
+    log.info("mcp_auth_success path={} userId={} tokenId={} scopes={}",
+        path(exchange), claims.userId(), claims.tokenId(), claims.scopes());
+  }
+
+  public void authenticationFailed(ServerWebExchange exchange, McpSecurityError error) {
+    log.warn("mcp_auth_failed path={} remoteAddress={} error={}",
+        path(exchange), remoteAddress(exchange), error.code());
+  }
+
+  public void rateLimited(ServerWebExchange exchange, McpTokenClaims claims) {
+    log.warn("mcp_rate_limited path={} userId={} tokenId={}",
+        path(exchange), claims.userId(), claims.tokenId());
+  }
+
+  private String path(ServerWebExchange exchange) {
+    return exchange.getRequest().getPath().pathWithinApplication().value();
+  }
+
+  private String remoteAddress(ServerWebExchange exchange) {
+    var remoteAddress = exchange.getRequest().getRemoteAddress();
+    return remoteAddress != null ? remoteAddress.toString() : "unknown";
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityAuditLogger.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityAuditLogger.java
@@ -12,8 +12,8 @@ public class McpSecurityAuditLogger {
   private static final Logger log = LoggerFactory.getLogger(McpSecurityAuditLogger.class);
 
   public void authenticationSucceeded(ServerWebExchange exchange, McpTokenClaims claims) {
-    log.info("mcp_auth_success path={} userId={} tokenId={} scopes={}",
-        path(exchange), claims.userId(), claims.tokenId(), claims.scopes());
+    log.debug("mcp_auth_success path={} userId={} scopes={}",
+        path(exchange), claims.userId(), claims.scopes());
   }
 
   public void authenticationFailed(ServerWebExchange exchange, McpSecurityError error) {
@@ -22,8 +22,8 @@ public class McpSecurityAuditLogger {
   }
 
   public void rateLimited(ServerWebExchange exchange, McpTokenClaims claims) {
-    log.warn("mcp_rate_limited path={} userId={} tokenId={}",
-        path(exchange), claims.userId(), claims.tokenId());
+    log.warn("mcp_rate_limited path={} userId={}",
+        path(exchange), claims.userId());
   }
 
   private String path(ServerWebExchange exchange) {

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityConfig.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityConfig.java
@@ -1,0 +1,57 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.security.web.server.savedrequest.NoOpServerRequestCache;
+
+@Configuration
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+public class McpSecurityConfig {
+
+  @Bean
+  public SecurityWebFilterChain mcpSecurityWebFilterChain(
+      ServerHttpSecurity http,
+      McpTokenValidator tokenValidator,
+      McpRateLimiter rateLimiter,
+      McpSecurityErrorWriter errorWriter,
+      McpSecurityAuditLogger auditLogger,
+      McpAuthenticationEntryPoint authenticationEntryPoint,
+      McpAccessDeniedHandler accessDeniedHandler,
+      McpSecurityProperties properties) {
+    String requiredAuthority = "SCOPE_" + properties.getToken().getRequiredScope();
+    McpAuthenticationWebFilter authenticationWebFilter = new McpAuthenticationWebFilter(
+        tokenValidator,
+        rateLimiter,
+        errorWriter,
+        auditLogger);
+    return http
+        .csrf(ServerHttpSecurity.CsrfSpec::disable)
+        .securityContextRepository(
+            NoOpServerSecurityContextRepository.getInstance())
+        .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+        .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+        .logout(ServerHttpSecurity.LogoutSpec::disable)
+        .requestCache(requestCache -> requestCache
+            .requestCache(NoOpServerRequestCache.getInstance()))
+        .exceptionHandling(exceptionHandling -> exceptionHandling
+            .authenticationEntryPoint(authenticationEntryPoint)
+            .accessDeniedHandler(accessDeniedHandler))
+        .addFilterAt(authenticationWebFilter,
+            SecurityWebFiltersOrder.AUTHENTICATION)
+        .authorizeExchange(exchanges -> exchanges
+            .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+            .pathMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+            .pathMatchers("/mcp", "/mcp/**").hasAuthority(requiredAuthority)
+            .anyExchange().denyAll())
+        .build();
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityError.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityError.java
@@ -10,7 +10,13 @@ public enum McpSecurityError {
   TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_INVALID", "MCP token is invalid"),
   TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_REVOKED", "MCP token is revoked"),
   INSUFFICIENT_SCOPE(HttpStatus.FORBIDDEN, "MCP_INSUFFICIENT_SCOPE", "MCP token scope is insufficient"),
-  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MCP_RATE_LIMIT_EXCEEDED", "MCP rate limit exceeded");
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MCP_RATE_LIMIT_EXCEEDED", "MCP rate limit exceeded"),
+  REVOCATION_CHECK_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,
+      "MCP_REVOCATION_CHECK_UNAVAILABLE",
+      "MCP token revocation status is temporarily unavailable"),
+  TOKEN_REGISTRY_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,
+      "MCP_TOKEN_REGISTRY_UNAVAILABLE",
+      "MCP token registry is temporarily unavailable");
 
   private final HttpStatus status;
   private final String code;

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityError.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityError.java
@@ -1,0 +1,37 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.http.HttpStatus;
+
+public enum McpSecurityError {
+
+  TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_MISSING", "MCP Bearer token is required"),
+  TOKEN_MALFORMED(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_MALFORMED", "MCP token is malformed"),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_EXPIRED", "MCP token is expired"),
+  TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_INVALID", "MCP token is invalid"),
+  TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "MCP_TOKEN_REVOKED", "MCP token is revoked"),
+  INSUFFICIENT_SCOPE(HttpStatus.FORBIDDEN, "MCP_INSUFFICIENT_SCOPE", "MCP token scope is insufficient"),
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MCP_RATE_LIMIT_EXCEEDED", "MCP rate limit exceeded");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  McpSecurityError(HttpStatus status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  public HttpStatus status() {
+    return status;
+  }
+
+  public String code() {
+    return code;
+  }
+
+  public String message() {
+    return message;
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityErrorWriter.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityErrorWriter.java
@@ -1,0 +1,78 @@
+package com.schemafy.mcp.common.security;
+
+import java.net.URI;
+import java.util.Locale;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.schemafy.core.common.json.JsonCodec;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class McpSecurityErrorWriter {
+
+  private final JsonCodec jsonCodec;
+  private final McpProblemProperties problemProperties;
+
+  public McpSecurityErrorWriter(
+      JsonCodec jsonCodec,
+      McpProblemProperties problemProperties) {
+    this.jsonCodec = jsonCodec;
+    this.problemProperties = problemProperties;
+  }
+
+  public Mono<Void> write(ServerWebExchange exchange, McpSecurityError error) {
+    var response = exchange.getResponse();
+    if (response.isCommitted()) {
+      return Mono.empty();
+    }
+    response.setStatusCode(error.status());
+    response.getHeaders().setContentType(MediaType.APPLICATION_PROBLEM_JSON);
+    try {
+      byte[] body = jsonCodec.toJsonBytes(createProblemDetail(exchange, error));
+      return response.writeWith(Mono.just(response.bufferFactory().wrap(body)));
+    } catch (IllegalArgumentException e) {
+      return response.setComplete();
+    }
+  }
+
+  private ProblemDetail createProblemDetail(ServerWebExchange exchange,
+      McpSecurityError error) {
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+        error.status(), error.message());
+    problemDetail.setTitle(error.status().getReasonPhrase());
+    problemDetail.setType(resolveType(error.code()));
+    problemDetail.setInstance(resolveInstance(exchange));
+    problemDetail.setProperty("reason", error.code());
+    return problemDetail;
+  }
+
+  private URI resolveType(String reason) {
+    String baseUri = problemProperties.getTypeBaseUri();
+    if (baseUri == null || baseUri.isBlank()
+        || "about:blank".equals(baseUri)) {
+      return URI.create("about:blank");
+    }
+
+    String normalizedBase = baseUri.endsWith("/")
+        ? baseUri.substring(0, baseUri.length() - 1)
+        : baseUri;
+    String reasonPath = reason.toLowerCase(Locale.ROOT)
+        .replace('_', '-');
+    return URI.create(normalizedBase + "/" + reasonPath);
+  }
+
+  private URI resolveInstance(ServerWebExchange exchange) {
+    String path = exchange.getRequest().getPath()
+        .pathWithinApplication().value();
+    if (path == null || path.isBlank()) {
+      return URI.create("/");
+    }
+    return URI.create(path);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityProperties.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityProperties.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -50,9 +49,6 @@ public class McpSecurityProperties {
     @NotBlank
     private String revocationKeyPrefix = "mcp:token:revoked:";
 
-    @PositiveOrZero
-    private long clockSkewSeconds = 30;
-
     public String getSecret() { return secret; }
 
     public void setSecret(String secret) { this.secret = secret; }
@@ -76,10 +72,6 @@ public class McpSecurityProperties {
     public String getRevocationKeyPrefix() { return revocationKeyPrefix; }
 
     public void setRevocationKeyPrefix(String revocationKeyPrefix) { this.revocationKeyPrefix = revocationKeyPrefix; }
-
-    public long getClockSkewSeconds() { return clockSkewSeconds; }
-
-    public void setClockSkewSeconds(long clockSkewSeconds) { this.clockSkewSeconds = clockSkewSeconds; }
 
   }
 

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityProperties.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityProperties.java
@@ -1,0 +1,116 @@
+package com.schemafy.mcp.common.security;
+
+import java.time.Duration;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "mcp.security")
+public class McpSecurityProperties {
+
+  @Valid
+  private Token token = new Token();
+
+  @Valid
+  private RateLimit rateLimit = new RateLimit();
+
+  public Token getToken() { return token; }
+
+  public void setToken(Token token) { this.token = token; }
+
+  public RateLimit getRateLimit() { return rateLimit; }
+
+  public void setRateLimit(RateLimit rateLimit) { this.rateLimit = rateLimit; }
+
+  public static class Token {
+
+    @NotBlank
+    @Size(min = 32)
+    private String secret = "schemafy-mcp-local-secret-minimum-256-bit-key-value";
+
+    @NotBlank
+    private String issuer = "schemafy-mcp";
+
+    @NotBlank
+    private String audience = "schemafy-mcp";
+
+    @NotBlank
+    private String tokenType = "MCP";
+
+    @NotBlank
+    private String requiredScope = "mcp";
+
+    @NotBlank
+    private String revocationKeyPrefix = "mcp:token:revoked:";
+
+    @PositiveOrZero
+    private long clockSkewSeconds = 30;
+
+    public String getSecret() { return secret; }
+
+    public void setSecret(String secret) { this.secret = secret; }
+
+    public String getIssuer() { return issuer; }
+
+    public void setIssuer(String issuer) { this.issuer = issuer; }
+
+    public String getAudience() { return audience; }
+
+    public void setAudience(String audience) { this.audience = audience; }
+
+    public String getTokenType() { return tokenType; }
+
+    public void setTokenType(String tokenType) { this.tokenType = tokenType; }
+
+    public String getRequiredScope() { return requiredScope; }
+
+    public void setRequiredScope(String requiredScope) { this.requiredScope = requiredScope; }
+
+    public String getRevocationKeyPrefix() { return revocationKeyPrefix; }
+
+    public void setRevocationKeyPrefix(String revocationKeyPrefix) { this.revocationKeyPrefix = revocationKeyPrefix; }
+
+    public long getClockSkewSeconds() { return clockSkewSeconds; }
+
+    public void setClockSkewSeconds(long clockSkewSeconds) { this.clockSkewSeconds = clockSkewSeconds; }
+
+  }
+
+  public static class RateLimit {
+
+    private boolean enabled = true;
+
+    @Positive
+    private int requests = 120;
+
+    @NotBlank
+    private String keyPrefix = "mcp:rate-limit:user:";
+
+    private Duration window = Duration.ofMinutes(1);
+
+    public boolean isEnabled() { return enabled; }
+
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public int getRequests() { return requests; }
+
+    public void setRequests(int requests) { this.requests = requests; }
+
+    public String getKeyPrefix() { return keyPrefix; }
+
+    public void setKeyPrefix(String keyPrefix) { this.keyPrefix = keyPrefix; }
+
+    public Duration getWindow() { return window; }
+
+    public void setWindow(Duration window) { this.window = window; }
+
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityRedisScripts.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpSecurityRedisScripts.java
@@ -1,0 +1,17 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.data.redis.core.script.RedisScript;
+
+final class McpSecurityRedisScripts {
+
+  static final RedisScript<Long> RATE_LIMIT_INCREMENT = RedisScript.of("""
+      local current = redis.call('INCR', KEYS[1])
+      if current == 1 then
+        redis.call('PEXPIRE', KEYS[1], ARGV[1])
+      end
+      return current
+      """, Long.class);
+
+  private McpSecurityRedisScripts() {}
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenClaims.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenClaims.java
@@ -1,0 +1,14 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.Set;
+
+public record McpTokenClaims(
+    String tokenId,
+    String userId,
+    Set<String> scopes) {
+
+  public boolean hasScope(String scope) {
+    return scopes.contains(scope);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenConfig.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenConfig.java
@@ -1,0 +1,20 @@
+package com.schemafy.mcp.common.security;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.jsonwebtoken.security.Keys;
+
+@Configuration(proxyBeanMethods = false)
+public class McpTokenConfig {
+
+  @Bean
+  SecretKey mcpTokenSecretKey(McpSecurityProperties properties) {
+    return Keys.hmacShaKeyFor(
+        properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenRevocationCache.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenRevocationCache.java
@@ -2,7 +2,7 @@ package com.schemafy.mcp.common.security;
 
 import reactor.core.publisher.Mono;
 
-public interface McpTokenRevocationStore {
+public interface McpTokenRevocationCache {
 
   Mono<Boolean> isRevoked(String tokenId);
 

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenRevocationStore.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenRevocationStore.java
@@ -1,0 +1,9 @@
+package com.schemafy.mcp.common.security;
+
+import reactor.core.publisher.Mono;
+
+public interface McpTokenRevocationStore {
+
+  Mono<Boolean> isRevoked(String tokenId);
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidationResult.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidationResult.java
@@ -1,0 +1,16 @@
+package com.schemafy.mcp.common.security;
+
+public record McpTokenValidationResult(
+    boolean valid,
+    McpTokenClaims claims,
+    McpSecurityError error) {
+
+  public static McpTokenValidationResult success(McpTokenClaims claims) {
+    return new McpTokenValidationResult(true, claims, null);
+  }
+
+  public static McpTokenValidationResult failure(McpSecurityError error) {
+    return new McpTokenValidationResult(false, null, error);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
@@ -2,10 +2,7 @@ package com.schemafy.mcp.common.security;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import javax.crypto.SecretKey;
@@ -16,6 +13,7 @@ import org.springframework.util.StringUtils;
 import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
 import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
 import com.schemafy.core.mcp.domain.McpToken;
+import com.schemafy.core.mcp.domain.McpTokenClaimSupport;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -27,24 +25,19 @@ import reactor.core.publisher.Mono;
 @Component
 public class McpTokenValidator {
 
-  private static final String CLAIM_TYPE = "type";
-  private static final String CLAIM_SCOPE = "scope";
-  private static final String CLAIM_SCOPES = "scopes";
-  private static final String CLAIM_SCP = "scp";
-
   private final McpSecurityProperties properties;
-  private final McpTokenRevocationStore revocationStore;
+  private final McpTokenRevocationCache revocationCache;
   private final GetMcpTokenUseCase getMcpTokenUseCase;
   private final Clock clock;
   private final SecretKey secretKey;
 
   public McpTokenValidator(
       McpSecurityProperties properties,
-      McpTokenRevocationStore revocationStore,
+      McpTokenRevocationCache revocationCache,
       GetMcpTokenUseCase getMcpTokenUseCase,
       Clock clock) {
     this.properties = properties;
-    this.revocationStore = revocationStore;
+    this.revocationCache = revocationCache;
     this.getMcpTokenUseCase = getMcpTokenUseCase;
     this.clock = clock;
     this.secretKey = Keys.hmacShaKeyFor(
@@ -86,21 +79,21 @@ public class McpTokenValidator {
       return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
     }
     if (!Objects.equals(properties.getToken().getTokenType(),
-        claims.get(CLAIM_TYPE, String.class))) {
+        claims.get(McpTokenClaimSupport.TYPE, String.class))) {
       return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
     }
     if (!StringUtils.hasText(claims.getId())) {
       return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
     }
 
-    Set<String> scopes = extractScopes(claims);
+    Set<String> scopes = McpTokenClaimSupport.extractScopes(claims::get);
     if (!scopes.contains(properties.getToken().getRequiredScope())) {
       return Mono.just(McpTokenValidationResult.failure(McpSecurityError.INSUFFICIENT_SCOPE));
     }
 
     McpTokenClaims tokenClaims = new McpTokenClaims(claims.getId(), claims.getSubject(),
         Set.copyOf(scopes));
-    return revocationStore.isRevoked(claims.getId())
+    return revocationCache.isRevoked(claims.getId())
         .flatMap(revoked -> revoked
             ? Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED))
             : validateRegisteredToken(tokenClaims))
@@ -130,30 +123,6 @@ public class McpTokenValidator {
       return McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED);
     }
     return McpTokenValidationResult.success(claims);
-  }
-
-  private Set<String> extractScopes(Claims claims) {
-    Set<String> scopes = new LinkedHashSet<>();
-    addScopes(scopes, claims.get(CLAIM_SCOPE));
-    addScopes(scopes, claims.get(CLAIM_SCOPES));
-    addScopes(scopes, claims.get(CLAIM_SCP));
-    return scopes;
-  }
-
-  private void addScopes(Set<String> scopes, Object value) {
-    if (value instanceof String stringValue) {
-      Arrays.stream(stringValue.split("[\\s,]+"))
-          .filter(StringUtils::hasText)
-          .forEach(scopes::add);
-      return;
-    }
-    if (value instanceof Collection<?> values) {
-      values.stream()
-          .filter(Objects::nonNull)
-          .map(Object::toString)
-          .filter(StringUtils::hasText)
-          .forEach(scopes::add);
-    }
   }
 
 }

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
@@ -1,12 +1,12 @@
 package com.schemafy.mcp.common.security;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -19,7 +19,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -35,13 +34,13 @@ public class McpTokenValidator {
       McpSecurityProperties properties,
       McpTokenRevocationCache revocationCache,
       GetMcpTokenUseCase getMcpTokenUseCase,
-      Clock clock) {
+      Clock clock,
+      @Qualifier("mcpTokenSecretKey") SecretKey secretKey) {
     this.properties = properties;
     this.revocationCache = revocationCache;
     this.getMcpTokenUseCase = getMcpTokenUseCase;
     this.clock = clock;
-    this.secretKey = Keys.hmacShaKeyFor(
-        properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
+    this.secretKey = secretKey;
   }
 
   public Mono<McpTokenValidationResult> validate(String token) {

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
@@ -1,0 +1,122 @@
+package com.schemafy.mcp.common.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import reactor.core.publisher.Mono;
+
+@Component
+public class McpTokenValidator {
+
+  private static final String CLAIM_TYPE = "type";
+  private static final String CLAIM_SCOPE = "scope";
+  private static final String CLAIM_SCOPES = "scopes";
+  private static final String CLAIM_SCP = "scp";
+
+  private final McpSecurityProperties properties;
+  private final McpTokenRevocationStore revocationStore;
+  private final SecretKey secretKey;
+
+  public McpTokenValidator(
+      McpSecurityProperties properties,
+      McpTokenRevocationStore revocationStore) {
+    this.properties = properties;
+    this.revocationStore = revocationStore;
+    this.secretKey = Keys.hmacShaKeyFor(
+        properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+  public Mono<McpTokenValidationResult> validate(String token) {
+    if (!StringUtils.hasText(token)) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_MISSING));
+    }
+    return Mono.fromCallable(() -> parseClaims(token))
+        .flatMap(this::validateClaims)
+        .onErrorResume(ExpiredJwtException.class,
+            e -> Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_EXPIRED)))
+        .onErrorResume(JwtException.class,
+            e -> Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_MALFORMED)))
+        .onErrorResume(IllegalArgumentException.class,
+            e -> Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_MALFORMED)));
+  }
+
+  private Claims parseClaims(String token) {
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .clockSkewSeconds(properties.getToken().getClockSkewSeconds())
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  private Mono<McpTokenValidationResult> validateClaims(Claims claims) {
+    if (!Objects.equals(properties.getToken().getIssuer(), claims.getIssuer())
+        || claims.getAudience() == null
+        || !claims.getAudience().contains(properties.getToken().getAudience())
+        || claims.getExpiration() == null
+        || claims.getExpiration().before(new Date())) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
+    }
+    if (!StringUtils.hasText(claims.getSubject())) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
+    }
+    if (!Objects.equals(properties.getToken().getTokenType(),
+        claims.get(CLAIM_TYPE, String.class))) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
+    }
+    if (!StringUtils.hasText(claims.getId())) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
+    }
+
+    Set<String> scopes = extractScopes(claims);
+    if (!scopes.contains(properties.getToken().getRequiredScope())) {
+      return Mono.just(McpTokenValidationResult.failure(McpSecurityError.INSUFFICIENT_SCOPE));
+    }
+
+    McpTokenClaims tokenClaims = new McpTokenClaims(claims.getId(), claims.getSubject(),
+        Set.copyOf(scopes));
+    return revocationStore.isRevoked(claims.getId())
+        .map(revoked -> revoked
+            ? McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED)
+            : McpTokenValidationResult.success(tokenClaims));
+  }
+
+  private Set<String> extractScopes(Claims claims) {
+    Set<String> scopes = new LinkedHashSet<>();
+    addScopes(scopes, claims.get(CLAIM_SCOPE));
+    addScopes(scopes, claims.get(CLAIM_SCOPES));
+    addScopes(scopes, claims.get(CLAIM_SCP));
+    return scopes;
+  }
+
+  private void addScopes(Set<String> scopes, Object value) {
+    if (value instanceof String stringValue) {
+      Arrays.stream(stringValue.split("[\\s,]+"))
+          .filter(StringUtils::hasText)
+          .forEach(scopes::add);
+      return;
+    }
+    if (value instanceof Collection<?> values) {
+      values.stream()
+          .filter(Objects::nonNull)
+          .map(Object::toString)
+          .filter(StringUtils::hasText)
+          .forEach(scopes::add);
+    }
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
@@ -1,6 +1,7 @@
 package com.schemafy.mcp.common.security;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -11,6 +12,10 @@ import javax.crypto.SecretKey;
 
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
+import com.schemafy.core.mcp.domain.McpToken;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -29,13 +34,19 @@ public class McpTokenValidator {
 
   private final McpSecurityProperties properties;
   private final McpTokenRevocationStore revocationStore;
+  private final GetMcpTokenUseCase getMcpTokenUseCase;
+  private final Clock clock;
   private final SecretKey secretKey;
 
   public McpTokenValidator(
       McpSecurityProperties properties,
-      McpTokenRevocationStore revocationStore) {
+      McpTokenRevocationStore revocationStore,
+      GetMcpTokenUseCase getMcpTokenUseCase,
+      Clock clock) {
     this.properties = properties;
     this.revocationStore = revocationStore;
+    this.getMcpTokenUseCase = getMcpTokenUseCase;
+    this.clock = clock;
     this.secretKey = Keys.hmacShaKeyFor(
         properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
   }
@@ -57,6 +68,7 @@ public class McpTokenValidator {
   private Claims parseClaims(String token) {
     return Jwts.parser()
         .verifyWith(secretKey)
+        .clock(() -> Date.from(clock.instant()))
         .clockSkewSeconds(properties.getToken().getClockSkewSeconds())
         .build()
         .parseSignedClaims(token)
@@ -68,7 +80,7 @@ public class McpTokenValidator {
         || claims.getAudience() == null
         || !claims.getAudience().contains(properties.getToken().getAudience())
         || claims.getExpiration() == null
-        || claims.getExpiration().before(new Date())) {
+        || claims.getExpiration().before(Date.from(clock.instant()))) {
       return Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID));
     }
     if (!StringUtils.hasText(claims.getSubject())) {
@@ -90,9 +102,35 @@ public class McpTokenValidator {
     McpTokenClaims tokenClaims = new McpTokenClaims(claims.getId(), claims.getSubject(),
         Set.copyOf(scopes));
     return revocationStore.isRevoked(claims.getId())
-        .map(revoked -> revoked
-            ? McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED)
-            : McpTokenValidationResult.success(tokenClaims));
+        .flatMap(revoked -> revoked
+            ? Mono.just(McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED))
+            : validateRegisteredToken(tokenClaims))
+        .onErrorResume(error -> Mono.just(McpTokenValidationResult.failure(
+            McpSecurityError.REVOCATION_CHECK_UNAVAILABLE)));
+  }
+
+  private Mono<McpTokenValidationResult> validateRegisteredToken(
+      McpTokenClaims tokenClaims) {
+    return getMcpTokenUseCase.getMcpToken(new GetMcpTokenQuery(tokenClaims.tokenId()))
+        .map(token -> validateRegisteredToken(tokenClaims, token))
+        .defaultIfEmpty(McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID))
+        .onErrorResume(error -> Mono.just(McpTokenValidationResult.failure(
+            McpSecurityError.TOKEN_REGISTRY_UNAVAILABLE)));
+  }
+
+  private McpTokenValidationResult validateRegisteredToken(
+      McpTokenClaims claims,
+      McpToken token) {
+    if (!token.belongsTo(claims.userId())
+        || !claims.hasScope(token.getScope())
+        || token.isDeleted()
+        || token.isExpiredAt(clock.instant())) {
+      return McpTokenValidationResult.failure(McpSecurityError.TOKEN_INVALID);
+    }
+    if (token.isRevoked()) {
+      return McpTokenValidationResult.failure(McpSecurityError.TOKEN_REVOKED);
+    }
+    return McpTokenValidationResult.success(claims);
   }
 
   private Set<String> extractScopes(Claims claims) {

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/McpTokenValidator.java
@@ -69,7 +69,6 @@ public class McpTokenValidator {
     return Jwts.parser()
         .verifyWith(secretKey)
         .clock(() -> Date.from(clock.instant()))
-        .clockSkewSeconds(properties.getToken().getClockSkewSeconds())
         .build()
         .parseSignedClaims(token)
         .getPayload();

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpRateLimiter.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpRateLimiter.java
@@ -1,0 +1,17 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import reactor.core.publisher.Mono;
+
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "false")
+class NoOpMcpRateLimiter implements McpRateLimiter {
+
+  @Override
+  public Mono<Boolean> tryAcquire(McpTokenClaims claims) {
+    return Mono.just(true);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpTokenRevocationCache.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpTokenRevocationCache.java
@@ -7,7 +7,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 @ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "false")
-class NoOpMcpTokenRevocationStore implements McpTokenRevocationStore {
+class NoOpMcpTokenRevocationCache implements McpTokenRevocationCache {
 
   @Override
   public Mono<Boolean> isRevoked(String tokenId) {

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpTokenRevocationStore.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/NoOpMcpTokenRevocationStore.java
@@ -1,0 +1,17 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import reactor.core.publisher.Mono;
+
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "false")
+class NoOpMcpTokenRevocationStore implements McpTokenRevocationStore {
+
+  @Override
+  public Mono<Boolean> isRevoked(String tokenId) {
+    return Mono.just(false);
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpRateLimiter.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpRateLimiter.java
@@ -1,0 +1,42 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import reactor.core.publisher.Mono;
+
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class RedisMcpRateLimiter implements McpRateLimiter {
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final McpSecurityProperties properties;
+
+  public RedisMcpRateLimiter(
+      ReactiveStringRedisTemplate redisTemplate,
+      McpSecurityProperties properties) {
+    this.redisTemplate = redisTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public Mono<Boolean> tryAcquire(McpTokenClaims claims) {
+    McpSecurityProperties.RateLimit rateLimit = properties.getRateLimit();
+    if (!rateLimit.isEnabled()) {
+      return Mono.just(true);
+    }
+
+    String key = rateLimit.getKeyPrefix() + claims.userId();
+    String windowMillis = Long.toString(rateLimit.getWindow().toMillis());
+    return redisTemplate.execute(
+        McpSecurityRedisScripts.RATE_LIMIT_INCREMENT,
+        List.of(key),
+        List.of(windowMillis))
+        .next()
+        .map(count -> count <= rateLimit.getRequests());
+  }
+
+}

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationCache.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationCache.java
@@ -9,12 +9,12 @@ import reactor.core.publisher.Mono;
 
 @Component
 @ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
-public class RedisMcpTokenRevocationStore implements McpTokenRevocationStore {
+public class RedisMcpTokenRevocationCache implements McpTokenRevocationCache {
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final McpSecurityProperties properties;
 
-  public RedisMcpTokenRevocationStore(
+  public RedisMcpTokenRevocationCache(
       ReactiveStringRedisTemplate redisTemplate,
       McpSecurityProperties properties) {
     this.redisTemplate = redisTemplate;

--- a/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationStore.java
+++ b/apps/backend/mcp/src/main/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationStore.java
@@ -1,0 +1,36 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import reactor.core.publisher.Mono;
+
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class RedisMcpTokenRevocationStore implements McpTokenRevocationStore {
+
+  private final ReactiveStringRedisTemplate redisTemplate;
+  private final McpSecurityProperties properties;
+
+  public RedisMcpTokenRevocationStore(
+      ReactiveStringRedisTemplate redisTemplate,
+      McpSecurityProperties properties) {
+    this.redisTemplate = redisTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public Mono<Boolean> isRevoked(String tokenId) {
+    if (!StringUtils.hasText(tokenId)) {
+      return Mono.just(false);
+    }
+    return redisTemplate.hasKey(revocationKey(tokenId));
+  }
+
+  private String revocationKey(String tokenId) {
+    return properties.getToken().getRevocationKeyPrefix() + tokenId;
+  }
+
+}

--- a/apps/backend/mcp/src/main/resources/application-server.yml
+++ b/apps/backend/mcp/src/main/resources/application-server.yml
@@ -3,6 +3,11 @@ spring:
     activate:
       on-profile: server
 
+mcp:
+  security:
+    token:
+      secret: ${MCP_TOKEN_SECRET}
+
 management:
   endpoints:
     web:

--- a/apps/backend/mcp/src/main/resources/application.yml
+++ b/apps/backend/mcp/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
   application:
     name: schemafy-mcp
 
+  data:
+    redis:
+      enabled: ${REDIS_ENABLED:true}
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   ai:
     mcp:
       server:
@@ -39,6 +45,25 @@ spring:
 
 server:
   port: ${MCP_SERVER_PORT:8081}
+
+mcp:
+  security:
+    token:
+      secret: ${MCP_TOKEN_SECRET:schemafy-mcp-local-secret-minimum-256-bit-key-value}
+      issuer: ${MCP_TOKEN_ISSUER:schemafy-mcp}
+      audience: ${MCP_TOKEN_AUDIENCE:schemafy-mcp}
+      token-type: ${MCP_TOKEN_TYPE:MCP}
+      required-scope: ${MCP_TOKEN_REQUIRED_SCOPE:mcp}
+      revocation-key-prefix: ${MCP_TOKEN_REVOCATION_KEY_PREFIX:mcp:token:revoked:}
+      clock-skew-seconds: ${MCP_TOKEN_CLOCK_SKEW_SECONDS:30}
+    rate-limit:
+      enabled: ${MCP_RATE_LIMIT_ENABLED:true}
+      requests: ${MCP_RATE_LIMIT_REQUESTS:120}
+      key-prefix: ${MCP_RATE_LIMIT_KEY_PREFIX:mcp:rate-limit:user:}
+      window: ${MCP_RATE_LIMIT_WINDOW:1m}
+
+problem:
+  type-base-uri: about:blank
 
 management:
   endpoints:

--- a/apps/backend/mcp/src/main/resources/application.yml
+++ b/apps/backend/mcp/src/main/resources/application.yml
@@ -55,7 +55,6 @@ mcp:
       token-type: ${MCP_TOKEN_TYPE:MCP}
       required-scope: ${MCP_TOKEN_REQUIRED_SCOPE:mcp}
       revocation-key-prefix: ${MCP_TOKEN_REVOCATION_KEY_PREFIX:mcp:token:revoked:}
-      clock-skew-seconds: ${MCP_TOKEN_CLOCK_SKEW_SECONDS:30}
     rate-limit:
       enabled: ${MCP_RATE_LIMIT_ENABLED:true}
       requests: ${MCP_RATE_LIMIT_REQUESTS:120}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpRedisDisabledFallbackIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpRedisDisabledFallbackIntegrationTest.java
@@ -1,0 +1,38 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("MCP Redis disabled fallback")
+class McpRedisDisabledFallbackIntegrationTest {
+
+  @Autowired
+  McpRateLimiter rateLimiter;
+
+  @Autowired
+  McpTokenRevocationStore revocationStore;
+
+  @Test
+  @DisplayName("Redis가 비활성화되어도 no-op fallback으로 보안 Bean을 구성한다")
+  void configuresFallbackSecurityBeansWhenRedisIsDisabled() {
+    McpTokenClaims claims = new McpTokenClaims("token-1", "user-1", Set.of("mcp"));
+
+    StepVerifier.create(rateLimiter.tryAcquire(claims))
+        .expectNext(true)
+        .verifyComplete();
+    StepVerifier.create(revocationStore.isRevoked(claims.tokenId()))
+        .expectNext(false)
+        .verifyComplete();
+  }
+
+}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpRedisDisabledFallbackIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpRedisDisabledFallbackIntegrationTest.java
@@ -20,7 +20,7 @@ class McpRedisDisabledFallbackIntegrationTest {
   McpRateLimiter rateLimiter;
 
   @Autowired
-  McpTokenRevocationStore revocationStore;
+  McpTokenRevocationCache revocationCache;
 
   @Test
   @DisplayName("Redis가 비활성화되어도 no-op fallback으로 보안 Bean을 구성한다")
@@ -30,7 +30,7 @@ class McpRedisDisabledFallbackIntegrationTest {
     StepVerifier.create(rateLimiter.tryAcquire(claims))
         .expectNext(true)
         .verifyComplete();
-    StepVerifier.create(revocationStore.isRevoked(claims.tokenId()))
+    StepVerifier.create(revocationCache.isRevoked(claims.tokenId()))
         .expectNext(false)
         .verifyComplete();
   }

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
@@ -46,13 +46,13 @@ class McpSecurityIntegrationTest {
   McpSecurityProperties properties;
 
   @Autowired
-  TestMcpTokenRevocationStore revocationStore;
+  TestMcpTokenRevocationCache revocationCache;
 
   McpTokenTestFactory tokenFactory;
 
   @BeforeEach
   void setUp() {
-    revocationStore.reset();
+    revocationCache.reset();
     tokenFactory = new McpTokenTestFactory(properties);
   }
 
@@ -98,7 +98,7 @@ class McpSecurityIntegrationTest {
   @Test
   @DisplayName("revocation 상태를 확인할 수 없으면 503을 반환한다")
   void rejectsWhenRevocationCheckUnavailable() {
-    revocationStore.fail();
+    revocationCache.fail();
 
     webTestClient.post()
         .uri("/mcp")
@@ -226,8 +226,8 @@ class McpSecurityIntegrationTest {
 
     @Bean
     @Primary
-    TestMcpTokenRevocationStore tokenRevocationStore() {
-      return new TestMcpTokenRevocationStore();
+    TestMcpTokenRevocationCache tokenRevocationCache() {
+      return new TestMcpTokenRevocationCache();
     }
 
     @Bean
@@ -255,7 +255,7 @@ class McpSecurityIntegrationTest {
 
   }
 
-  static class TestMcpTokenRevocationStore implements McpTokenRevocationStore {
+  static class TestMcpTokenRevocationCache implements McpTokenRevocationCache {
 
     private boolean fail;
 

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.schemafy.mcp.common.security;
 
+import java.time.Clock;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -22,6 +24,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
+import com.schemafy.core.mcp.domain.McpToken;
 import com.schemafy.core.project.application.access.ProjectAccessRequesterContext;
 
 import reactor.core.publisher.Mono;
@@ -40,10 +45,14 @@ class McpSecurityIntegrationTest {
   @Autowired
   McpSecurityProperties properties;
 
+  @Autowired
+  TestMcpTokenRevocationStore revocationStore;
+
   McpTokenTestFactory tokenFactory;
 
   @BeforeEach
   void setUp() {
+    revocationStore.reset();
     tokenFactory = new McpTokenTestFactory(properties);
   }
 
@@ -83,6 +92,29 @@ class McpSecurityIntegrationTest {
         .jsonPath("$.status").isEqualTo(401)
         .jsonPath("$.title").isEqualTo("Unauthorized")
         .jsonPath("$.detail").isEqualTo("MCP token is malformed")
+        .jsonPath("$.instance").isEqualTo("/mcp");
+  }
+
+  @Test
+  @DisplayName("revocation 상태를 확인할 수 없으면 503을 반환한다")
+  void rejectsWhenRevocationCheckUnavailable() {
+    revocationStore.fail();
+
+    webTestClient.post()
+        .uri("/mcp")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenFactory.validToken())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(initializeRequest())
+        .exchange()
+        .expectStatus().is5xxServerError()
+        .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.reason").isEqualTo("MCP_REVOCATION_CHECK_UNAVAILABLE")
+        .jsonPath("$.status").isEqualTo(503)
+        .jsonPath("$.title").isEqualTo("Service Unavailable")
+        .jsonPath("$.detail")
+        .isEqualTo("MCP token revocation status is temporarily unavailable")
         .jsonPath("$.instance").isEqualTo("/mcp");
   }
 
@@ -193,8 +225,17 @@ class McpSecurityIntegrationTest {
   static class ContextProbeConfiguration {
 
     @Bean
-    McpTokenRevocationStore tokenRevocationStore() {
-      return tokenId -> Mono.just(false);
+    @Primary
+    TestMcpTokenRevocationStore tokenRevocationStore() {
+      return new TestMcpTokenRevocationStore();
+    }
+
+    @Bean
+    @Primary
+    GetMcpTokenUseCase getMcpTokenUseCase(
+        McpSecurityProperties properties,
+        Clock clock) {
+      return new TestGetMcpTokenUseCase(properties, clock);
     }
 
     @Bean
@@ -210,6 +251,51 @@ class McpSecurityIntegrationTest {
                   "requesterId", ProjectAccessRequesterContext.requesterIdOrNull(context),
                   "actorUserId", ErdOperationContexts.metadata(context).actorUserIdOr(null),
                   "authenticationName", securityContext.getAuthentication().getName())))));
+    }
+
+  }
+
+  static class TestMcpTokenRevocationStore implements McpTokenRevocationStore {
+
+    private boolean fail;
+
+    @Override
+    public Mono<Boolean> isRevoked(String tokenId) {
+      if (fail) {
+        return Mono.error(new IllegalStateException("Redis unavailable"));
+      }
+      return Mono.just(false);
+    }
+
+    void fail() {
+      this.fail = true;
+    }
+
+    void reset() {
+      this.fail = false;
+    }
+
+  }
+
+  static class TestGetMcpTokenUseCase implements GetMcpTokenUseCase {
+
+    private final McpToken token;
+
+    TestGetMcpTokenUseCase(McpSecurityProperties properties, Clock clock) {
+      this.token = McpToken.issue(
+          "token-1",
+          "user-1",
+          properties.getToken().getRequiredScope(),
+          clock.instant().minusSeconds(60),
+          clock.instant().plusSeconds(3600));
+    }
+
+    @Override
+    public Mono<McpToken> getMcpToken(GetMcpTokenQuery query) {
+      if (token.getId().equals(query.tokenId())) {
+        return Mono.just(token);
+      }
+      return Mono.empty();
     }
 
   }

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpSecurityIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.erd.operation.ErdOperationContexts;
+import com.schemafy.core.project.application.access.ProjectAccessRequesterContext;
+
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class McpSecurityIntegrationTest {
+
+  @Autowired
+  WebTestClient webTestClient;
+
+  @Autowired
+  McpSecurityProperties properties;
+
+  McpTokenTestFactory tokenFactory;
+
+  @BeforeEach
+  void setUp() {
+    tokenFactory = new McpTokenTestFactory(properties);
+  }
+
+  @Test
+  @DisplayName("/mcp 요청은 Authorization 헤더가 없으면 401을 반환한다")
+  void rejectsMissingToken() {
+    webTestClient.post()
+        .uri("/mcp")
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(initializeRequest())
+        .exchange()
+        .expectStatus().isUnauthorized()
+        .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.reason").isEqualTo("MCP_TOKEN_MISSING")
+        .jsonPath("$.status").isEqualTo(401)
+        .jsonPath("$.title").isEqualTo("Unauthorized")
+        .jsonPath("$.detail").isEqualTo("MCP Bearer token is required")
+        .jsonPath("$.instance").isEqualTo("/mcp");
+  }
+
+  @Test
+  @DisplayName("/mcp 요청은 잘못된 토큰이면 401을 반환한다")
+  void rejectsInvalidToken() {
+    webTestClient.post()
+        .uri("/mcp")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token")
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(initializeRequest())
+        .exchange()
+        .expectStatus().isUnauthorized()
+        .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.reason").isEqualTo("MCP_TOKEN_MALFORMED")
+        .jsonPath("$.status").isEqualTo(401)
+        .jsonPath("$.title").isEqualTo("Unauthorized")
+        .jsonPath("$.detail").isEqualTo("MCP token is malformed")
+        .jsonPath("$.instance").isEqualTo("/mcp");
+  }
+
+  @Test
+  @DisplayName("/mcp 요청은 MCP scope가 부족하면 403을 반환한다")
+  void rejectsInsufficientScope() {
+    webTestClient.post()
+        .uri("/mcp")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenFactory.tokenWithoutRequiredScope())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(initializeRequest())
+        .exchange()
+        .expectStatus().isForbidden()
+        .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.reason").isEqualTo("MCP_INSUFFICIENT_SCOPE")
+        .jsonPath("$.status").isEqualTo(403)
+        .jsonPath("$.title").isEqualTo("Forbidden")
+        .jsonPath("$.detail").isEqualTo("MCP token scope is insufficient")
+        .jsonPath("$.instance").isEqualTo("/mcp");
+  }
+
+  @Test
+  @DisplayName("유효한 MCP 토큰은 requesterId와 SecurityContext를 Reactor context에 저장한다")
+  void storesRequesterContext() {
+    webTestClient.post()
+        .uri("/mcp/context-probe")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenFactory.validToken())
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.requesterId").isEqualTo("user-1")
+        .jsonPath("$.actorUserId").isEqualTo("user-1")
+        .jsonPath("$.authenticationName").isEqualTo("user-1");
+  }
+
+  @Test
+  @DisplayName("Authorization Bearer prefix는 대소문자를 구분하지 않는다")
+  void acceptsLowercaseBearerPrefix() {
+    webTestClient.post()
+        .uri("/mcp/context-probe")
+        .header(HttpHeaders.AUTHORIZATION, "bearer " + tokenFactory.validToken())
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.requesterId").isEqualTo("user-1")
+        .jsonPath("$.actorUserId").isEqualTo("user-1")
+        .jsonPath("$.authenticationName").isEqualTo("user-1");
+  }
+
+  @Test
+  @DisplayName("유효한 MCP 토큰이면 initialize 요청이 성공하고 빈 tool 목록 상태를 유지한다")
+  void initializesWithValidToken() {
+    String token = tokenFactory.validToken();
+    EntityExchangeResult<byte[]> initializeResult = webTestClient.post()
+        .uri("/mcp")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(initializeRequest())
+        .exchange()
+        .expectStatus().isOk()
+        .expectHeader().exists("Mcp-Session-Id")
+        .expectBody()
+        .returnResult();
+
+    String sessionId = initializeResult.getResponseHeaders().getFirst("Mcp-Session-Id");
+    assertThat(new String(initializeResult.getResponseBody()))
+        .contains("schemafy-mcp-test");
+
+    webTestClient.post()
+        .uri("/mcp")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        .header("Mcp-Session-Id", sessionId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+        .bodyValue(mcpRequest("tools-1", "tools/list"))
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(result -> assertThat(new String(result.getResponseBody()))
+            .contains("\"tools\":[]"));
+  }
+
+  private Map<String, Object> initializeRequest() {
+    return Map.of(
+        "jsonrpc", "2.0",
+        "id", "init-1",
+        "method", "initialize",
+        "params", Map.of(
+            "protocolVersion", "2024-11-05",
+            "capabilities", Map.of(),
+            "clientInfo", Map.of(
+                "name", "schemafy-test-client",
+                "version", "0.0.1")));
+  }
+
+  private Map<String, Object> mcpRequest(String id, String method) {
+    return Map.of(
+        "jsonrpc", "2.0",
+        "id", id,
+        "method", method,
+        "params", Map.of());
+  }
+
+  @TestConfiguration
+  static class ContextProbeConfiguration {
+
+    @Bean
+    McpTokenRevocationStore tokenRevocationStore() {
+      return tokenId -> Mono.just(false);
+    }
+
+    @Bean
+    McpRateLimiter rateLimiter() {
+      return claims -> Mono.just(true);
+    }
+
+    @Bean
+    RouterFunction<ServerResponse> contextProbeRoute() {
+      return RouterFunctions.route(POST("/mcp/context-probe"),
+          request -> Mono.deferContextual(context -> ReactiveSecurityContextHolder.getContext()
+              .flatMap(securityContext -> ServerResponse.ok().bodyValue(Map.of(
+                  "requesterId", ProjectAccessRequesterContext.requesterIdOrNull(context),
+                  "actorUserId", ErdOperationContexts.metadata(context).actorUserIdOr(null),
+                  "authenticationName", securityContext.getAuthentication().getName())))));
+    }
+
+  }
+
+}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
@@ -1,6 +1,7 @@
 package com.schemafy.mcp.common.security;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -15,10 +16,16 @@ final class McpTokenTestFactory {
   private static final String DEFAULT_USER_ID = "user-1";
 
   private final McpSecurityProperties properties;
+  private final Clock clock;
   private final SecretKey secretKey;
 
   McpTokenTestFactory(McpSecurityProperties properties) {
+    this(properties, Clock.systemUTC());
+  }
+
+  McpTokenTestFactory(McpSecurityProperties properties, Clock clock) {
     this.properties = properties;
+    this.clock = clock;
     this.secretKey = Keys.hmacShaKeyFor(
         properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
   }
@@ -32,7 +39,7 @@ final class McpTokenTestFactory {
   }
 
   String expiredToken() {
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     return token(builder()
         .issuedAt(Date.from(now.minusSeconds(120)))
         .expiration(Date.from(now.minusSeconds(60))));
@@ -43,7 +50,7 @@ final class McpTokenTestFactory {
   }
 
   String wrongAudienceToken() {
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     return token(Jwts.builder()
         .id(DEFAULT_TOKEN_ID)
         .subject(DEFAULT_USER_ID)
@@ -64,7 +71,7 @@ final class McpTokenTestFactory {
   }
 
   private io.jsonwebtoken.JwtBuilder builder() {
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     return Jwts.builder()
         .id(DEFAULT_TOKEN_ID)
         .subject(DEFAULT_USER_ID)

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
@@ -7,6 +7,8 @@ import java.util.Date;
 import java.util.List;
 import javax.crypto.SecretKey;
 
+import com.schemafy.core.mcp.domain.McpTokenClaimSupport;
+
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
@@ -35,7 +37,7 @@ final class McpTokenTestFactory {
   }
 
   String tokenWithoutRequiredScope() {
-    return token(builder().claim("scope", "schema:read"));
+    return token(builder().claim(McpTokenClaimSupport.SCOPE, "schema:read"));
   }
 
   String expiredToken() {
@@ -58,12 +60,12 @@ final class McpTokenTestFactory {
         .audience().add("wrong-audience").and()
         .issuedAt(Date.from(now))
         .expiration(Date.from(now.plusSeconds(3600)))
-        .claim("type", properties.getToken().getTokenType())
-        .claim("scope", properties.getToken().getRequiredScope()));
+        .claim(McpTokenClaimSupport.TYPE, properties.getToken().getTokenType())
+        .claim(McpTokenClaimSupport.SCOPE, properties.getToken().getRequiredScope()));
   }
 
   String wrongTokenTypeToken() {
-    return token(builder().claim("type", "ACCESS"));
+    return token(builder().claim(McpTokenClaimSupport.TYPE, "ACCESS"));
   }
 
   String revokedToken(String tokenId) {
@@ -79,8 +81,8 @@ final class McpTokenTestFactory {
         .audience().add(properties.getToken().getAudience()).and()
         .issuedAt(Date.from(now))
         .expiration(Date.from(now.plusSeconds(3600)))
-        .claim("type", properties.getToken().getTokenType())
-        .claim("scope", String.join(" ", List.of(
+        .claim(McpTokenClaimSupport.TYPE, properties.getToken().getTokenType())
+        .claim(McpTokenClaimSupport.SCOPE, String.join(" ", List.of(
             properties.getToken().getRequiredScope(),
             "schema:read")));
   }

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenTestFactory.java
@@ -1,0 +1,85 @@
+package com.schemafy.mcp.common.security;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+final class McpTokenTestFactory {
+
+  private static final String DEFAULT_TOKEN_ID = "token-1";
+  private static final String DEFAULT_USER_ID = "user-1";
+
+  private final McpSecurityProperties properties;
+  private final SecretKey secretKey;
+
+  McpTokenTestFactory(McpSecurityProperties properties) {
+    this.properties = properties;
+    this.secretKey = Keys.hmacShaKeyFor(
+        properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+  String validToken() {
+    return token(builder());
+  }
+
+  String tokenWithoutRequiredScope() {
+    return token(builder().claim("scope", "schema:read"));
+  }
+
+  String expiredToken() {
+    Instant now = Instant.now();
+    return token(builder()
+        .issuedAt(Date.from(now.minusSeconds(120)))
+        .expiration(Date.from(now.minusSeconds(60))));
+  }
+
+  String wrongIssuerToken() {
+    return token(builder().issuer("wrong-issuer"));
+  }
+
+  String wrongAudienceToken() {
+    Instant now = Instant.now();
+    return token(Jwts.builder()
+        .id(DEFAULT_TOKEN_ID)
+        .subject(DEFAULT_USER_ID)
+        .issuer(properties.getToken().getIssuer())
+        .audience().add("wrong-audience").and()
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(now.plusSeconds(3600)))
+        .claim("type", properties.getToken().getTokenType())
+        .claim("scope", properties.getToken().getRequiredScope()));
+  }
+
+  String wrongTokenTypeToken() {
+    return token(builder().claim("type", "ACCESS"));
+  }
+
+  String revokedToken(String tokenId) {
+    return token(builder().id(tokenId));
+  }
+
+  private io.jsonwebtoken.JwtBuilder builder() {
+    Instant now = Instant.now();
+    return Jwts.builder()
+        .id(DEFAULT_TOKEN_ID)
+        .subject(DEFAULT_USER_ID)
+        .issuer(properties.getToken().getIssuer())
+        .audience().add(properties.getToken().getAudience()).and()
+        .issuedAt(Date.from(now))
+        .expiration(Date.from(now.plusSeconds(3600)))
+        .claim("type", properties.getToken().getTokenType())
+        .claim("scope", String.join(" ", List.of(
+            properties.getToken().getRequiredScope(),
+            "schema:read")));
+  }
+
+  private String token(io.jsonwebtoken.JwtBuilder builder) {
+    return builder.signWith(secretKey).compact();
+  }
+
+}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
@@ -1,0 +1,127 @@
+package com.schemafy.mcp.common.security;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpTokenValidatorTest {
+
+  private static final String REVOKED_TOKEN_ID = "revoked-token";
+
+  McpSecurityProperties properties;
+  McpTokenTestFactory tokenFactory;
+  McpTokenValidator validator;
+  TestMcpTokenRevocationStore revocationStore;
+
+  @BeforeEach
+  void setUp() {
+    properties = new McpSecurityProperties();
+    properties.getToken().setSecret("test-schemafy-mcp-secret-minimum-256-bit-key-value");
+    properties.getToken().setIssuer("schemafy-mcp-test");
+    properties.getToken().setAudience("schemafy-mcp-test");
+    properties.getToken().setClockSkewSeconds(0);
+    revocationStore = new TestMcpTokenRevocationStore();
+    validator = new McpTokenValidator(properties, revocationStore);
+    tokenFactory = new McpTokenTestFactory(properties);
+  }
+
+  @Test
+  @DisplayName("유효한 MCP 토큰을 검증한다")
+  void validatesToken() {
+    StepVerifier.create(validator.validate(tokenFactory.validToken()))
+        .assertNext(result -> {
+          assertThat(result.valid()).isTrue();
+          assertThat(result.claims().userId()).isEqualTo("user-1");
+          assertThat(result.claims().hasScope("mcp")).isTrue();
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("누락된 토큰을 거부한다")
+  void rejectsMissingToken() {
+    expectFailure(Mono.defer(() -> validator.validate(null)), McpSecurityError.TOKEN_MISSING);
+  }
+
+  @Test
+  @DisplayName("형식이 잘못된 토큰을 거부한다")
+  void rejectsMalformedToken() {
+    expectFailure(validator.validate("not-a-jwt"), McpSecurityError.TOKEN_MALFORMED);
+  }
+
+  @Test
+  @DisplayName("만료된 토큰을 거부한다")
+  void rejectsExpiredToken() {
+    expectFailure(validator.validate(tokenFactory.expiredToken()), McpSecurityError.TOKEN_EXPIRED);
+  }
+
+  @Test
+  @DisplayName("issuer가 다른 토큰을 거부한다")
+  void rejectsWrongIssuer() {
+    expectFailure(validator.validate(tokenFactory.wrongIssuerToken()), McpSecurityError.TOKEN_INVALID);
+  }
+
+  @Test
+  @DisplayName("audience가 다른 토큰을 거부한다")
+  void rejectsWrongAudience() {
+    expectFailure(validator.validate(tokenFactory.wrongAudienceToken()), McpSecurityError.TOKEN_INVALID);
+  }
+
+  @Test
+  @DisplayName("MCP 토큰 타입이 아닌 토큰을 거부한다")
+  void rejectsWrongTokenType() {
+    expectFailure(validator.validate(tokenFactory.wrongTokenTypeToken()), McpSecurityError.TOKEN_INVALID);
+  }
+
+  @Test
+  @DisplayName("필수 MCP scope가 없는 토큰을 거부한다")
+  void rejectsMissingScope() {
+    expectFailure(validator.validate(tokenFactory.tokenWithoutRequiredScope()),
+        McpSecurityError.INSUFFICIENT_SCOPE);
+  }
+
+  @Test
+  @DisplayName("폐기된 토큰을 거부한다")
+  void rejectsRevokedToken() {
+    revocationStore.revoke(REVOKED_TOKEN_ID).block();
+
+    expectFailure(validator.validate(tokenFactory.revokedToken(REVOKED_TOKEN_ID)),
+        McpSecurityError.TOKEN_REVOKED);
+  }
+
+  private void expectFailure(Mono<McpTokenValidationResult> actual, McpSecurityError error) {
+    StepVerifier.create(actual)
+        .assertNext(result -> {
+          assertThat(result.valid()).isFalse();
+          assertThat(result.error()).isEqualTo(error);
+        })
+        .verifyComplete();
+  }
+
+  private static class TestMcpTokenRevocationStore
+      implements McpTokenRevocationStore {
+
+    private final Set<String> revokedTokenIds = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public Mono<Boolean> isRevoked(String tokenId) {
+      return Mono.just(tokenId != null && !tokenId.isBlank()
+          && revokedTokenIds.contains(tokenId));
+    }
+
+    Mono<Void> revoke(String tokenId) {
+      revokedTokenIds.add(tokenId);
+      return Mono.empty();
+    }
+
+  }
+
+}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
@@ -1,11 +1,13 @@
 package com.schemafy.mcp.common.security;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.crypto.SecretKey;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,7 @@ import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
 import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
 import com.schemafy.core.mcp.domain.McpToken;
 
+import io.jsonwebtoken.security.Keys;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -39,9 +42,11 @@ class McpTokenValidatorTest {
     properties.getToken().setAudience("schemafy-mcp-test");
     revocationCache = new TestMcpTokenRevocationCache();
     Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    SecretKey secretKey = Keys.hmacShaKeyFor(
+        properties.getToken().getSecret().getBytes(StandardCharsets.UTF_8));
     getMcpTokenUseCase = new TestGetMcpTokenUseCase(properties, clock);
     validator = new McpTokenValidator(properties, revocationCache,
-        getMcpTokenUseCase, clock);
+        getMcpTokenUseCase, clock, secretKey);
     tokenFactory = new McpTokenTestFactory(properties, clock);
   }
 

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
@@ -1,11 +1,19 @@
 package com.schemafy.mcp.common.security;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenQuery;
+import com.schemafy.core.mcp.application.port.in.GetMcpTokenUseCase;
+import com.schemafy.core.mcp.domain.McpToken;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -15,11 +23,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class McpTokenValidatorTest {
 
   private static final String REVOKED_TOKEN_ID = "revoked-token";
+  private static final Instant NOW = Instant.parse("2026-06-27T00:00:00Z");
 
   McpSecurityProperties properties;
   McpTokenTestFactory tokenFactory;
   McpTokenValidator validator;
   TestMcpTokenRevocationStore revocationStore;
+  TestGetMcpTokenUseCase getMcpTokenUseCase;
 
   @BeforeEach
   void setUp() {
@@ -29,8 +39,11 @@ class McpTokenValidatorTest {
     properties.getToken().setAudience("schemafy-mcp-test");
     properties.getToken().setClockSkewSeconds(0);
     revocationStore = new TestMcpTokenRevocationStore();
-    validator = new McpTokenValidator(properties, revocationStore);
-    tokenFactory = new McpTokenTestFactory(properties);
+    Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    getMcpTokenUseCase = new TestGetMcpTokenUseCase(properties, clock);
+    validator = new McpTokenValidator(properties, revocationStore,
+        getMcpTokenUseCase, clock);
+    tokenFactory = new McpTokenTestFactory(properties, clock);
   }
 
   @Test
@@ -97,6 +110,42 @@ class McpTokenValidatorTest {
         McpSecurityError.TOKEN_REVOKED);
   }
 
+  @Test
+  @DisplayName("Redis revocation 조회가 실패하면 fail-closed로 거부한다")
+  void rejectsWhenRevocationCheckUnavailable() {
+    revocationStore.fail();
+
+    expectFailure(validator.validate(tokenFactory.validToken()),
+        McpSecurityError.REVOCATION_CHECK_UNAVAILABLE);
+  }
+
+  @Test
+  @DisplayName("DB token registry에 등록되지 않은 토큰을 거부한다")
+  void rejectsUnregisteredToken() {
+    getMcpTokenUseCase.clear();
+
+    expectFailure(validator.validate(tokenFactory.validToken()),
+        McpSecurityError.TOKEN_INVALID);
+  }
+
+  @Test
+  @DisplayName("DB token registry에서 폐기된 토큰을 거부한다")
+  void rejectsTokenRevokedInRegistry() {
+    getMcpTokenUseCase.revoke("token-1");
+
+    expectFailure(validator.validate(tokenFactory.validToken()),
+        McpSecurityError.TOKEN_REVOKED);
+  }
+
+  @Test
+  @DisplayName("DB token registry 조회가 실패하면 fail-closed로 거부한다")
+  void rejectsWhenTokenRegistryUnavailable() {
+    getMcpTokenUseCase.fail();
+
+    expectFailure(validator.validate(tokenFactory.validToken()),
+        McpSecurityError.TOKEN_REGISTRY_UNAVAILABLE);
+  }
+
   private void expectFailure(Mono<McpTokenValidationResult> actual, McpSecurityError error) {
     StepVerifier.create(actual)
         .assertNext(result -> {
@@ -110,9 +159,13 @@ class McpTokenValidatorTest {
       implements McpTokenRevocationStore {
 
     private final Set<String> revokedTokenIds = ConcurrentHashMap.newKeySet();
+    private boolean fail;
 
     @Override
     public Mono<Boolean> isRevoked(String tokenId) {
+      if (fail) {
+        return Mono.error(new IllegalStateException("Redis unavailable"));
+      }
       return Mono.just(tokenId != null && !tokenId.isBlank()
           && revokedTokenIds.contains(tokenId));
     }
@@ -120,6 +173,49 @@ class McpTokenValidatorTest {
     Mono<Void> revoke(String tokenId) {
       revokedTokenIds.add(tokenId);
       return Mono.empty();
+    }
+
+    void fail() {
+      this.fail = true;
+    }
+
+  }
+
+  private static class TestGetMcpTokenUseCase implements GetMcpTokenUseCase {
+
+    private final Map<String, McpToken> tokens = new ConcurrentHashMap<>();
+    private final Clock clock;
+    private boolean fail;
+
+    TestGetMcpTokenUseCase(McpSecurityProperties properties, Clock clock) {
+      this.clock = clock;
+      McpToken token = McpToken.issue(
+          "token-1",
+          "user-1",
+          properties.getToken().getRequiredScope(),
+          clock.instant().minusSeconds(60),
+          clock.instant().plusSeconds(3600));
+      tokens.put(token.getId(), token);
+    }
+
+    @Override
+    public Mono<McpToken> getMcpToken(GetMcpTokenQuery query) {
+      if (fail) {
+        return Mono.error(new IllegalStateException("Token registry unavailable"));
+      }
+      return Mono.justOrEmpty(tokens.get(query.tokenId()));
+    }
+
+    void clear() {
+      tokens.clear();
+    }
+
+    void revoke(String tokenId) {
+      tokens.get(tokenId).revoke(clock.instant());
+    }
+
+    void fail() {
+      this.fail = true;
     }
 
   }

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
@@ -28,7 +28,7 @@ class McpTokenValidatorTest {
   McpSecurityProperties properties;
   McpTokenTestFactory tokenFactory;
   McpTokenValidator validator;
-  TestMcpTokenRevocationStore revocationStore;
+  TestMcpTokenRevocationCache revocationCache;
   TestGetMcpTokenUseCase getMcpTokenUseCase;
 
   @BeforeEach
@@ -37,10 +37,10 @@ class McpTokenValidatorTest {
     properties.getToken().setSecret("test-schemafy-mcp-secret-minimum-256-bit-key-value");
     properties.getToken().setIssuer("schemafy-mcp-test");
     properties.getToken().setAudience("schemafy-mcp-test");
-    revocationStore = new TestMcpTokenRevocationStore();
+    revocationCache = new TestMcpTokenRevocationCache();
     Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
     getMcpTokenUseCase = new TestGetMcpTokenUseCase(properties, clock);
-    validator = new McpTokenValidator(properties, revocationStore,
+    validator = new McpTokenValidator(properties, revocationCache,
         getMcpTokenUseCase, clock);
     tokenFactory = new McpTokenTestFactory(properties, clock);
   }
@@ -103,7 +103,7 @@ class McpTokenValidatorTest {
   @Test
   @DisplayName("폐기된 토큰을 거부한다")
   void rejectsRevokedToken() {
-    revocationStore.revoke(REVOKED_TOKEN_ID).block();
+    revocationCache.revoke(REVOKED_TOKEN_ID).block();
 
     expectFailure(validator.validate(tokenFactory.revokedToken(REVOKED_TOKEN_ID)),
         McpSecurityError.TOKEN_REVOKED);
@@ -112,7 +112,7 @@ class McpTokenValidatorTest {
   @Test
   @DisplayName("Redis revocation 조회가 실패하면 fail-closed로 거부한다")
   void rejectsWhenRevocationCheckUnavailable() {
-    revocationStore.fail();
+    revocationCache.fail();
 
     expectFailure(validator.validate(tokenFactory.validToken()),
         McpSecurityError.REVOCATION_CHECK_UNAVAILABLE);
@@ -154,8 +154,8 @@ class McpTokenValidatorTest {
         .verifyComplete();
   }
 
-  private static class TestMcpTokenRevocationStore
-      implements McpTokenRevocationStore {
+  private static class TestMcpTokenRevocationCache
+      implements McpTokenRevocationCache {
 
     private final Set<String> revokedTokenIds = ConcurrentHashMap.newKeySet();
     private boolean fail;

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/McpTokenValidatorTest.java
@@ -37,7 +37,6 @@ class McpTokenValidatorTest {
     properties.getToken().setSecret("test-schemafy-mcp-secret-minimum-256-bit-key-value");
     properties.getToken().setIssuer("schemafy-mcp-test");
     properties.getToken().setAudience("schemafy-mcp-test");
-    properties.getToken().setClockSkewSeconds(0);
     revocationStore = new TestMcpTokenRevocationStore();
     Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
     getMcpTokenUseCase = new TestGetMcpTokenUseCase(properties, clock);

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpRateLimiterTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpRateLimiterTest.java
@@ -1,0 +1,83 @@
+package com.schemafy.mcp.common.security;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisMcpRateLimiterTest {
+
+  private static final String KEY = "mcp:rate-limit:user:user-1";
+
+  @Mock
+  ReactiveStringRedisTemplate redisTemplate;
+
+  McpSecurityProperties properties;
+  RedisMcpRateLimiter rateLimiter;
+
+  @BeforeEach
+  void setUp() {
+    properties = new McpSecurityProperties();
+    properties.getRateLimit().setRequests(2);
+    properties.getRateLimit().setWindow(Duration.ofSeconds(30));
+    rateLimiter = new RedisMcpRateLimiter(redisTemplate, properties);
+  }
+
+  @Test
+  @DisplayName("Redis script로 카운터 증가와 TTL 설정을 원자적으로 수행한다")
+  void incrementsCounterWithRedisScript() {
+    when(redisTemplate.execute(
+        McpSecurityRedisScripts.RATE_LIMIT_INCREMENT,
+        List.of(KEY),
+        List.of("30000")))
+        .thenReturn(Flux.just(1L));
+
+    StepVerifier.create(rateLimiter.tryAcquire(claims()))
+        .expectNext(true)
+        .verifyComplete();
+
+    verify(redisTemplate).execute(
+        McpSecurityRedisScripts.RATE_LIMIT_INCREMENT,
+        List.of(KEY),
+        List.of("30000"));
+  }
+
+  @Test
+  @DisplayName("Redis 카운터가 허용치를 넘으면 요청을 거부한다")
+  void rejectsWhenCounterExceedsLimit() {
+    when(redisTemplate.execute(
+        McpSecurityRedisScripts.RATE_LIMIT_INCREMENT,
+        List.of(KEY),
+        List.of("30000")))
+        .thenReturn(Flux.just(3L));
+
+    StepVerifier.create(rateLimiter.tryAcquire(claims()))
+        .expectNext(false)
+        .verifyComplete();
+
+    verify(redisTemplate).execute(
+        McpSecurityRedisScripts.RATE_LIMIT_INCREMENT,
+        List.of(KEY),
+        List.of("30000"));
+  }
+
+  private McpTokenClaims claims() {
+    return new McpTokenClaims("token-1", "user-1", Set.of("mcp"));
+  }
+
+}

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationCacheTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationCacheTest.java
@@ -17,16 +17,16 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class RedisMcpTokenRevocationStoreTest {
+class RedisMcpTokenRevocationCacheTest {
 
   @Mock
   ReactiveStringRedisTemplate redisTemplate;
 
-  RedisMcpTokenRevocationStore revocationStore;
+  RedisMcpTokenRevocationCache revocationCache;
 
   @BeforeEach
   void setUp() {
-    revocationStore = new RedisMcpTokenRevocationStore(
+    revocationCache = new RedisMcpTokenRevocationCache(
         redisTemplate,
         new McpSecurityProperties());
   }
@@ -37,7 +37,7 @@ class RedisMcpTokenRevocationStoreTest {
     when(redisTemplate.hasKey("mcp:token:revoked:token-1"))
         .thenReturn(Mono.just(true));
 
-    StepVerifier.create(revocationStore.isRevoked("token-1"))
+    StepVerifier.create(revocationCache.isRevoked("token-1"))
         .expectNext(true)
         .verifyComplete();
 
@@ -47,7 +47,7 @@ class RedisMcpTokenRevocationStoreTest {
   @Test
   @DisplayName("토큰 ID가 비어 있으면 Redis를 조회하지 않는다")
   void skipsRedisLookupForBlankTokenId() {
-    StepVerifier.create(revocationStore.isRevoked(" "))
+    StepVerifier.create(revocationCache.isRevoked(" "))
         .expectNext(false)
         .verifyComplete();
 

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationStoreTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/common/security/RedisMcpTokenRevocationStoreTest.java
@@ -1,0 +1,57 @@
+package com.schemafy.mcp.common.security;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisMcpTokenRevocationStoreTest {
+
+  @Mock
+  ReactiveStringRedisTemplate redisTemplate;
+
+  RedisMcpTokenRevocationStore revocationStore;
+
+  @BeforeEach
+  void setUp() {
+    revocationStore = new RedisMcpTokenRevocationStore(
+        redisTemplate,
+        new McpSecurityProperties());
+  }
+
+  @Test
+  @DisplayName("폐기된 토큰 여부를 Redis key 존재 여부로 확인한다")
+  void checksRevokedTokenWithRedisKey() {
+    when(redisTemplate.hasKey("mcp:token:revoked:token-1"))
+        .thenReturn(Mono.just(true));
+
+    StepVerifier.create(revocationStore.isRevoked("token-1"))
+        .expectNext(true)
+        .verifyComplete();
+
+    verify(redisTemplate).hasKey("mcp:token:revoked:token-1");
+  }
+
+  @Test
+  @DisplayName("토큰 ID가 비어 있으면 Redis를 조회하지 않는다")
+  void skipsRedisLookupForBlankTokenId() {
+    StepVerifier.create(revocationStore.isRevoked(" "))
+        .expectNext(false)
+        .verifyComplete();
+
+    verifyNoInteractions(redisTemplate);
+  }
+
+}

--- a/apps/backend/mcp/src/test/resources/application-test.yml
+++ b/apps/backend/mcp/src/test/resources/application-test.yml
@@ -46,7 +46,6 @@ mcp:
       audience: schemafy-mcp-test
       token-type: MCP
       required-scope: mcp
-      clock-skew-seconds: 0
     rate-limit:
       enabled: false
       requests: 100

--- a/apps/backend/mcp/src/test/resources/application-test.yml
+++ b/apps/backend/mcp/src/test/resources/application-test.yml
@@ -2,6 +2,15 @@ spring:
   application:
     name: schemafy-mcp-test
 
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+
+  data:
+    redis:
+      enabled: false
+
   ai:
     mcp:
       server:
@@ -28,6 +37,20 @@ spring:
 
 server:
   port: 0
+
+mcp:
+  security:
+    token:
+      secret: test-schemafy-mcp-secret-minimum-256-bit-key-value
+      issuer: schemafy-mcp-test
+      audience: schemafy-mcp-test
+      token-type: MCP
+      required-scope: mcp
+      clock-skew-seconds: 0
+    rate-limit:
+      enabled: false
+      requests: 100
+      window: 1m
 
 management:
   endpoints:

--- a/apps/backend/sql-resources/ddl/h2/mcp_tokens.sql
+++ b/apps/backend/sql-resources/ddl/h2/mcp_tokens.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+    id             CHAR(26)      NOT NULL,
+    user_id        CHAR(26)      NOT NULL,
+    scope          VARCHAR(255)  NOT NULL,
+    issued_at      TIMESTAMP     NOT NULL,
+    expires_at     TIMESTAMP     NOT NULL,
+    revoked_at     TIMESTAMP     NULL,
+    last_used_at   TIMESTAMP     NULL,
+    created_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at     TIMESTAMP     NULL,
+    CONSTRAINT pk_mcp_tokens PRIMARY KEY (id)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_user ON mcp_tokens (user_id, expires_at, revoked_at);

--- a/apps/backend/sql-resources/ddl/mariadb/mcp_tokens.sql
+++ b/apps/backend/sql-resources/ddl/mariadb/mcp_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+    id             CHAR(26)      NOT NULL,
+    user_id        CHAR(26)      NOT NULL,
+    scope          VARCHAR(255)  NOT NULL,
+    issued_at      TIMESTAMP     NOT NULL,
+    expires_at     TIMESTAMP     NOT NULL,
+    revoked_at     TIMESTAMP     NULL,
+    last_used_at   TIMESTAMP     NULL,
+    created_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at     TIMESTAMP     NULL,
+    CONSTRAINT pk_mcp_tokens PRIMARY KEY (id),
+    INDEX idx_mcp_tokens_user (user_id, expires_at, revoked_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## 개요

- `apps/backend/mcp`의 `/mcp` 요청에 MCP 전용 Bearer token 인증 적용
- 로그인 사용자가 MCP token을 발급/폐기할 수 있는 API 추가
- 발급된 token을 DB registry에 저장하고, MCP 검증 시 등록/소유자/scope/만료/revoke 상태 확인
- Redis 기반 revoke cache와 rate limit 추가
- MCP 인증 성공 시 이후 core access check에 필요한 사용자 context 전파
- MCP token API 문서 추가

## 참고

- OAuth/SSO 기반 MCP 연결은 후속 과제로 분리
- MCP resource/tool 구현은 후속 이슈 범위

## 이슈

- close #426
