### PR TITLE
refactor(#322): align ERD persistence entity construction

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationLogEntity.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationLogEntity.java
@@ -9,7 +9,6 @@ import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -69,7 +68,6 @@ public class ErdOperationLogEntity implements Persistable<String> {
   @CreatedDate
   private Instant createdAt;
 
-  @Builder
   ErdOperationLogEntity(
       String opId,
       String projectId,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationLogMapper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/ErdOperationLogMapper.java
@@ -11,23 +11,22 @@ import com.schemafy.core.erd.operation.domain.ErdOperationType;
 class ErdOperationLogMapper {
 
   ErdOperationLogEntity toEntity(ErdOperationLog erdOperationLog) {
-    return ErdOperationLogEntity.builder()
-        .opId(erdOperationLog.opId())
-        .projectId(erdOperationLog.projectId())
-        .schemaId(erdOperationLog.schemaId())
-        .opType(erdOperationLog.opType().name())
-        .committedRevision(erdOperationLog.committedRevision())
-        .baseSchemaRevision(erdOperationLog.baseSchemaRevision())
-        .clientOperationId(erdOperationLog.clientOperationId())
-        .collabSessionId(erdOperationLog.collabSessionId())
-        .actorUserId(erdOperationLog.actorUserId())
-        .derivationKind(erdOperationLog.derivationKind().name())
-        .derivedFromOpId(erdOperationLog.derivedFromOpId())
-        .lifecycleState(erdOperationLog.lifecycleState().name())
-        .payloadJson(erdOperationLog.payloadJson())
-        .inversePayloadJson(erdOperationLog.inversePayloadJson())
-        .affectedTableIdsJson(erdOperationLog.affectedTableIdsJson())
-        .build();
+    return new ErdOperationLogEntity(
+        erdOperationLog.opId(),
+        erdOperationLog.projectId(),
+        erdOperationLog.schemaId(),
+        erdOperationLog.opType().name(),
+        erdOperationLog.committedRevision(),
+        erdOperationLog.baseSchemaRevision(),
+        erdOperationLog.clientOperationId(),
+        erdOperationLog.collabSessionId(),
+        erdOperationLog.actorUserId(),
+        erdOperationLog.derivationKind().name(),
+        erdOperationLog.derivedFromOpId(),
+        erdOperationLog.lifecycleState().name(),
+        erdOperationLog.payloadJson(),
+        erdOperationLog.inversePayloadJson(),
+        erdOperationLog.affectedTableIdsJson());
   }
 
   ErdOperationLog toDomain(ErdOperationLogEntity entity) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateEntity.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateEntity.java
@@ -10,7 +10,6 @@ import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -37,7 +36,6 @@ public class SchemaCollaborationStateEntity implements Persistable<String> {
   @LastModifiedDate
   private Instant updatedAt;
 
-  @Builder
   SchemaCollaborationStateEntity(
       String schemaId,
       String projectId,

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateMapper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/operation/adapter/out/persistence/SchemaCollaborationStateMapper.java
@@ -8,13 +8,12 @@ import com.schemafy.core.erd.operation.domain.SchemaCollaborationState;
 class SchemaCollaborationStateMapper {
 
   SchemaCollaborationStateEntity toEntity(SchemaCollaborationState schemaCollaborationState) {
-    return SchemaCollaborationStateEntity.builder()
-        .schemaId(schemaCollaborationState.schemaId())
-        .projectId(schemaCollaborationState.projectId())
-        .currentRevision(schemaCollaborationState.currentRevision())
-        .createdAt(schemaCollaborationState.createdAt())
-        .updatedAt(schemaCollaborationState.updatedAt())
-        .build();
+    return new SchemaCollaborationStateEntity(
+        schemaCollaborationState.schemaId(),
+        schemaCollaborationState.projectId(),
+        schemaCollaborationState.currentRevision(),
+        schemaCollaborationState.createdAt(),
+        schemaCollaborationState.updatedAt());
   }
 
   SchemaCollaborationState toDomain(SchemaCollaborationStateEntity entity) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/adapter/out/persistence/SchemaEntity.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/adapter/out/persistence/SchemaEntity.java
@@ -11,7 +11,6 @@ import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -49,8 +48,7 @@ public class SchemaEntity implements Persistable<String> {
   @Version
   private Long version;
 
-  @Builder
-  private SchemaEntity(String id, String projectId, String dbVendorName,
+  SchemaEntity(String id, String projectId, String dbVendorName,
       String name, String charset, String collation) {
     this.id = id;
     this.projectId = projectId;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/adapter/out/persistence/SchemaMapper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/schema/adapter/out/persistence/SchemaMapper.java
@@ -8,14 +8,13 @@ import com.schemafy.core.erd.schema.domain.Schema;
 class SchemaMapper {
 
   SchemaEntity toEntity(Schema schema) {
-    return SchemaEntity.builder()
-        .id(schema.id())
-        .projectId(schema.projectId())
-        .dbVendorName(schema.dbVendorName())
-        .name(schema.name())
-        .charset(schema.charset())
-        .collation(schema.collation())
-        .build();
+    return new SchemaEntity(
+        schema.id(),
+        schema.projectId(),
+        schema.dbVendorName(),
+        schema.name(),
+        schema.charset(),
+        schema.collation());
   }
 
   Schema toDomain(SchemaEntity entity) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/adapter/out/persistence/TableEntity.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/adapter/out/persistence/TableEntity.java
@@ -11,7 +11,6 @@ import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -49,8 +48,7 @@ public class TableEntity implements Persistable<String> {
   @Version
   private Long version;
 
-  @Builder
-  private TableEntity(String id, String schemaId, String name,
+  TableEntity(String id, String schemaId, String name,
       String charset, String collation, String extra) {
     this.id = id;
     this.schemaId = schemaId;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/table/adapter/out/persistence/TableMapper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/table/adapter/out/persistence/TableMapper.java
@@ -15,14 +15,13 @@ class TableMapper {
   }
 
   TableEntity toEntity(Table table) {
-    return TableEntity.builder()
-        .id(table.id())
-        .schemaId(table.schemaId())
-        .name(table.name())
-        .charset(table.charset())
-        .collation(table.collation())
-        .extra(table.extra())
-        .build();
+    return new TableEntity(
+        table.id(),
+        table.schemaId(),
+        table.name(),
+        table.charset(),
+        table.collation(),
+        table.extra());
   }
 
   Table toDomain(TableEntity entity) {


### PR DESCRIPTION
## 개요

- ERD persistence entity 생성 패턴을 package-private 생성자와 mapper 내부 생성 방식으로 정리
- `SchemaEntity`, `TableEntity`, `ErdOperationLogEntity`, `SchemaCollaborationStateEntity`의 Lombok `@Builder` 제거
- 각 mapper에서 builder 대신 entity 생성자를 직접 호출하도록 변경

## 참고

- DB schema, domain model, API contract 변경 없음
- ERD memo 계열 timestamp 보존 구조는 이번 범위에서 제외

## 이슈

close #322