### PR TITLE
fix(#438): switch to schema after creation

### DIFF
--- a/apps/frontend/src/features/drawing/hooks/useSchemaMutations.ts
+++ b/apps/frontend/src/features/drawing/hooks/useSchemaMutations.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createSchema, changeSchemaName, deleteSchema } from '../api';
-import type { CreateSchemaRequest, ChangeSchemaNameRequest } from '../api';
+import type {
+  CreateSchemaRequest,
+  ChangeSchemaNameRequest,
+  SchemaResponse,
+} from '../api';
 import { collaborationStore } from '@/store/collaboration.store';
 import { operationHistoryStore } from '@/store/operation-history.store';
 import { erdKeys } from './query-keys';
@@ -15,6 +19,17 @@ export const useCreateSchema = (projectId: string) => {
       const syncStatus = syncCommittedRevision(result.data.id, result);
 
       if (syncStatus === 'stale') return;
+
+      queryClient.setQueryData<SchemaResponse[]>(
+        erdKeys.schemas(projectId),
+        (schemas) => {
+          if (!schemas) return [result.data];
+          if (schemas.some((schema) => schema.id === result.data.id)) {
+            return schemas;
+          }
+          return [...schemas, result.data];
+        },
+      );
 
       queryClient.invalidateQueries({
         queryKey: erdKeys.schemas(projectId),


### PR DESCRIPTION
## 개요

스키마 생성 시 새로 생성된 스키마로 이동하도록 쿼리 캐시에 추가

## 스크린샷

https://github.com/user-attachments/assets/c6fbf1e9-9ee7-4ff6-b1a2-1f95a39505d4


## 이슈


- close #438