### PR TITLE
refactor: polish frontend UI design

### DIFF
--- a/apps/frontend/src/assets/index.ts
+++ b/apps/frontend/src/assets/index.ts
@@ -4,9 +4,6 @@ import descriptionImg from './description.png';
 import aiAssistantImg from './ai-assistant.svg';
 import collaborationImg from './collaboration.svg';
 import useImg from './use.svg';
-import benefitsImg1 from './benefits1.png';
-import benefitsImg2 from './benefits2.png';
-import benefitsImg3 from './benefits3.png';
 
 export const landingPageImages = {
   hero: {
@@ -16,10 +13,5 @@ export const landingPageImages = {
     aiAssistant: aiAssistantImg,
     collaboration: collaborationImg,
     use: useImg,
-  },
-  benefits: {
-    faster: benefitsImg1,
-    accuracy: benefitsImg2,
-    teamwork: benefitsImg3,
   },
 };

--- a/apps/frontend/src/components/Avatar.tsx
+++ b/apps/frontend/src/components/Avatar.tsx
@@ -49,7 +49,10 @@ const AvatarRoot = ({
   <AvatarPrimitive.Root
     data-slot="avatar"
     ref={ref}
-    className={cn('relative flex shrink-0 overflow-hidden', className)}
+    className={cn(
+      'relative flex shrink-0 overflow-hidden bg-schemafy-secondary ring-1 ring-schemafy-glass-border',
+      className,
+    )}
     {...props}
   />
 );

--- a/apps/frontend/src/components/Button.tsx
+++ b/apps/frontend/src/components/Button.tsx
@@ -11,20 +11,23 @@ import { Link, type LinkProps } from '@tanstack/react-router';
 
 const buttonVariants = cva(
   `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg transition-all duration-200 
-  disabled:pointer-events-none disabled:opacity-50 active:scale-95 font-heading-xs focus:outline-none`,
+  disabled:pointer-events-none disabled:opacity-50 font-heading-xs schemafy-focus-ring`,
   {
     variants: {
       variant: {
-        default: 'bg-schemafy-button-bg text-schemafy-button-text',
-        secondary: 'bg-schemafy-secondary text-schemafy-text',
+        default:
+          'bg-schemafy-button-bg text-schemafy-button-text shadow-sm hover:shadow-md',
+        secondary:
+          'border border-schemafy-glass-border bg-schemafy-panel text-schemafy-text shadow-sm hover:bg-schemafy-secondary',
         destructive: 'bg-schemafy-destructive text-white',
-        outline: 'border border-schemafy-text text-schemafy-text',
-        none: 'text-schemafy-text font-overline-sm',
+        outline:
+          'border border-schemafy-glass-border bg-transparent text-schemafy-text hover:bg-schemafy-secondary',
+        none: 'text-schemafy-text font-overline-sm hover:text-schemafy-text',
       },
       size: {
-        dropdown: 'py-2 font-overline-xs min-w-[5rem]',
+        dropdown: 'h-9 px-3 font-overline-xs min-w-[5rem]',
         default: 'px-4 h-10',
-        sm: 'py-0.3 px-3 font-overline-xs min-w-[4rem]',
+        sm: 'h-9 px-3 font-overline-xs min-w-[4rem]',
         none: '',
       },
       fullWidth: {

--- a/apps/frontend/src/components/Dialog.tsx
+++ b/apps/frontend/src/components/Dialog.tsx
@@ -18,7 +18,7 @@ const DialogOverlay = ({
 }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>) => (
   <DialogPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/55 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -36,13 +36,13 @@ const DialogContent = ({
     <DialogPrimitive.Content
       aria-describedby={undefined}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-schemafy-bg p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'schemafy-strong-panel fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw_-_2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl p-5 text-schemafy-text duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:gap-5 sm:p-6',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="schemafy-icon-button schemafy-focus-ring absolute right-3.5 top-3.5 p-1.5 disabled:pointer-events-none sm:right-4 sm:top-4">
         <X className="h-4 w-4" color="var(--color-schemafy-dark-gray)" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -71,7 +71,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&>*]:w-full sm:[&>*]:w-auto',
       className,
     )}
     {...props}
@@ -84,10 +84,7 @@ const DialogTitle = ({
   ...props
 }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) => (
   <DialogPrimitive.Title
-    className={cn(
-      'text-schemafy-text font-overline-md leading-none tracking-tight',
-      className,
-    )}
+    className={cn('font-heading-sm leading-none text-schemafy-text', className)}
     {...props}
   />
 );

--- a/apps/frontend/src/components/DropDown.tsx
+++ b/apps/frontend/src/components/DropDown.tsx
@@ -3,7 +3,12 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 
 import { cn } from '@/lib/utils';
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenu = ({
+  modal = false,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) => (
+  <DropdownMenuPrimitive.Root modal={modal} {...props} />
+);
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
@@ -11,7 +16,7 @@ const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
 const DropdownMenuContent = ({
   className,
-  sideOffset = 30,
+  sideOffset = 12,
   ref,
   ...props
 }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
@@ -22,7 +27,7 @@ const DropdownMenuContent = ({
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 p-4 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[12rem] overflow-y-auto overflow-x-hidden rounded-[20px] bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        'schemafy-strong-panel z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[12rem] overflow-y-auto overflow-x-hidden rounded-2xl p-4 text-popover-foreground',
         className,
       )}
       {...props}

--- a/apps/frontend/src/components/EntityFormDialog.tsx
+++ b/apps/frontend/src/components/EntityFormDialog.tsx
@@ -64,7 +64,7 @@ export const EntityFormDialog = ({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={namePlaceholder}
-              className="w-full px-4 py-3 border border-schemafy-light-gray rounded-[12px] font-body-sm placeholder-schemafy-dark-gray bg-schemafy-bg focus:outline-none"
+              className="schemafy-input w-full px-4 py-3 font-body-sm"
             />
           </div>
           <div className="flex flex-col gap-1.5">
@@ -76,7 +76,7 @@ export const EntityFormDialog = ({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder={descriptionPlaceholder}
-              className="w-full px-4 py-3 border border-schemafy-light-gray rounded-[12px] font-body-sm placeholder-schemafy-dark-gray bg-schemafy-bg focus:outline-none"
+              className="schemafy-input w-full px-4 py-3 font-body-sm"
             />
           </div>
         </div>

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export const Footer = () => {
   return (
-    <footer className="w-full flex justify-center py-10">
-      <p className="self-stretch text-center text-schemafy-dark-gray">
+    <footer className="w-full px-4 py-10">
+      <p className="mx-auto w-full max-w-[1120px] border-t border-schemafy-glass-border/70 pt-6 text-center font-body-sm text-schemafy-dark-gray">
         © 2025 Schemafy. All rights reserved.
       </p>
     </footer>

--- a/apps/frontend/src/components/Header/CanvasHeader.tsx
+++ b/apps/frontend/src/components/Header/CanvasHeader.tsx
@@ -5,21 +5,33 @@ import { ShareContents } from './contents/ShareContents';
 import { SettingsContents } from './contents/SettingsContents';
 import { useLogout } from '@/features/auth';
 import { useParams } from '@tanstack/react-router';
+import { LogOut } from 'lucide-react';
 
 export const CanvasHeader = () => {
-  const { projectId } = useParams({ from: '/project/$projectId' });
+  const params = useParams({
+    strict: false,
+    shouldThrow: false,
+  });
+  const projectId = params?.projectId ?? '';
   const handleLogout = useLogout();
 
   return (
-    <div className="flex items-center gap-9">
+    <div className="flex min-w-0 items-center gap-1 sm:gap-4">
       <ExportContents />
       <ShareContents projectId={projectId} />
       <SettingsContents />
-      <Button variant={'secondary'} round onClick={handleLogout}>
-        Sign Out
+      <Button
+        variant={'secondary'}
+        round
+        onClick={handleLogout}
+        className="schemafy-header-button h-9 w-9 border border-schemafy-glass-border bg-schemafy-panel px-0 text-schemafy-text shadow-sm hover:bg-schemafy-secondary sm:h-10 sm:w-auto sm:px-4"
+        aria-label="Sign Out"
+      >
+        <LogOut className="h-4 w-4 sm:hidden" />
+        <span className="hidden sm:inline">Sign Out</span>
       </Button>
-      <div className="flex items-center gap-2">
-        <div className="flex items-center -space-x-3 *:data-[slot=avatar]:ring-background *:data-[slot=avatar]:ring-2 [&>*:nth-child(1)]:z-30 [&>*:nth-child(2)]:z-20 [&>*:nth-child(3)]:z-10">
+      <div className="hidden items-center gap-2 sm:flex">
+        <div className="flex items-center -space-x-3 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-schemafy-bg [&>*:nth-child(1)]:z-30 [&>*:nth-child(2)]:z-20 [&>*:nth-child(3)]:z-10">
           <Avatar src="https://picsum.photos/200/300?random=1" />
           <Avatar src="https://picsum.photos/100/300?random=1" deactivate />
           <Avatar src="https://picsum.photos/200/100?random=1" deactivate />

--- a/apps/frontend/src/components/Header/DashboardHeader.tsx
+++ b/apps/frontend/src/components/Header/DashboardHeader.tsx
@@ -3,34 +3,60 @@ import { Button, ButtonLink } from '../Button';
 import { Avatar } from '../Avatar';
 import { NotificationContents } from './contents/NotificationContents';
 import { useLogout } from '@/features/auth';
+import { FolderKanban, LogOut, Plus, Settings } from 'lucide-react';
 
 export const DashboardHeader = () => {
   const handleLogout = useLogout();
 
   return (
-    <div className="flex items-center justify-end gap-5 w-full">
-      <div className="flex items-center gap-9 ml-8">
-        <ButtonLink to="/workspace" variant={'none'} size={'none'}>
-          Projects
+    <div className="flex w-full min-w-0 items-center justify-end">
+      <div className="flex min-w-0 flex-nowrap items-center justify-end gap-1.5 pl-2 sm:min-w-max sm:gap-5">
+        <ButtonLink
+          to="/workspace"
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button schemafy-header-button flex h-9 w-9 shrink-0 items-center justify-center p-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2"
+          aria-label="Projects"
+        >
+          <FolderKanban className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Projects</span>
         </ButtonLink>
-        <Button variant={'none'} size={'none'}>
-          Settings
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button schemafy-header-button flex h-9 w-9 shrink-0 items-center justify-center p-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2"
+          aria-label="Settings"
+        >
+          <Settings className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Settings</span>
         </Button>
         <NotificationContents />
-      </div>
-      <div className="flex items-center gap-4">
-        <div className="flex gap-2">
-          <ButtonLink round to="/workspace">
-            New Project
-          </ButtonLink>
-          <Button variant={'secondary'} round onClick={handleLogout}>
-            Sign Out
-          </Button>
-        </div>
-        <span className="flex items-center font-body-sm text-schemafy-dark-gray">
+        <ButtonLink
+          round
+          to="/workspace"
+          className="schemafy-header-button h-9 w-9 shrink-0 px-0 sm:h-10 sm:w-auto sm:px-4"
+          aria-label="New Project"
+        >
+          <Plus className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">New Project</span>
+        </ButtonLink>
+        <Button
+          variant={'secondary'}
+          round
+          onClick={handleLogout}
+          className="schemafy-header-button h-9 w-9 shrink-0 px-0 sm:h-10 sm:w-auto sm:px-4"
+          aria-label="Sign Out"
+        >
+          <LogOut className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Sign Out</span>
+        </Button>
+        <span className="hidden items-center font-body-sm text-schemafy-dark-gray lg:flex">
           {authStore.user?.name}
         </span>
-        <Avatar src="https://picsum.photos/200/300?random=1" />
+        <Avatar
+          className="hidden ring-2 ring-schemafy-glass-border sm:flex"
+          src="https://picsum.photos/200/300?random=1"
+        />
       </div>
     </div>
   );

--- a/apps/frontend/src/components/Header/Header.tsx
+++ b/apps/frontend/src/components/Header/Header.tsx
@@ -22,24 +22,26 @@ export const Header = observer(
     }, [isCanvasPage, isAuthLoading, accessToken, user, isInitialized]);
 
     return (
-      <header className="w-full border-b border-schemafy-light-gray flex justify-center sticky">
+      <header className="sticky top-0 z-50 flex w-full justify-center border-b border-schemafy-glass-border bg-schemafy-panel/90 backdrop-blur-xl">
         <div
           className={cn(
             !isCanvasPage && 'max-w-[1280px]',
-            'w-full transition-all duration-200 z-50 flex items-center px-10 py-3 justify-between',
+            'z-50 flex w-full min-w-0 items-center justify-between gap-3 px-4 py-3 transition-all duration-200 sm:gap-4 sm:px-6 lg:px-10',
           )}
         >
-          <Link to="/">
-            <div className="flex items-center gap-4">
+          <Link to="/" className="shrink-0">
+            <div className="flex items-center gap-3">
               <img
                 src={logoImg}
                 alt="schemafy-logo"
-                className="w-4 h-4 dark:invert"
+                className="h-4 w-4 dark:invert"
               />
-              <h1 className="font-heading-md dark:invert">Schemafy</h1>
+              <h1 className="hidden font-heading-sm text-schemafy-text sm:block">
+                Schemafy
+              </h1>
             </div>
           </Link>
-          {contents}
+          <div className="flex min-w-0 flex-1 justify-end">{contents}</div>
         </div>
       </header>
     );

--- a/apps/frontend/src/components/Header/LandingHeader.tsx
+++ b/apps/frontend/src/components/Header/LandingHeader.tsx
@@ -2,11 +2,11 @@ import { ButtonLink } from '../Button';
 
 export const LandingHeader = () => {
   return (
-    <div className="flex items-center gap-2">
-      <ButtonLink round to="/signup">
+    <div className="flex min-w-0 items-center gap-2">
+      <ButtonLink round to="/signup" className="px-4">
         Get Started
       </ButtonLink>
-      <ButtonLink variant={'secondary'} round to="/signin">
+      <ButtonLink variant={'secondary'} round to="/signin" className="px-4">
         Sign In
       </ButtonLink>
     </div>

--- a/apps/frontend/src/components/Header/contents/ExportContents.tsx
+++ b/apps/frontend/src/components/Header/contents/ExportContents.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../DropDown';
 import { Button } from '../../Button';
 import { RadioGroup, RadioGroupItem } from '../../RadioGroup';
+import { Download } from 'lucide-react';
 
 export const ExportContents = () => {
   const [exportFormat, setExportFormat] = useState<string>('DDL');
@@ -13,11 +14,26 @@ export const ExportContents = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={'none'} size={'none'}>
-          Export
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button schemafy-header-button flex h-9 w-9 items-center justify-center p-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2"
+          aria-label="Export"
+        >
+          <Download className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Export</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="flex flex-col gap-2.5">
+      <DropdownMenuContent
+        align="end"
+        className="flex w-[calc(100vw-2rem)] min-w-0 flex-col gap-3 sm:w-auto"
+      >
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">Export as</span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Choose a format for the current schema.
+          </span>
+        </div>
         <RadioGroup value={exportFormat} onValueChange={setExportFormat}>
           <RadioGroupItem value={'DDL'}>DDL Script</RadioGroupItem>
           <RadioGroupItem value={'Mermaid'}>Mermaid Code</RadioGroupItem>

--- a/apps/frontend/src/components/Header/contents/ImportContents.tsx
+++ b/apps/frontend/src/components/Header/contents/ImportContents.tsx
@@ -10,11 +10,21 @@ export const ImportContents = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={'none'} size={'none'}>
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button px-3 py-2"
+        >
           Import
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="flex flex-col gap-2.5">
+      <DropdownMenuContent align="end" className="flex flex-col gap-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">Import</span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Upload schema resources.
+          </span>
+        </div>
         <div>
           <input
             type="file"
@@ -24,7 +34,7 @@ export const ImportContents = () => {
           />
           <label
             htmlFor="file-upload"
-            className="flex flex-col gap-2 px-2.5 py-4 items-center justify-center w-full border border-dashed border-schemafy-dark-gray font-caption-sm text-schemafy-dark-gray rounded-lg cursor-pointer hover:bg-schemafy-secondary transition-opacity"
+            className="flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-schemafy-glass-border px-2.5 py-5 font-caption-sm text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary"
           >
             <FilePlus size={16} />
             File Upload

--- a/apps/frontend/src/components/Header/contents/NotificationContents.tsx
+++ b/apps/frontend/src/components/Header/contents/NotificationContents.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../DropDown';
 import { useMyWorkspaceInvitations } from '@/features/workspace/hooks/useMyWorkspaceInvitations';
 import { useMyProjectInvitations } from '@/features/project/hooks/useMyProjectInvitations';
+import { cn } from '@/lib';
+import { Bell } from 'lucide-react';
 
 type UnifiedInvitation =
   | {
@@ -92,21 +94,45 @@ export const NotificationContents = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <div className="flex gap-0.5 items-center">
-          <Button variant={'none'} size={'none'}>
+        <div
+          className="schemafy-menu-button schemafy-header-button relative flex h-9 w-9 items-center justify-center p-0 sm:h-auto sm:w-auto sm:gap-1 sm:px-3 sm:py-2"
+          aria-label="Notifications"
+        >
+          <Bell className="h-4 w-4 sm:hidden" />
+          <Button
+            variant={'none'}
+            size={'none'}
+            className="pointer-events-none hidden sm:inline-flex"
+          >
             Notifications
           </Button>
-          <div className="rounded-full bg-schemafy-destructive w-5 h-5 flex items-center justify-center text-schemafy-button-text text-sm">
+          <div
+            className={cn(
+              'flex h-5 w-5 items-center justify-center rounded-full text-sm sm:static',
+              'absolute -right-1 -top-1',
+              unified.length > 0
+                ? 'bg-schemafy-destructive text-white'
+                : 'schemafy-badge text-schemafy-dark-gray',
+            )}
+          >
             {unified.length}
           </div>
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="flex flex-col gap-2.5 font-body-xs"
+        className="flex w-[calc(100vw-2rem)] min-w-0 flex-col gap-3 font-body-xs sm:w-auto sm:min-w-[22rem]"
       >
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">
+            Notifications
+          </span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Workspace and project invitations.
+          </span>
+        </div>
         {unified.length === 0 ? (
-          <p className="font-body-sm text-schemafy-dark-gray px-1">
+          <p className="rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/50 px-3 py-4 text-center font-body-sm text-schemafy-dark-gray">
             No new notifications
           </p>
         ) : (
@@ -143,7 +169,7 @@ const NotificationItem = ({
     invitation.type === 'workspace' ? 'Workspace' : 'Project';
 
   return (
-    <div className="flex gap-2.5 items-center">
+    <div className="flex items-center gap-3 rounded-xl border border-schemafy-glass-border bg-schemafy-panel px-3 py-2">
       <Avatar size={'dropdown'} src="https://picsum.photos/200/300?random=1" />
       <div className="min-w-0 max-w-[11.5rem] font-body-xs text-schemafy-text">
         <div className="break-words">

--- a/apps/frontend/src/components/Header/contents/SettingsContents.tsx
+++ b/apps/frontend/src/components/Header/contents/SettingsContents.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../DropDown';
 import { Button } from '../../Button';
 import { RadioGroup, RadioGroupItem } from '../../RadioGroup';
+import { Settings } from 'lucide-react';
 
 export const SettingsContents = () => {
   const { theme, setTheme } = useContext(ThemeProviderContext);
@@ -14,33 +15,47 @@ export const SettingsContents = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={'none'} size={'none'}>
-          Settings
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button schemafy-header-button flex h-9 w-9 items-center justify-center p-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2"
+          aria-label="Settings"
+        >
+          <Settings className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Settings</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="flex flex-col gap-2.5 font-body-xs"
+        className="flex w-[calc(100vw-2rem)] min-w-0 flex-col gap-3 font-body-xs sm:w-auto sm:min-w-[20rem]"
       >
-        <div className="flex justify-between gap-4 items-center">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">
+            Project settings
+          </span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Adjust display preferences for the editor.
+          </span>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <label className="font-overline-xs">Name</label>
           <input
             type="text"
             value={'Schemafy'}
             onChange={() => {}}
-            className="w-[12.5rem] placeholder:text-schemafy-dark-gray bg-secondary rounded-[10px] px-3 py-2"
+            className="schemafy-input w-full px-3 py-2 sm:w-[12.5rem]"
           />
         </div>
-        <div className="flex justify-between gap-4 items-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <label className="font-overline-xs">Description</label>
           <input
             type="text"
             value={'Schemafy ERD Diagram'}
             onChange={() => {}}
-            className="w-[12.5rem] placeholder:text-schemafy-dark-gray bg-secondary rounded-[10px] px-3 py-2"
+            className="schemafy-input w-full px-3 py-2 sm:w-[12.5rem]"
           />
         </div>
-        <div className="flex gap-4 items-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
           <label className="font-overline-xs">Theme</label>
           <RadioGroup
             value={theme}
@@ -55,7 +70,12 @@ export const SettingsContents = () => {
         <Button fullWidth size={'dropdown'}>
           Save
         </Button>
-        <Button fullWidth size={'dropdown'} variant={'outline'}>
+        <Button
+          fullWidth
+          size={'dropdown'}
+          variant={'outline'}
+          className="border-schemafy-destructive/40 text-schemafy-destructive hover:bg-schemafy-destructive/10"
+        >
           Delete Project
         </Button>
       </DropdownMenuContent>

--- a/apps/frontend/src/components/Header/contents/ShareContents.tsx
+++ b/apps/frontend/src/components/Header/contents/ShareContents.tsx
@@ -19,7 +19,8 @@ import { useProjectInvitations } from '@/features/project/hooks/useProjectInvita
 import { useProjectMembers } from '@/features/project/hooks/useProjectMembers';
 import { availableRoles } from '@/features/project/utils/role';
 import { authStore } from '@/store';
-import { toCapitalized } from '@/lib';
+import { cn, toCapitalized } from '@/lib';
+import { Share2 } from 'lucide-react';
 
 const RoleText = ({ role }: { role: string }) => {
   return (
@@ -33,16 +34,20 @@ const RoleSelect = ({
   value,
   onValueChange,
   userRole = 'ADMIN',
+  className,
 }: {
   value: string;
   onValueChange: (value: string) => void;
   userRole?: string;
+  className?: string;
 }) => {
   const roles = availableRoles(userRole);
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger className="w-[3.75rem] border-none font-body-xs">
+      <SelectTrigger
+        className={cn('h-9 w-[6.25rem] px-3 py-0 font-body-xs', className)}
+      >
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
@@ -98,30 +103,46 @@ export const ShareContents = ({ projectId }: { projectId: string }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={'none'} size={'none'}>
-          Share
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button schemafy-header-button flex h-9 w-9 items-center justify-center p-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2"
+          aria-label="Share"
+        >
+          <Share2 className="h-4 w-4 sm:hidden" />
+          <span className="hidden sm:inline">Share</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="flex flex-col gap-2.5 font-body-xs"
+        className="flex w-[calc(100vw-2rem)] min-w-0 flex-col gap-3 font-body-xs sm:w-auto sm:min-w-[24rem]"
       >
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">
+            Share project
+          </span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Manage project members and invitations.
+          </span>
+        </div>
         {canManageMembers && (
-          <div className="flex gap-4">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_6.75rem_5.5rem] sm:items-center">
             <input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-[12.5rem] placeholder:text-schemafy-dark-gray bg-secondary rounded-[10px] px-3 py-2"
+              className="schemafy-input h-10 min-w-0 px-3 py-0 font-body-xs"
               placeholder="schemafy@email.com"
             />
             <RoleSelect
               value={inviteRole}
               onValueChange={setInviteRole}
               userRole={currentUserRole}
+              className="h-10 w-full"
             />
             <Button
               size={'dropdown'}
+              className="h-10 w-full px-4"
               onClick={handleInvite}
               disabled={isCreatingInvitation}
             >
@@ -129,15 +150,17 @@ export const ShareContents = ({ projectId }: { projectId: string }) => {
             </Button>
           </div>
         )}
-        <p className="text-schemafy-dark-gray">Who has access</p>
+        <p className="font-overline-xs text-schemafy-dark-gray">
+          Who has access
+        </p>
         {orderedMembers.map((member) => (
           <div
             key={member.userId}
-            className="flex justify-between items-center"
+            className="flex items-center justify-between gap-3 rounded-xl px-2 py-1.5 hover:bg-schemafy-secondary"
           >
-            <div className="flex gap-2.5 items-center">
+            <div className="flex min-w-0 items-center gap-2.5">
               <Avatar size={'dropdown'} />
-              <p>{member.userName}</p>
+              <p className="truncate">{member.userName}</p>
             </div>
             {canManageMembers && member.userId !== currentUserId ? (
               <RoleSelect

--- a/apps/frontend/src/components/Header/contents/VersionContents.tsx
+++ b/apps/frontend/src/components/Header/contents/VersionContents.tsx
@@ -10,15 +10,27 @@ export const VersionsContents = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={'none'} size={'none'}>
+        <Button
+          variant={'none'}
+          size={'none'}
+          className="schemafy-menu-button px-3 py-2"
+        >
           Versions
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="flex flex-col gap-2.5 font-body-xs"
+        className="flex min-w-[18rem] flex-col gap-3 font-body-xs"
       >
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-overline-xs text-schemafy-text">
+            Version activity
+          </span>
+          <span className="font-caption-sm text-schemafy-dark-gray">
+            Recent schema updates.
+          </span>
+        </div>
+        <div className="flex flex-col gap-1.5 rounded-xl border border-schemafy-glass-border bg-schemafy-panel px-3 py-2">
           <div className="flex gap-2.5 items-center">
             <Avatar
               size={'dropdown'}

--- a/apps/frontend/src/components/InputField.tsx
+++ b/apps/frontend/src/components/InputField.tsx
@@ -30,8 +30,11 @@ export const InputField = memo(
     const inputId = useId();
 
     return (
-      <div className="flex flex-col flex-grow gap-1 py-3 px-4">
-        <label htmlFor={inputId} className="mb-1 font-overline-md">
+      <div className="flex flex-grow flex-col gap-1.5 py-2.5">
+        <label
+          htmlFor={inputId}
+          className="font-overline-xs text-schemafy-dark-gray"
+        >
           {label} {required && '*'}
         </label>
         <input
@@ -45,8 +48,8 @@ export const InputField = memo(
           onChange={onChange}
           onBlur={onBlur}
           className={cn(
-            'border border-schemafy-light-gray placeholder-schemafy-dark-gray font-body-md rounded-[12px] p-4',
-            disabled && 'text-schemafy-dark-gray bg-schemafy-secondary',
+            'schemafy-input px-4 py-3.5 font-body-sm',
+            disabled && 'bg-schemafy-secondary text-schemafy-dark-gray',
           )}
         />
         {error && (

--- a/apps/frontend/src/components/Landing/Benefits.tsx
+++ b/apps/frontend/src/components/Landing/Benefits.tsx
@@ -1,53 +1,212 @@
-import { landingPageImages } from '@/assets';
+import {
+  CheckCircle2,
+  GitBranch,
+  KeyRound,
+  MessageSquare,
+  ShieldCheck,
+  Sparkles,
+  UsersRound,
+} from 'lucide-react';
 
 const BENEFITS = [
   {
-    image: landingPageImages.benefits.faster,
-    title: 'Faster Design',
+    icon: Sparkles,
+    visual: 'diagram',
+    label: 'Modeling',
+    title: 'Canvas-first Editing',
     description:
-      'Design ERDs in minutes with AI assistance, saving you valuable time.',
+      'Build readable table maps with direct table, column, and relationship controls.',
   },
   {
-    image: landingPageImages.benefits.accuracy,
-    title: 'Improved Accuracy',
+    icon: ShieldCheck,
+    visual: 'quality',
+    label: 'Details',
+    title: 'Readable Structure',
     description:
-      'Reduce errors and ensure accuracy with AI-powered suggestions and validation.',
+      'Keep primary keys, foreign keys, nullable fields, and data types visible while you edit.',
   },
   {
-    image: landingPageImages.benefits.teamwork,
-    title: 'Enhanced Teamwork',
+    icon: UsersRound,
+    visual: 'team',
+    label: 'Review',
+    title: 'Project Sharing',
     description:
-      'Work together seamlessly with real-time collaboration features, boosting team productivity.',
+      'Use workspace roles, project sharing, and memos to keep design context in one place.',
   },
-];
+] as const;
+
+type BenefitVisual = (typeof BENEFITS)[number]['visual'];
+
+const DiagramPreview = () => (
+  <div className="relative h-44 overflow-hidden rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/45 p-4">
+    <div className="absolute inset-0 bg-[linear-gradient(90deg,hsl(var(--schemafy-light-gray)/0.22)_1px,transparent_1px),linear-gradient(180deg,hsl(var(--schemafy-light-gray)/0.22)_1px,transparent_1px)] bg-[size:24px_24px]" />
+    <div className="relative grid h-full grid-cols-[1fr_2.5rem_1fr] items-center gap-2">
+      <div className="rounded-xl border border-schemafy-glass-border bg-schemafy-panel p-3">
+        <div className="mb-2 flex items-center gap-2">
+          <KeyRound className="h-3.5 w-3.5 text-schemafy-yellow" />
+          <span className="font-caption-sm text-schemafy-text">users</span>
+        </div>
+        <div className="space-y-1.5">
+          <span className="block h-1.5 w-4/5 rounded-full bg-schemafy-dark-gray/45" />
+          <span className="block h-1.5 w-3/5 rounded-full bg-schemafy-dark-gray/30" />
+          <span className="block h-1.5 w-2/3 rounded-full bg-schemafy-dark-gray/30" />
+        </div>
+      </div>
+      <div className="flex items-center">
+        <span className="h-px flex-1 bg-schemafy-soft-blue/60" />
+        <span className="h-2 w-2 rounded-full border border-schemafy-soft-blue bg-schemafy-panel-strong" />
+        <span className="h-px flex-1 bg-schemafy-soft-blue/60" />
+      </div>
+      <div className="rounded-xl border border-schemafy-glass-border bg-schemafy-panel p-3">
+        <div className="mb-2 flex items-center gap-2">
+          <GitBranch className="h-3.5 w-3.5 text-schemafy-soft-blue" />
+          <span className="font-caption-sm text-schemafy-text">projects</span>
+        </div>
+        <div className="space-y-1.5">
+          <span className="block h-1.5 w-3/4 rounded-full bg-schemafy-dark-gray/45" />
+          <span className="block h-1.5 w-1/2 rounded-full bg-schemafy-dark-gray/30" />
+          <span className="block h-1.5 w-4/5 rounded-full bg-schemafy-dark-gray/30" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const QualityPreview = () => {
+  const rows = [
+    ['Primary keys', 'Visible'],
+    ['Foreign keys', 'Linked'],
+    ['Nullable fields', 'Shown'],
+  ];
+
+  return (
+    <div className="h-44 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/45 p-4">
+      <div className="flex h-full flex-col justify-between gap-2">
+        <div className="grid gap-1.5">
+          {rows.map(([label, value]) => (
+            <div
+              key={label}
+              className="flex items-center justify-between gap-3 rounded-lg border border-schemafy-glass-border bg-schemafy-panel px-3 py-1.5"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 shrink-0 text-schemafy-green" />
+                <span className="truncate font-caption-md text-schemafy-text">
+                  {label}
+                </span>
+              </div>
+              <span className="shrink-0 rounded-full bg-schemafy-green/12 px-2 py-0.5 font-caption-sm text-schemafy-green">
+                {value}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          {['PK', 'FK', 'NN'].map((item) => (
+            <span
+              key={item}
+              className="rounded-lg border border-schemafy-glass-border bg-schemafy-panel px-2 py-1 text-center font-code-xs text-schemafy-dark-gray"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TeamPreview = () => (
+  <div className="h-44 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/45 p-4">
+    <div className="flex h-full flex-col justify-between gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex -space-x-2">
+          {['AD', 'ME', 'VI'].map((name) => (
+            <span
+              key={name}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-schemafy-glass-border bg-schemafy-panel-strong font-caption-sm text-schemafy-text"
+            >
+              {name}
+            </span>
+          ))}
+        </div>
+        <span className="schemafy-badge px-2.5 py-1 font-caption-sm">
+          Shared
+        </span>
+      </div>
+      <div className="grid gap-2">
+        {['users.email noted', 'orders.user_id linked'].map((message) => (
+          <div
+            key={message}
+            className="flex items-center gap-2 rounded-lg border border-schemafy-glass-border bg-schemafy-panel px-3 py-2"
+          >
+            <MessageSquare className="h-4 w-4 shrink-0 text-schemafy-violet" />
+            <span className="truncate font-caption-md text-schemafy-text">
+              {message}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-schemafy-light-gray/55">
+        <span className="block h-full w-2/3 rounded-full bg-schemafy-soft-blue/75" />
+      </div>
+    </div>
+  </div>
+);
+
+const BenefitVisualPanel = ({ type }: { type: BenefitVisual }) => {
+  if (type === 'quality') {
+    return <QualityPreview />;
+  }
+
+  if (type === 'team') {
+    return <TeamPreview />;
+  }
+
+  return <DiagramPreview />;
+};
 
 export const Benefits = () => {
   return (
-    <section className="inline-flex flex-col px-4 py-10 gap-10">
-      <div className="flex flex-col justify-between">
-        <h2 className="font-display-md">Benefits</h2>
-        <p className="font-body-md">
-          Schemafy offers a range of features to help you design ERDs more
-          efficiently.
+    <section className="mx-auto flex w-full max-w-7xl flex-col gap-6 py-10">
+      <div className="flex max-w-2xl flex-col gap-3">
+        <span className="schemafy-badge w-fit px-3 py-1 font-caption-md">
+          Design system in practice
+        </span>
+        <h2 className="font-heading-xl text-schemafy-text">
+          Calm by default, detailed when needed
+        </h2>
+        <p className="font-body-md text-schemafy-dark-gray">
+          Schemafy keeps the lower-level database details legible without making
+          the workspace feel noisy.
         </p>
       </div>
-      <div className="flex flex-grow gap-3">
-        {BENEFITS.map((benefit) => (
-          <article
-            key={benefit.title}
-            className="flex flex-col gap-3 w-[300px]"
-          >
-            <img
-              src={benefit.image}
-              alt={benefit.title}
-              className="self-stretch"
-            />
-            <div className="flex flex-col">
-              <h3 className="font-heading-sm">{benefit.title}</h3>
-              <p className="font-body-sm">{benefit.description}</p>
-            </div>
-          </article>
-        ))}
+      <div className="grid gap-4 md:grid-cols-3">
+        {BENEFITS.map((benefit) => {
+          const Icon = benefit.icon;
+
+          return (
+            <article
+              key={benefit.title}
+              className="schemafy-subtle-card flex min-h-[23rem] flex-col gap-4 p-4"
+            >
+              <BenefitVisualPanel type={benefit.visual} />
+              <div className="flex flex-1 flex-col justify-between gap-4 px-1 pb-1">
+                <div className="flex flex-col gap-2.5">
+                  <div className="flex items-center gap-2 text-schemafy-dark-gray">
+                    <Icon className="h-4 w-4" />
+                    <span className="font-caption-md">{benefit.label}</span>
+                  </div>
+                  <h3 className="font-heading-sm text-schemafy-text">
+                    {benefit.title}
+                  </h3>
+                  <p className="font-body-sm text-schemafy-dark-gray">
+                    {benefit.description}
+                  </p>
+                </div>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/frontend/src/components/Landing/Description.tsx
+++ b/apps/frontend/src/components/Landing/Description.tsx
@@ -1,23 +1,99 @@
+import { CheckCircle2, Database, GitBranch, KeyRound } from 'lucide-react';
 import { landingPageImages } from '@/assets';
 import { Button } from '@/components';
 
+const HERO_METRICS = [
+  ['12', 'tables mapped'],
+  ['28', 'relations traced'],
+  ['4', 'memos attached'],
+] as const;
+
+const HERO_PREVIEW_ROWS = [
+  ['users.id', KeyRound, 'PK'],
+  ['projects.owner_id', GitBranch, 'FK'],
+  ['memo.comment', CheckCircle2, 'Note'],
+] as const;
+
 export const Description = () => {
   return (
-    <section className="self-stretch flex px-4 py-10 gap-8 flex-grow">
-      <img src={landingPageImages.hero.description} alt="description image" />
-      <div className="inline-flex flex-col justify-center items-start gap-8">
-        <div className="flex flex-col justify-start items-start gap-2">
-          <h2 className="font-display-lg">
-            Design ERDs with AI assistance and collaboration features
-          </h2>
-          <p className="font-body-md">
-            Schemafy is a tool for drawing ERDs with AI assistance and
-            collaboration features. It helps you design databases faster and
-            more efficiently.
-          </p>
+    <section className="relative my-6 flex min-h-[min(680px,calc(100vh-7rem))] overflow-hidden rounded-[1.5rem] border border-schemafy-glass-border shadow-[0_28px_80px_-56px_rgb(15_23_42/0.8)]">
+      <div className="absolute inset-0">
+        <img
+          src={landingPageImages.hero.description}
+          alt="Schemafy ERD canvas preview"
+          className="h-full w-full object-cover object-left-top"
+        />
+        <div className="absolute inset-0 bg-[linear-gradient(90deg,hsl(var(--schemafy-bg))_0%,hsl(var(--schemafy-bg)/0.92)_38%,hsl(var(--schemafy-bg)/0.42)_72%,transparent_100%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent_0%,hsl(var(--schemafy-canvas)/0.34)_100%)]" />
+      </div>
+      <div className="relative z-10 flex w-full flex-col justify-center gap-8 px-6 py-12 sm:px-10 lg:flex-row lg:items-center lg:justify-between lg:px-14">
+        <div className="flex max-w-3xl flex-col items-start gap-7">
+          <div className="flex flex-col items-start gap-4">
+            <span className="schemafy-badge px-3 py-1 font-caption-md">
+              Modern ERD design workspace
+            </span>
+            <h2 className="font-display-lg text-schemafy-text">Schemafy</h2>
+            <p className="max-w-2xl font-body-md text-schemafy-dark-gray">
+              Design ERDs with precision, collaboration, and less visual noise.
+              Keep database structure, schema decisions, and team feedback in
+              one calm canvas.
+            </p>
+          </div>
+          <div className="grid w-full max-w-xl gap-3 sm:grid-cols-3">
+            {HERO_METRICS.map(([value, label]) => (
+              <div
+                key={label}
+                className="rounded-2xl border border-schemafy-glass-border bg-schemafy-panel/70 px-4 py-3 backdrop-blur-xl"
+              >
+                <p className="font-heading-md text-schemafy-text">{value}</p>
+                <p className="font-caption-md text-schemafy-dark-gray">
+                  {label}
+                </p>
+              </div>
+            ))}
+          </div>
+          <Button className="px-6" round>
+            Get Started
+          </Button>
         </div>
-        <Button fullWidth>Get Started</Button>
+        <HeroSchemaPreview />
       </div>
     </section>
   );
 };
+
+const HeroSchemaPreview = () => (
+  <div className="hidden w-full max-w-md shrink-0 lg:block">
+    <div className="schemafy-strong-panel rounded-2xl p-4">
+      <div className="mb-4 flex items-center justify-between gap-4 border-b border-schemafy-glass-border pb-3">
+        <div className="flex items-center gap-2">
+          <Database className="h-4 w-4 text-schemafy-soft-blue" />
+          <span className="font-heading-xs text-schemafy-text">
+            Database map
+          </span>
+        </div>
+        <span className="rounded-full bg-schemafy-green/12 px-2.5 py-1 font-caption-sm text-schemafy-green">
+          Ready
+        </span>
+      </div>
+      <div className="grid gap-3">
+        {HERO_PREVIEW_ROWS.map(([label, Icon, badge]) => (
+          <div
+            key={label}
+            className="flex items-center justify-between gap-4 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/55 px-3 py-2.5"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <Icon className="h-4 w-4 shrink-0 text-schemafy-soft-blue" />
+              <span className="truncate font-caption-md text-schemafy-text">
+                {label}
+              </span>
+            </div>
+            <span className="rounded-full border border-schemafy-glass-border bg-schemafy-panel px-2 py-0.5 font-code-xs text-schemafy-dark-gray">
+              {badge}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);

--- a/apps/frontend/src/components/Landing/Features.tsx
+++ b/apps/frontend/src/components/Landing/Features.tsx
@@ -3,43 +3,64 @@ import { landingPageImages } from '@/assets';
 const FEATURES = [
   {
     icon: landingPageImages.features.aiAssistant,
-    title: 'AI Assistance',
+    title: 'Canvas Modeling',
     description:
-      'Get AI-powered suggestions for your ERDs, making the design process faster and more intuitive.',
+      'Create tables, columns, relationships, indexes, and constraints directly on the ERD canvas.',
   },
   {
     icon: landingPageImages.features.collaboration,
     title: 'Collaboration',
     description:
-      'Collaborate with your team in real-time, ensuring everyone is on the same page.',
+      'Share projects with workspace members and discuss schema decisions with memos.',
   },
   {
     icon: landingPageImages.features.use,
     title: 'Easy to Use',
     description:
-      "Schemafy's intuitive interface makes it easy to create and manage your ERDs, even without prior experience.",
+      'Keep project, workspace, and schema editing controls close to the task at hand.',
   },
 ];
 
 export const Features = () => {
   return (
-    <section className="inline-flex flex-col px-4 py-10 gap-10">
-      <div className="flex flex-col justify-between">
-        <h2 className="font-display-md">Features</h2>
-        <p className="font-body-md">
-          Experience the benefits of using Schemafy for your ERD design needs.
+    <section className="mx-auto flex w-full max-w-7xl flex-col gap-6 py-10">
+      <div className="flex max-w-2xl flex-col gap-3">
+        <span className="schemafy-badge w-fit px-3 py-1 font-caption-md">
+          Product workflow
+        </span>
+        <h2 className="font-heading-xl text-schemafy-text">
+          Designed for ERD work
+        </h2>
+        <p className="font-body-md text-schemafy-dark-gray">
+          Every surface stays close to the modeling task, from entity structure
+          to review feedback.
         </p>
       </div>
-      <div className="flex flex-grow gap-3">
-        {FEATURES.map((feature) => (
+      <div className="grid gap-4 md:grid-cols-3">
+        {FEATURES.map((feature, index) => (
           <article
             key={feature.title}
-            className="flex flex-col rounded-lg border border-schemafy-light-gray gap-3 w-[300px] p-4"
+            className="schemafy-subtle-card flex min-h-44 flex-col justify-between gap-5 p-5"
           >
-            <img src={feature.icon} alt={feature.title} className="w-6 h-6" />
-            <div className="flex flex-col gap-2">
-              <h3 className="font-heading-sm">{feature.title}</h3>
-              <p className="font-body-sm">{feature.description}</p>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-schemafy-glass-border bg-schemafy-secondary">
+                <img
+                  src={feature.icon}
+                  alt={feature.title}
+                  className="h-5 w-5"
+                />
+              </div>
+              <span className="font-code-xs text-schemafy-dark-gray">
+                0{index + 1}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2.5">
+              <h3 className="font-heading-sm text-schemafy-text">
+                {feature.title}
+              </h3>
+              <p className="font-body-sm text-schemafy-dark-gray">
+                {feature.description}
+              </p>
             </div>
           </article>
         ))}

--- a/apps/frontend/src/components/Landing/ReadyToUse.tsx
+++ b/apps/frontend/src/components/Landing/ReadyToUse.tsx
@@ -1,15 +1,68 @@
+import { ArrowRight, CheckCircle2, Database, GitBranch } from 'lucide-react';
 import { Button } from '@/components';
 
 export const ReadyToUse = () => {
   return (
-    <section className="flex flex-col py-20 px-10 gap-8 items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <h3 className="font-display-md">Ready to design your next database?</h3>
-        <p className="font-body-md">
-          Start using Schemafy today and experience the difference.
-        </p>
+    <section className="mx-auto w-full max-w-7xl py-10">
+      <div className="schemafy-page-card overflow-hidden px-5 py-8 sm:px-8 lg:px-10">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex max-w-2xl flex-col items-start gap-4">
+            <span className="schemafy-badge px-3 py-1 font-caption-md">
+              Ready workspace
+            </span>
+            <h3 className="font-heading-xl text-schemafy-text">
+              Ready to design your next database?
+            </h3>
+            <p className="font-body-md text-schemafy-dark-gray">
+              Start from a clear canvas with schema structure, relationship
+              context, and team feedback already shaped for database designers.
+            </p>
+            <Button className="px-6" round>
+              Get Started
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="schemafy-strong-panel w-full max-w-md rounded-2xl p-4">
+            <div className="flex items-center justify-between gap-4 border-b border-schemafy-glass-border pb-3">
+              <div className="flex items-center gap-2">
+                <Database className="h-4 w-4 text-schemafy-soft-blue" />
+                <span className="font-heading-xs text-schemafy-text">
+                  Design Preview
+                </span>
+              </div>
+              <span className="rounded-full bg-schemafy-green/12 px-2.5 py-1 font-caption-sm text-schemafy-green">
+                Ready
+              </span>
+            </div>
+            <div className="grid gap-3 pt-4">
+              {[
+                ['12 tables', 'Entity map is organized'],
+                ['28 relations', 'Foreign keys are visible'],
+                ['4 memos', 'Comments are attached'],
+              ].map(([metric, detail], index) => (
+                <div
+                  key={metric}
+                  className="flex items-center justify-between gap-4 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/55 px-3 py-2.5"
+                >
+                  <div className="flex min-w-0 items-center gap-2">
+                    {index === 1 ? (
+                      <GitBranch className="h-4 w-4 shrink-0 text-schemafy-violet" />
+                    ) : (
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-schemafy-green" />
+                    )}
+                    <span className="truncate font-caption-md text-schemafy-text">
+                      {metric}
+                    </span>
+                  </div>
+                  <span className="truncate text-right font-caption-sm text-schemafy-dark-gray">
+                    {detail}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
       </div>
-      <Button>Get Started</Button>
     </section>
   );
 };

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -11,12 +11,17 @@ export const Layout = () => {
   const isWorkspacePage = pathname.startsWith('/workspace');
 
   return (
-    <div className="layout flex flex-col min-h-screen bg-schemafy-bg w-full items-center">
+    <div
+      className={cn(
+        'layout flex min-h-screen w-full flex-col items-center bg-schemafy-bg',
+        !isCanvasPage && 'schemafy-page-gradient',
+      )}
+    >
       <Header isCanvasPage={isCanvasPage} />
       <main
         className={cn(
           'flex-grow w-full flex',
-          !isCanvasPage && !isWorkspacePage && 'max-w-[960px]',
+          !isCanvasPage && !isWorkspacePage && 'max-w-[1120px]',
         )}
       >
         <Outlet />

--- a/apps/frontend/src/components/ListItem.tsx
+++ b/apps/frontend/src/components/ListItem.tsx
@@ -27,23 +27,34 @@ export const ListItem = ({
   };
 
   return (
-    <li className="flex flex-col gap-1 items-center px-3 py-2 w-full rounded-[10px] border border-schemafy-light-gray">
-      <div className="flex w-full justify-between items-center gap-4">
-        <p className="font-overline-sm text-schemafy-text flex gap-1 items-center">
-          {name}
-          <Edit size={12} onClick={handleEditClick} cursor="pointer" />
-          <Trash
-            size={12}
-            color="var(--color-schemafy-destructive)"
-            onClick={handleDeleteClick}
-            cursor="pointer"
-          />
-        </p>
+    <li className="schemafy-subtle-card flex w-full flex-col items-center gap-2 px-4 py-3">
+      <div className="flex w-full items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate font-overline-sm text-schemafy-text">{name}</p>
+          <div className="flex shrink-0 gap-1">
+            <button
+              type="button"
+              title="Edit"
+              onClick={handleEditClick}
+              className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center"
+            >
+              <Edit size={12} />
+            </button>
+            <button
+              type="button"
+              title="Delete"
+              onClick={handleDeleteClick}
+              className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center hover:text-schemafy-destructive"
+            >
+              <Trash size={12} />
+            </button>
+          </div>
+        </div>
         <Tag count={count} isEntity={!!description} />
       </div>
-      <div className="flex w-full justify-between items-center font-body-xs text-schemafy-dark-gray">
-        <p>{description}</p>
-        {date && <p>Last Updated: {formatDate(date)}</p>}
+      <div className="flex w-full flex-wrap items-center justify-between gap-x-4 gap-y-1 font-body-xs text-schemafy-dark-gray">
+        <p className="min-w-0 break-words">{description}</p>
+        {date && <p className="shrink-0">Last Updated: {formatDate(date)}</p>}
       </div>
     </li>
   );
@@ -51,7 +62,7 @@ export const ListItem = ({
 
 const Tag = ({ count, isEntity }: { count: number; isEntity: boolean }) => {
   return (
-    <div className="px-2 py-0.5 flex bg-schemafy-light-gray font-body-xs text-schemafy-dark-gray rounded-full">
+    <div className="schemafy-badge flex px-2 py-0.5 font-body-xs">
       {count} {isEntity ? 'fields' : 'entities'}
     </div>
   );

--- a/apps/frontend/src/components/Pagination.tsx
+++ b/apps/frontend/src/components/Pagination.tsx
@@ -26,14 +26,14 @@ export const Pagination = ({
       <button
         onClick={() => onPageChange(1)}
         disabled={currentPage === 1}
-        className="w-8 h-8 flex items-center justify-center rounded-full font-body-md text-schemafy-dark-gray disabled:opacity-30 hover:bg-schemafy-secondary transition-colors"
+        className="schemafy-focus-ring flex h-8 w-8 items-center justify-center rounded-full font-body-md text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary disabled:opacity-30"
       >
         «
       </button>
       <button
         onClick={() => onPageChange(Math.max(1, currentPage - 1))}
         disabled={currentPage === 1}
-        className="w-8 h-8 flex items-center justify-center rounded-full font-body-md text-schemafy-dark-gray disabled:opacity-30 hover:bg-schemafy-secondary transition-colors"
+        className="schemafy-focus-ring flex h-8 w-8 items-center justify-center rounded-full font-body-md text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary disabled:opacity-30"
       >
         ‹
       </button>
@@ -45,7 +45,7 @@ export const Pagination = ({
             'w-8 h-8 flex items-center justify-center rounded-full font-body-sm transition-colors',
             currentPage === page
               ? 'bg-schemafy-button-bg text-schemafy-button-text'
-              : 'text-schemafy-dark-gray hover:bg-schemafy-secondary',
+              : 'schemafy-focus-ring text-schemafy-dark-gray hover:bg-schemafy-secondary',
           )}
         >
           {page}
@@ -54,14 +54,14 @@ export const Pagination = ({
       <button
         onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
         disabled={currentPage >= totalPages || totalPages === 0}
-        className="w-8 h-8 flex items-center justify-center rounded-full font-body-md text-schemafy-dark-gray disabled:opacity-30 hover:bg-schemafy-secondary transition-colors"
+        className="schemafy-focus-ring flex h-8 w-8 items-center justify-center rounded-full font-body-md text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary disabled:opacity-30"
       >
         ›
       </button>
       <button
         onClick={() => onPageChange(totalPages)}
         disabled={currentPage >= totalPages || totalPages === 0}
-        className="w-8 h-8 flex items-center justify-center rounded-full font-body-md text-schemafy-dark-gray disabled:opacity-30 hover:bg-schemafy-secondary transition-colors"
+        className="schemafy-focus-ring flex h-8 w-8 items-center justify-center rounded-full font-body-md text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary disabled:opacity-30"
       >
         »
       </button>

--- a/apps/frontend/src/components/RadioGroup.tsx
+++ b/apps/frontend/src/components/RadioGroup.tsx
@@ -62,7 +62,8 @@ export const RadioGroupItem = ({
   return (
     <div
       className={cn(
-        'flex items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-schemafy-text font-body-xs cursor-pointer select-none outline-none transition-colors',
+        'schemafy-focus-ring flex cursor-pointer select-none items-center gap-2 rounded-xl py-2 pl-2.5 pr-3 font-body-xs text-schemafy-text outline-none transition-colors hover:bg-schemafy-secondary',
+        isChecked && 'bg-schemafy-secondary text-schemafy-text',
         disabled && 'opacity-50 pointer-events-none cursor-not-allowed',
         className,
       )}
@@ -79,7 +80,7 @@ export const RadioGroupItem = ({
         checked={isChecked}
         onChange={() => {}}
         disabled={disabled}
-        className="w-2.5 h-2.5 accent-schemafy-text cursor-pointer pointer-events-none"
+        className="h-2.5 w-2.5 cursor-pointer accent-schemafy-soft-blue pointer-events-none"
         tabIndex={-1}
       />
       {children}

--- a/apps/frontend/src/components/Select.tsx
+++ b/apps/frontend/src/components/Select.tsx
@@ -21,7 +21,7 @@ const SelectTrigger = ({
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex w-full items-center justify-between rounded-md border border-input bg-schemafy-bg text-schemafy-text ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'schemafy-input flex w-full items-center justify-between px-3 py-2 text-schemafy-text data-[placeholder]:text-schemafy-dark-gray disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
@@ -87,7 +87,7 @@ const SelectContent = ({
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-schemafy-light-gray bg-schemafy-bg text-schemafy-text shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        'schemafy-strong-panel relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-2xl p-1 text-schemafy-text data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -120,7 +120,10 @@ const SelectLabel = ({
 }) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pl-2 pr-2 text-sm font-semibold', className)}
+    className={cn(
+      'py-1.5 pl-2 pr-2 font-overline-xs text-schemafy-dark-gray',
+      className,
+    )}
     {...props}
   />
 );
@@ -137,7 +140,7 @@ const SelectItem = ({
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center justify-between rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center justify-between rounded-xl py-2 pl-3 pr-8 font-body-xs outline-none transition-colors focus:bg-schemafy-secondary focus:text-schemafy-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/apps/frontend/src/features/auth/components/SignInForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignInForm.tsx
@@ -89,7 +89,7 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
   return (
     <form
       noValidate
-      className="flex flex-col w-full max-w-[480px]"
+      className="flex w-full max-w-[480px] flex-col gap-2"
       onSubmit={handleSubmit}
     >
       {formFields.map((field) => (
@@ -109,18 +109,20 @@ export const SignInForm = ({ oauthError }: SignInFormProps) => {
       <Button
         variant={'none'}
         size={'none'}
-        className="text-schemafy-dark-gray pt-1 pb-3"
+        className="schemafy-menu-button ml-auto px-3 py-1.5 text-schemafy-dark-gray"
       >
         Forgot Password?
       </Button>
-      <div className="flex flex-col w-full gap-6 py-3">
+      <div className="flex w-full flex-col gap-3 pt-3">
         <Button type="submit" disabled={isSubmitting} round fullWidth>
           {isSubmitting ? 'Sign In...' : 'Sign In'}
         </Button>
         {oauthError && (
-          <p className="text-red-600 text-sm mt-2 mb-2">{oauthError}</p>
+          <p className="rounded-xl border border-schemafy-destructive/30 bg-schemafy-destructive/10 px-3 py-2 font-body-sm text-schemafy-destructive">
+            {oauthError}
+          </p>
         )}
-        <div className="flex flex-col w-full gap-2">
+        <div className="flex w-full flex-col gap-2">
           <Button
             type="button"
             variant={'secondary'}

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -107,7 +107,7 @@ export const SignUpForm = () => {
   return (
     <form
       noValidate
-      className="flex flex-col w-full max-w-[480px]"
+      className="flex w-full max-w-[480px] flex-col gap-2"
       onSubmit={handleSubmit}
     >
       {formFields.map((field) => (
@@ -124,9 +124,11 @@ export const SignUpForm = () => {
           onBlur={handleBlur}
         />
       ))}
-      <Button type="submit" disabled={isSubmitting} className="my-4" round>
-        {isSubmitting ? 'Creating...' : 'Create Account'}
-      </Button>
+      <div className="pt-3">
+        <Button type="submit" disabled={isSubmitting} round fullWidth>
+          {isSubmitting ? 'Creating...' : 'Create Account'}
+        </Button>
+      </div>
     </form>
   );
 };

--- a/apps/frontend/src/features/collaboration/components/ChatBubble.tsx
+++ b/apps/frontend/src/features/collaboration/components/ChatBubble.tsx
@@ -19,19 +19,21 @@ export const ChatBubble = ({ message, color }: ChatBubbleProps) => {
 
   return (
     <div
-      className="mt-0.5 overflow-hidden rounded-lg shadow-lg max-w-xs"
-      style={{ opacity, transition: 'opacity 500ms' }}
+      className="schemafy-strong-panel mt-1 max-w-xs overflow-hidden rounded-2xl"
+      style={{
+        opacity,
+        transition: 'opacity 500ms',
+        borderColor: 'hsl(var(--schemafy-glass-border))',
+        boxShadow: `0 0 0 1px ${color}22, var(--shadow-schemafy-float)`,
+      }}
     >
       <div
-        className="px-1.5 py-0.5 font-overline-xs text-white whitespace-nowrap"
+        className="whitespace-nowrap px-2.5 py-1 font-overline-xs text-white"
         style={{ backgroundColor: color }}
       >
         {message.userName}
       </div>
-      <div
-        className="px-1.5 py-0.5 font-body-sm text-white break-words"
-        style={{ backgroundColor: color }}
-      >
+      <div className="break-words px-2.5 py-1.5 font-body-sm text-schemafy-text">
         {message.content}
       </div>
     </div>

--- a/apps/frontend/src/features/collaboration/components/ChatInput.tsx
+++ b/apps/frontend/src/features/collaboration/components/ChatInput.tsx
@@ -56,7 +56,7 @@ const ChatMessageItem = ({ message }: ChatMessageItemProps) => {
 
   return (
     <div
-      className="h-8 px-2.5 flex items-center font-body-sm text-white"
+      className="flex min-h-8 items-center rounded-xl px-3 py-1.5 font-body-sm text-schemafy-text"
       style={{
         animation: `chat-message-in ${ANIMATION_MS}ms ease forwards`,
         opacity: isFadingOut ? 0 : 1,
@@ -120,19 +120,17 @@ export const ChatInput = observer(
           }}
         >
           <div
-            className="relative rounded-lg shadow-lg min-w-[180px] max-w-xs"
+            className="schemafy-strong-panel relative min-w-[220px] max-w-sm rounded-2xl p-1.5"
             style={{
-              backgroundColor: color,
+              borderColor: 'hsl(var(--schemafy-glass-border))',
+              boxShadow: `0 0 0 1px ${color}22, var(--shadow-schemafy-float)`,
               animation: isExiting
                 ? `chat-container-out ${CONTAINER_ANIMATION_MS}ms ease forwards`
                 : `chat-container-in ${CONTAINER_ANIMATION_MS}ms ease forwards`,
             }}
           >
             {hasMessages && (
-              <div
-                className="absolute bottom-full left-0 right-0 mb-1 flex flex-col overflow-hidden rounded-lg shadow-lg"
-                style={{ backgroundColor: color, maxHeight: '6rem' }}
-              >
+              <div className="schemafy-strong-panel absolute bottom-full left-0 right-0 mb-2 flex max-h-24 flex-col overflow-hidden rounded-2xl p-1">
                 {activeMessages.map((activeMessage) => (
                   <ChatMessageItem
                     key={activeMessage.messageId}
@@ -148,7 +146,7 @@ export const ChatInput = observer(
               onChange={(e) => setMessage(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="메시지 입력..."
-              className="w-full px-2.5 py-1.5 bg-transparent text-white placeholder:text-white/50 font-body-sm focus:outline-none rounded-lg"
+              className="schemafy-focus-ring w-full rounded-xl bg-schemafy-secondary/85 px-3 py-2 font-body-sm text-schemafy-text placeholder:text-schemafy-dark-gray"
               maxLength={500}
             />
           </div>

--- a/apps/frontend/src/features/drawing/components/Column/EditModeColumn.tsx
+++ b/apps/frontend/src/features/drawing/components/Column/EditModeColumn.tsx
@@ -46,7 +46,7 @@ export const EditModeColumn = ({
       : 'Remove Column';
 
   return (
-    <div className="p-2 space-y-2 text-schemafy-text">
+    <div className="space-y-2.5 px-3.5 py-3 text-schemafy-text">
       <div className="flex items-center gap-2">
         <DragHandle
           columnId={column.id}
@@ -58,7 +58,7 @@ export const EditModeColumn = ({
           type="text"
           value={localName}
           onChange={(e) => handleNameChange(e.target.value)}
-          className="flex-1 px-2 py-1 text-sm border border-schemafy-light-gray rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="schemafy-focus-ring flex-1 rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2.5 py-1.5 text-sm text-schemafy-text"
           placeholder="Column name"
         />
 
@@ -72,15 +72,16 @@ export const EditModeColumn = ({
         />
 
         <button
+          type="button"
           onClick={() => {
             onPendingChange?.(false);
             onRemoveColumn(column.id);
           }}
           disabled={isDeleteDisabled}
-          className={`p-1 rounded flex-shrink-0 ${
+          className={`schemafy-focus-ring flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-colors ${
             isDeleteDisabled
-              ? 'text-schemafy-dark-gray cursor-not-allowed'
-              : 'text-schemafy-destructive hover:bg-red-100'
+              ? 'cursor-not-allowed text-schemafy-dark-gray'
+              : 'text-schemafy-destructive hover:bg-schemafy-destructive/10'
           }`}
           title={deleteTitle}
         >
@@ -99,7 +100,7 @@ const DragHandle = ({ columnId, onDragStart, onDragEnd }: DragHandleProps) => {
       draggable
       onDragStart={(e) => onDragStart(e, columnId)}
       onDragEnd={onDragEnd}
-      className="cursor-move p-1 hover:bg-schemafy-light-gray rounded transition-colors nodrag"
+      className="nodrag flex h-8 w-8 cursor-move items-center justify-center rounded-lg transition-colors hover:bg-schemafy-secondary"
       title="Drag to reorder"
       onMouseDown={(e) => e.stopPropagation()}
     >
@@ -113,7 +114,7 @@ const ColumnConstraints = ({
   onUpdateColumn,
 }: ColumnConstraintsProps) => {
   return (
-    <div className="flex flex-wrap gap-3 text-xs ml-4">
+    <div className="ml-10 flex flex-wrap gap-x-4 gap-y-2 text-xs">
       {CONSTRAINTS.filter(({ visible }) => visible).map(
         ({ key, label, color }) => {
           const isFkDisabled = column.isForeignKey && key === 'isPrimaryKey';
@@ -126,7 +127,7 @@ const ColumnConstraints = ({
           return (
             <label
               key={key}
-              className={`flex items-center gap-1 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+              className={`flex items-center gap-1.5 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
               title={title}
             >
               <input
@@ -136,7 +137,7 @@ const ColumnConstraints = ({
                   onUpdateColumn(column.id, key, e.target.checked)
                 }
                 disabled={isDisabled}
-                className="w-3 h-3"
+                className="h-3.5 w-3.5"
               />
               <span className={`${color} font-medium`}>{label}</span>
             </label>

--- a/apps/frontend/src/features/drawing/components/Column/TypeSelector.tsx
+++ b/apps/frontend/src/features/drawing/components/Column/TypeSelector.tsx
@@ -127,14 +127,14 @@ export const TypeSelector = ({
   };
 
   return (
-    <div className="flex items-center gap-0.5 text-xs font-mono">
+    <div className="flex items-center gap-1 text-xs font-mono">
       <Select
         onValueChange={handleTypeSelect}
         value={displayType}
         disabled={disabled}
       >
         <SelectTrigger
-          className="text-xs font-mono px-2 py-1 border border-schemafy-light-gray rounded focus:outline-none w-auto min-w-[5rem] [&>span]:line-clamp-none"
+          className="schemafy-focus-ring w-auto min-w-[5.5rem] rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2.5 py-1.5 font-mono text-xs [&>span]:line-clamp-none"
           title={
             disabled
               ? 'Cannot change the type of a foreign key column'
@@ -184,7 +184,7 @@ export const TypeSelector = ({
                               param.valueType,
                             )
                           }
-                          className={`${isStringArray ? 'w-28' : 'w-8'} text-center bg-transparent border-b border-schemafy-dark-gray focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
+                          className={`${isStringArray ? 'w-28' : 'w-8'} border-b border-schemafy-dark-gray bg-transparent text-center focus:border-schemafy-soft-blue focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none`}
                         />
                       </Fragment>
                     );

--- a/apps/frontend/src/features/drawing/components/Column/ViewModeColumn.tsx
+++ b/apps/frontend/src/features/drawing/components/Column/ViewModeColumn.tsx
@@ -3,18 +3,20 @@ import { formatTypeDisplay } from './utils';
 
 export const ViewModeColumn = ({ column }: ViewModeColumnProps) => {
   const nameClassName = column.isPrimaryKey
-    ? 'font-bold text-schemafy-yellow'
+    ? 'font-semibold text-schemafy-text'
     : column.isForeignKey
-      ? 'font-bold text-schemafy-green'
+      ? 'font-semibold text-schemafy-text'
       : 'text-schemafy-text';
 
   return (
-    <div className="p-2 text-schemafy-text">
+    <div className="px-3 py-2.5 text-schemafy-text">
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <span className={`text-sm ${nameClassName}`}>{column.name}</span>
-          <span className="text-xs text-schemafy-dark-gray font-mono">
-            ({formatTypeDisplay(column.type, column.typeArguments)})
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className={`truncate text-sm ${nameClassName}`}>
+            {column.name}
+          </span>
+          <span className="shrink-0 rounded-md bg-schemafy-secondary/60 px-1.5 py-0.5 font-mono text-[11px] text-schemafy-dark-gray">
+            {formatTypeDisplay(column.type, column.typeArguments)}
           </span>
         </div>
 
@@ -26,18 +28,26 @@ export const ViewModeColumn = ({ column }: ViewModeColumnProps) => {
 
 const ColumnBadges = ({ column }: ColumnBadgesProps) => {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex shrink-0 items-center gap-1">
       {column.isPrimaryKey && (
-        <span className="text-xs text-schemafy-yellow font-medium">PK</span>
+        <span className="rounded-full border border-schemafy-yellow/20 bg-schemafy-yellow/10 px-1.5 py-0.5 text-[10px] font-semibold text-schemafy-yellow">
+          PK
+        </span>
       )}
       {column.isForeignKey && (
-        <span className="text-xs text-schemafy-green font-medium">FK</span>
+        <span className="rounded-full border border-schemafy-green/20 bg-schemafy-green/10 px-1.5 py-0.5 text-[10px] font-semibold text-schemafy-green">
+          FK
+        </span>
       )}
       {!column.isPrimaryKey && column.isNotNull && (
-        <span className="text-xs text-schemafy-destructive font-medium">*</span>
+        <span className="rounded-full border border-schemafy-destructive/20 bg-schemafy-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-schemafy-destructive">
+          NN
+        </span>
       )}
       {!column.isPrimaryKey && column.isUnique && (
-        <span className="text-xs text-schemafy-blue font-medium">UQ</span>
+        <span className="rounded-full border border-schemafy-blue/20 bg-schemafy-blue/10 px-1.5 py-0.5 text-[10px] font-semibold text-schemafy-blue">
+          UQ
+        </span>
       )}
     </div>
   );

--- a/apps/frontend/src/features/drawing/components/Column/index.tsx
+++ b/apps/frontend/src/features/drawing/components/Column/index.tsx
@@ -19,10 +19,10 @@ export const ColumnRow = ({
   onPendingChange,
 }: ColumnRowProps) => {
   const rowClassName = `
-    border-b border-schemafy-light-gray last:border-b-0 transition-colors duration-200
-    ${isEditMode ? 'hover:bg-schemafy-secondary' : ''}
+    border-b border-schemafy-glass-border/45 last:border-b-0 transition-colors duration-200
+    ${isEditMode ? 'hover:bg-schemafy-secondary/70' : 'hover:bg-schemafy-secondary/35'}
     ${draggedItem === column.id ? 'opacity-50' : ''}
-    ${dragOverItem === column.id ? 'bg-blue-50 border-blue-200' : ''}
+    ${dragOverItem === column.id ? 'border-schemafy-soft-blue bg-schemafy-soft-blue/10' : ''}
   `.trim();
 
   return (

--- a/apps/frontend/src/features/drawing/components/ConstraintRow.tsx
+++ b/apps/frontend/src/features/drawing/components/ConstraintRow.tsx
@@ -55,16 +55,18 @@ export const ViewModeConstraint = ({
   const kindLabel = constraint.kind === 'PRIMARY_KEY' ? 'PK' : 'UNIQUE';
 
   return (
-    <div className="p-2">
-      <div className="text-xs text-schemafy-dark-gray font-mono">
-        <span className="text-schemafy-text font-medium">
+    <div className="px-3 py-2.5">
+      <div className="font-mono text-xs text-schemafy-dark-gray">
+        <span className="font-medium text-schemafy-text">
           {constraint.name}
         </span>{' '}
-        <span className="text-schemafy-purple">{kindLabel}</span>
+        <span className="schemafy-badge px-1.5 py-0.5 text-[10px]">
+          {kindLabel}
+        </span>
         {columnsStr && (
           <>
             {' '}
-            (<span className="text-schemafy-blue">{columnsStr}</span>)
+            (<span className="text-schemafy-dark-gray">{columnsStr}</span>)
           </>
         )}
       </div>
@@ -87,7 +89,7 @@ export const EditModeConstraint = ({
   const kindLabel = constraint.kind === 'PRIMARY_KEY' ? 'PK' : 'UNIQUE';
 
   return (
-    <div className="p-2 space-y-2 bg-schemafy-bg text-schemafy-text">
+    <div className="space-y-2.5 bg-schemafy-bg px-3.5 py-3 text-schemafy-text">
       <div className="flex items-center gap-2">
         <EditableNameInput
           name={constraint.name}
@@ -96,7 +98,7 @@ export const EditModeConstraint = ({
             onUpdateConstraintName(constraint.id, newName)
           }
         />
-        <span className="text-xs font-mono text-schemafy-dark-gray">
+        <span className="schemafy-badge px-2 py-1 font-mono text-xs">
           {kindLabel}
         </span>
 
@@ -106,7 +108,7 @@ export const EditModeConstraint = ({
         />
       </div>
 
-      <div className="ml-4 space-y-1">
+      <div className="ml-4 space-y-2">
         {constraint.columns
           .sort((a, b) => a.seqNo - b.seqNo)
           .map((constraintColumn) => (

--- a/apps/frontend/src/features/drawing/components/ConstraintSection.tsx
+++ b/apps/frontend/src/features/drawing/components/ConstraintSection.tsx
@@ -25,15 +25,16 @@ export const ConstraintSection = ({
   };
 
   return (
-    <div className="border-t-2 border-schemafy-table-header-bg">
-      <div className="bg-schemafy-dark-gray-40 p-2 flex items-center justify-between">
-        <span className="text-xs font-medium text-schemafy-text">
+    <div className="border-t border-schemafy-glass-border/55">
+      <div className="flex items-center justify-between bg-schemafy-secondary/35 px-3 py-1.5">
+        <span className="font-overline-xs text-schemafy-dark-gray">
           CONSTRAINTS
         </span>
         {isEditMode && (
           <button
+            type="button"
             onClick={handleCreateConstraint}
-            className="p-0.5 text-schemafy-text hover:bg-schemafy-dark-gray-40 rounded transition-colors"
+            className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
             title="Add UNIQUE constraint"
           >
             <Plus size={14} />
@@ -43,7 +44,7 @@ export const ConstraintSection = ({
 
       <div>
         {filteredConstraints.length === 0 ? (
-          <div className="p-2 text-center text-schemafy-dark-gray text-xs">
+          <div className="px-3 py-2.5 text-center text-xs text-schemafy-dark-gray">
             No constraints defined
           </div>
         ) : (

--- a/apps/frontend/src/features/drawing/components/CustomConnectionLine.tsx
+++ b/apps/frontend/src/features/drawing/components/CustomConnectionLine.tsx
@@ -48,9 +48,10 @@ export const CustomConnectionLine = ({
     <g>
       <path
         fill="none"
-        stroke="var(--color-schemafy-dark-gray)"
-        strokeWidth={2}
-        strokeOpacity={0.5}
+        stroke="var(--color-schemafy-soft-blue)"
+        strokeWidth={1.5}
+        strokeOpacity={0.68}
+        strokeLinecap="round"
         d={path}
       />
     </g>

--- a/apps/frontend/src/features/drawing/components/CustomControls.tsx
+++ b/apps/frontend/src/features/drawing/components/CustomControls.tsx
@@ -4,17 +4,20 @@ import { Plus, Minus } from 'lucide-react';
 export const CustomControls = () => {
   const { zoomIn, zoomOut } = useReactFlow();
   return (
-    <div
-      style={{
-        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-      }}
-      className="z-10 bg-schemafy-bg text-schemafy-text px-5 py-3 gap-5 flex rounded-lg absolute bottom-45 right-4"
-    >
-      <button onClick={() => zoomIn()}>
-        <Plus size={16} color="var(--color-schemafy-dark-gray)" />
+    <div className="schemafy-canvas-controls schemafy-canvas-panel absolute right-6 bottom-45 z-10 flex h-12 items-center gap-1 rounded-2xl px-2 text-schemafy-text">
+      <button
+        onClick={() => zoomIn()}
+        className="schemafy-focus-ring flex h-9 w-9 items-center justify-center rounded-xl text-schemafy-dark-gray transition-all duration-200 hover:bg-schemafy-secondary hover:text-schemafy-text"
+        aria-label="Zoom in"
+      >
+        <Plus size={16} />
       </button>
-      <button onClick={() => zoomOut()}>
-        <Minus size={16} color="var(--color-schemafy-dark-gray)" />
+      <button
+        onClick={() => zoomOut()}
+        className="schemafy-focus-ring flex h-9 w-9 items-center justify-center rounded-xl text-schemafy-dark-gray transition-all duration-200 hover:bg-schemafy-secondary hover:text-schemafy-text"
+        aria-label="Zoom out"
+      >
+        <Minus size={16} />
       </button>
     </div>
   );

--- a/apps/frontend/src/features/drawing/components/CustomSmoothStepEdge.tsx
+++ b/apps/frontend/src/features/drawing/components/CustomSmoothStepEdge.tsx
@@ -6,7 +6,6 @@ import {
   type EdgeProps,
   type Edge,
 } from '@xyflow/react';
-import { Move } from 'lucide-react';
 import type { Point, EdgeData } from '../types';
 import { useControlPointDrag } from '../hooks/useControlPointDrag';
 import {
@@ -31,6 +30,7 @@ export const CustomSmoothStepEdge = memo(
     label,
     labelStyle,
     data,
+    selected,
   }: EdgeProps<Edge<EdgeData>>) => {
     const sourceNode = useInternalNode(source);
     const targetNode = useInternalNode(target);
@@ -65,6 +65,7 @@ export const CustomSmoothStepEdge = memo(
 
     const renderHandle = (position: Point, handleIndex: number) => {
       const isActive = draggingHandle === handleIndex;
+      const isVisible = selected || isActive;
 
       return (
         <EdgeLabelRenderer key={handleIndex}>
@@ -72,30 +73,32 @@ export const CustomSmoothStepEdge = memo(
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${position.x}px, ${position.y}px)`,
-              pointerEvents: 'all',
+              pointerEvents: isVisible ? 'all' : 'none',
               cursor: isActive ? 'grabbing' : 'grab',
               zIndex: 1000,
+              opacity: isVisible ? 1 : 0,
             }}
             className="nodrag nopan"
             onMouseDown={handleMouseDown(handleIndex)}
           >
             <div
               className={`
-              bg-schemafy-bg border-2 rounded-full shadow-lg transition-all
-              ${isActive ? 'scale-125 border-schemafy-blue' : 'border-schemafy-dark-gray hover:border-schemafy-blue'}
+              schemafy-edge-control schemafy-canvas-panel rounded-full transition-all
+              ${isActive ? 'scale-110 border-schemafy-soft-blue text-schemafy-soft-blue' : 'text-schemafy-dark-gray hover:border-schemafy-soft-blue hover:text-schemafy-soft-blue'}
             `}
               style={{
-                width: 20,
-                height: 20,
+                width: 16,
+                height: 16,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
               }}
             >
-              <Move
-                size={10}
+              <span
                 className={
-                  isActive ? 'text-schemafy-blue' : 'text-schemafy-dark-gray'
+                  isActive
+                    ? 'h-1.5 w-1.5 rounded-full bg-schemafy-soft-blue'
+                    : 'h-1.5 w-1.5 rounded-full bg-schemafy-dark-gray'
                 }
               />
             </div>
@@ -113,14 +116,22 @@ export const CustomSmoothStepEdge = memo(
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelPosition.x}px, ${labelPosition.y}px)`,
-              fontSize: labelStyle?.fontSize || 12,
-              fontWeight: labelStyle?.fontWeight || 'bold',
+              fontSize: labelStyle?.fontSize || 11,
+              fontWeight: labelStyle?.fontWeight || 600,
               color: labelStyle?.color || 'var(--color-schemafy-dark-gray)',
               pointerEvents: 'none',
-              background: 'var(--color-schemafy-bg)',
-              padding: '2px 6px',
-              borderRadius: '4px',
+              background: 'hsl(var(--schemafy-panel))',
+              border: '1px solid hsl(var(--schemafy-glass-border))',
+              boxShadow: 'none',
+              backdropFilter: 'none',
+              padding: '2px 7px',
+              borderRadius: '999px',
+              lineHeight: 1.35,
               marginTop: '-25px',
+              maxWidth: 140,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
             {label}

--- a/apps/frontend/src/features/drawing/components/EditableRowBase.tsx
+++ b/apps/frontend/src/features/drawing/components/EditableRowBase.tsx
@@ -37,7 +37,7 @@ export function EditableRowBase<T extends BaseItem>({
   renderEditMode,
 }: EditableRowBaseProps<T>) {
   return (
-    <div className="border-b border-schemafy-light-gray last:border-b-0">
+    <div className="border-b border-schemafy-glass-border/60 last:border-b-0">
       {isEditMode
         ? renderEditMode(item, tableColumns)
         : renderViewMode(item, tableColumns)}
@@ -72,7 +72,7 @@ export const EditableNameInput = ({
       type="text"
       value={localName}
       onChange={(e) => handleChange(e.target.value)}
-      className="flex-1 px-2 py-1 text-sm border border-schemafy-light-gray rounded focus:outline-none"
+      className="schemafy-focus-ring flex-1 rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2.5 py-1.5 text-sm text-schemafy-text placeholder:text-schemafy-dark-gray"
       placeholder={placeholder}
     />
   );
@@ -86,8 +86,9 @@ interface DeleteButtonProps {
 export const DeleteButton = ({ onDelete, title }: DeleteButtonProps) => {
   return (
     <button
+      type="button"
       onClick={onDelete}
-      className="p-1 rounded flex-shrink-0 text-schemafy-destructive hover:bg-red-100"
+      className="schemafy-focus-ring flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-schemafy-destructive transition-colors hover:bg-schemafy-destructive/10"
       title={title}
     >
       <Trash2 size={12} />
@@ -107,12 +108,13 @@ export const ColumnItem = ({
   additionalControls,
 }: ColumnItemProps) => {
   return (
-    <div className="flex items-center gap-2 text-xs">
-      <span className="text-schemafy-blue font-medium">{columnName}</span>
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-schemafy-glass-border/70 bg-schemafy-secondary/45 px-2.5 py-1.5 text-xs">
+      <span className="font-medium text-schemafy-blue">{columnName}</span>
       {additionalControls}
       <button
+        type="button"
         onClick={onRemove}
-        className="p-0.5 rounded"
+        className="schemafy-focus-ring flex h-6 w-6 items-center justify-center rounded-md text-schemafy-dark-gray transition-colors hover:bg-schemafy-destructive/10 hover:text-schemafy-destructive"
         title="Remove column"
       >
         <X size={12} />
@@ -142,7 +144,7 @@ export const AddColumnSelector = ({
         }}
         value=""
       >
-        <SelectTrigger className="w-[8rem] text-xs font-mono py-1 px-1.5 border border-schemafy-light-gray rounded focus:outline-none">
+        <SelectTrigger className="schemafy-focus-ring w-[8.5rem] rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2 py-1.5 font-mono text-xs">
           <SelectValue placeholder="+ Add column" />
         </SelectTrigger>
         <SelectContent popover="auto">

--- a/apps/frontend/src/features/drawing/components/FloatingButtons.tsx
+++ b/apps/frontend/src/features/drawing/components/FloatingButtons.tsx
@@ -13,9 +13,9 @@ export const FloatingButtons = ({
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="fixed bottom-4 left-4 z-50">
+    <div className="fixed bottom-4 left-4 z-50 sm:bottom-6 sm:left-6">
       <div
-        className="flex flex-col items-center bg-schemafy-bg rounded-full shadow-lg p-2 transition-all duration-300 ease-in-out"
+        className="schemafy-canvas-panel flex min-h-12 min-w-12 flex-col items-center rounded-full p-1.5 transition-all duration-300 ease-in-out"
         onMouseEnter={() => setIsExpanded(true)}
         onMouseLeave={() => setIsExpanded(false)}
       >
@@ -28,10 +28,10 @@ export const FloatingButtons = ({
         >
           <button
             onClick={onHelpClick}
-            className="flex items-center justify-center p-4 rounded-full hover:bg-schemafy-secondary transition-colors"
+            className="schemafy-focus-ring flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-schemafy-secondary"
           >
             <HelpCircle
-              size={24}
+              size={18}
               color={
                 isShortcutPanelOpen
                   ? 'var(--color-schemafy-text)'
@@ -40,13 +40,13 @@ export const FloatingButtons = ({
             />
           </button>
 
-          <button className="flex items-center justify-center p-4 rounded-full hover:bg-schemafy-secondary transition-colors">
-            <Bot size={24} color="var(--color-schemafy-dark-gray)" />
+          <button className="schemafy-focus-ring flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-schemafy-secondary">
+            <Bot size={18} color="var(--color-schemafy-dark-gray)" />
           </button>
         </div>
 
-        <button className="flex items-center p-4 rounded-full justify-center">
-          <Ellipsis size={24} color="var(--color-schemafy-dark-gray)" />
+        <button className="schemafy-focus-ring flex h-9 w-9 items-center justify-center rounded-full">
+          <Ellipsis size={18} color="var(--color-schemafy-dark-gray)" />
         </button>
       </div>
     </div>

--- a/apps/frontend/src/features/drawing/components/IndexRow.tsx
+++ b/apps/frontend/src/features/drawing/components/IndexRow.tsx
@@ -65,13 +65,13 @@ export const ViewModeIndex = ({ index, tableColumns }: ViewModeIndexProps) => {
     .join(', ');
 
   return (
-    <div className="p-2">
-      <div className="text-xs text-schemafy-dark-gray font-mono">
-        <span className="text-schemafy-text font-medium">{index.name}</span>
+    <div className="px-3 py-2.5">
+      <div className="font-mono text-xs text-schemafy-dark-gray">
+        <span className="font-medium text-schemafy-text">{index.name}</span>
         {columnsStr && (
           <>
             {' '}
-            (<span className="text-schemafy-blue">{columnsStr}</span>)
+            (<span className="text-schemafy-dark-gray">{columnsStr}</span>)
           </>
         )}
         {index.type !== 'BTREE' && (
@@ -82,7 +82,7 @@ export const ViewModeIndex = ({ index, tableColumns }: ViewModeIndexProps) => {
         )}
       </div>
       {index.comment && (
-        <div className="text-xs text-dark-gray mt-1 ml-4">
+        <div className="ml-4 mt-1 text-xs text-schemafy-dark-gray">
           /* {index.comment} */
         </div>
       )}
@@ -105,7 +105,7 @@ export const EditModeIndex = ({
   );
 
   return (
-    <div className="p-2 space-y-2 bg-schemafy-bg text-schemafy-text">
+    <div className="space-y-2.5 bg-schemafy-bg px-3.5 py-3 text-schemafy-text">
       <div className="flex items-center gap-2">
         <EditableNameInput
           name={index.name}
@@ -118,7 +118,7 @@ export const EditModeIndex = ({
           }
           value={index.type}
         >
-          <SelectTrigger className="text-xs font-mono p-1.5 border border-schemafy-light-gray rounded focus:outline-none w-[6rem]">
+          <SelectTrigger className="schemafy-focus-ring w-[6.5rem] rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2 py-1.5 font-mono text-xs">
             <SelectValue placeholder={index.type} />
           </SelectTrigger>
           <SelectContent popover="auto">
@@ -138,7 +138,7 @@ export const EditModeIndex = ({
         />
       </div>
 
-      <div className="ml-4 space-y-1">
+      <div className="ml-4 space-y-2">
         {index.columns
           .sort((a, b) => a.seqNo - b.seqNo)
           .map((indexColumn) => (
@@ -153,7 +153,7 @@ export const EditModeIndex = ({
                   }
                   value={indexColumn.sortDir}
                 >
-                  <SelectTrigger className="text-xs font-mono py-1 px-1.5 border border-schemafy-light-gray rounded focus:outline-none w-[6rem]">
+                  <SelectTrigger className="schemafy-focus-ring w-[6.5rem] rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/60 px-2 py-1.5 font-mono text-xs">
                     <SelectValue placeholder={indexColumn.sortDir} />
                   </SelectTrigger>
                   <SelectContent popover="auto">

--- a/apps/frontend/src/features/drawing/components/IndexSection.tsx
+++ b/apps/frontend/src/features/drawing/components/IndexSection.tsx
@@ -19,13 +19,16 @@ export const IndexSection = ({
   }
 
   return (
-    <div className="border-t-2 border-schemafy-table-header-bg">
-      <div className="bg-schemafy-dark-gray-40 p-2 flex items-center justify-between">
-        <span className="text-xs font-medium text-schemafy-text">INDEXES</span>
+    <div className="border-t border-schemafy-glass-border/55">
+      <div className="flex items-center justify-between bg-schemafy-secondary/35 px-3 py-1.5">
+        <span className="font-overline-xs text-schemafy-dark-gray">
+          INDEXES
+        </span>
         {isEditMode && (
           <button
+            type="button"
             onClick={onCreateIndex}
-            className="p-0.5 text-schemafy-text hover:bg-schemafy-dark-gray-40 rounded transition-colors"
+            className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
             title="Add Index"
           >
             <Plus size={14} />
@@ -35,7 +38,7 @@ export const IndexSection = ({
 
       <div>
         {indexes.length === 0 ? (
-          <div className="p-2 text-center text-schemafy-dark-gray text-xs">
+          <div className="px-3 py-2.5 text-center text-xs text-schemafy-dark-gray">
             No indexes defined
           </div>
         ) : (

--- a/apps/frontend/src/features/drawing/components/ReactFlowCanvas.tsx
+++ b/apps/frontend/src/features/drawing/components/ReactFlowCanvas.tsx
@@ -33,17 +33,25 @@ const EDGE_TYPES = {
   customSmoothStep: CustomSmoothStepEdge,
 };
 
-const MINIMAP_NODE_COLOR = () => 'var(--color-schemafy-text)';
+const MINIMAP_NODE_COLOR = () => 'var(--color-schemafy-soft-blue)';
+
+// React Flow uses style width/height for SVG viewBox math, so these must be numeric CSS pixels.
+const MINIMAP_WIDTH = 176;
+const MINIMAP_HEIGHT = 112;
 
 const MINIMAP_STYLE = {
-  backgroundColor: 'var(--color-schemafy-bg-80)',
-  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-  borderRadius: '10px',
+  backgroundColor: 'hsl(var(--schemafy-panel))',
+  border: '1px solid hsl(var(--schemafy-glass-border))',
+  boxShadow: 'none',
+  borderRadius: '14px',
   overflow: 'hidden' as const,
   position: 'absolute' as const,
-  bottom: '1rem',
-  right: '1rem',
+  bottom: '1.5rem',
+  right: '1.5rem',
   margin: '0',
+  backdropFilter: 'none',
+  width: MINIMAP_WIDTH,
+  height: MINIMAP_HEIGHT,
 };
 
 const PRO_OPTIONS = { hideAttribution: true };
@@ -165,7 +173,7 @@ const ReactFlowCanvasComponent = ({
   return (
     <div
       style={{ cursor: activeTool === 'hand' ? 'grab' : 'default' }}
-      className="w-full h-full"
+      className="h-full w-full bg-schemafy-canvas"
     >
       <RelationshipMarker />
       <ReactFlow
@@ -192,10 +200,11 @@ const ReactFlowCanvasComponent = ({
         fitView={false}
         minZoom={0.1}
         maxZoom={4}
+        className="schemafy-scrollbar"
       >
         <MiniMap
           nodeColor={MINIMAP_NODE_COLOR}
-          maskColor="var(--color-schemafy-bg-80)"
+          maskColor="hsl(var(--schemafy-bg) / 0.16)"
           style={MINIMAP_STYLE}
           zoomable
           pannable
@@ -204,6 +213,8 @@ const ReactFlowCanvasComponent = ({
         <Background
           variant={BackgroundVariant.Dots}
           color="var(--color-schemafy-canvas-dot)"
+          gap={20}
+          size={1}
         />
         {activeTool === 'table' && <TablePreview />}
         {activeTool === 'memo' && <MemoPreview />}

--- a/apps/frontend/src/features/drawing/components/RelationshipEditor.tsx
+++ b/apps/frontend/src/features/drawing/components/RelationshipEditor.tsx
@@ -109,7 +109,7 @@ export const RelationshipEditor = ({
   };
 
   return (
-    <div className="absolute top-4 left-4 z-10 bg-schemafy-bg p-3 rounded-lg shadow-md border border-schemafy-light-gray space-y-3">
+    <div className="schemafy-canvas-panel absolute top-6 left-6 z-10 space-y-3 rounded-2xl p-4">
       <div className="text-sm font-medium text-schemafy-text">
         Edit Relationship
       </div>
@@ -120,7 +120,7 @@ export const RelationshipEditor = ({
           type="text"
           value={localName}
           onChange={(e) => setLocalName(e.target.value)}
-          className="w-full px-2 py-1 text-sm bg-schemafy-secondary border border-schemafy-light-gray rounded text-schemafy-text focus:outline-none focus:ring-1 focus:ring-schemafy-text"
+          className="schemafy-focus-ring w-full rounded-lg border border-schemafy-glass-border bg-schemafy-secondary/70 px-3 py-2 text-sm text-schemafy-text"
           placeholder="Relationship name"
         />
       </div>

--- a/apps/frontend/src/features/drawing/components/RelationshipSelector.tsx
+++ b/apps/frontend/src/features/drawing/components/RelationshipSelector.tsx
@@ -22,7 +22,7 @@ export const RelationshipSelector = ({
   };
 
   return (
-    <div className="bg-schemafy-bg border border-schemafy-light-gray rounded-lg p-3 min-w-48">
+    <div className="schemafy-canvas-panel min-w-48 rounded-2xl p-3">
       <div className="text-xs font-medium text-schemafy-text mb-3">
         Relationship Type
       </div>
@@ -33,8 +33,8 @@ export const RelationshipSelector = ({
             key={key}
             onClick={() => handleTypeChange(key as RelationshipType)}
             className={`
-              w-full text-left px-2 py-1 rounded text-sm text-schemafy-text hover:bg-schemafy-secondary flex items-center gap-2
-              ${config.type === key ? 'bg-schemafy-secondary border border-schemafy-light-gray' : ''}
+              schemafy-focus-ring flex w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-sm text-schemafy-text transition-colors hover:bg-schemafy-secondary
+              ${config.type === key ? 'border border-schemafy-soft-blue/30 bg-schemafy-soft-blue/10' : ''}
             `}
           >
             <LinePreview isNonIdentifying={config.isNonIdentifying} />
@@ -43,14 +43,14 @@ export const RelationshipSelector = ({
         ))}
       </div>
 
-      <div className="border-t border-schemafy-light-gray my-3"></div>
+      <div className="my-3 border-t border-schemafy-glass-border"></div>
 
       <label className="flex items-center gap-2 cursor-pointer text-sm mb-3">
         <input
           type="checkbox"
           checked={config.isNonIdentifying}
           onChange={(e) => handleNonIdentifyingChange(e.target.checked)}
-          className="w-4 h-4 text-schemafy-text rounded focus:ring-schemafy-text"
+          className="h-4 w-4 rounded text-schemafy-soft-blue focus:ring-schemafy-focus"
         />
         <span className="text-schemafy-text">Non-Identifying</span>
       </label>
@@ -59,7 +59,7 @@ export const RelationshipSelector = ({
 };
 
 const LinePreview = ({ isNonIdentifying }: { isNonIdentifying: boolean }) => {
-  const color = 'var(--color-schemafy-dark-gray)';
+  const color = 'var(--color-schemafy-edge)';
 
   return (
     <svg width="24" height="4" className="flex-shrink-0">

--- a/apps/frontend/src/features/drawing/components/SchemaInput.tsx
+++ b/apps/frontend/src/features/drawing/components/SchemaInput.tsx
@@ -34,7 +34,7 @@ export const SchemaInput = ({
   const isValid = validateSchemaName(value);
 
   return (
-    <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+    <div className="flex flex-col gap-2.5" onClick={(e) => e.stopPropagation()}>
       <input
         type="text"
         value={value}
@@ -42,14 +42,20 @@ export const SchemaInput = ({
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         maxLength={SCHEMA_NAME_CONSTRAINTS.MAX_LENGTH}
-        className="p-3 font-body-xs w-full rounded-[8px] bg-schemafy-secondary text-schemafy-text focus:outline-none focus:ring-1 focus:ring-schemafy-primary"
+        className="schemafy-input h-10 w-full px-3 font-body-xs"
         autoFocus
       />
       <div className="flex w-full gap-2">
-        <Button onClick={onSave} disabled={!isValid} size="dropdown" fullWidth>
+        <Button
+          onClick={onSave}
+          disabled={!isValid}
+          size="dropdown"
+          fullWidth
+          className="h-10"
+        >
           {saveLabel}
         </Button>
-        <Button onClick={onCancel} size="dropdown" fullWidth>
+        <Button onClick={onCancel} size="dropdown" fullWidth className="h-10">
           {cancelLabel}
         </Button>
       </div>

--- a/apps/frontend/src/features/drawing/components/SchemaListItem.tsx
+++ b/apps/frontend/src/features/drawing/components/SchemaListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from '@/components';
+import { Edit, Trash } from 'lucide-react';
 import { SchemaInput } from './SchemaInput';
 
 interface SchemaListItemProps {
@@ -41,13 +41,48 @@ export const SchemaListItem = ({
   }
 
   return (
-    <div onClick={() => onSelect(schema.id)} className="cursor-pointer">
-      <ListItem
-        name={schema.name}
-        count={tableCount}
-        onChange={() => onStartEdit(schema.id, schema.name)}
-        onDelete={() => onDelete(schema.id)}
-      />
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(schema.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(schema.id);
+        }
+      }}
+      className="schemafy-focus-ring flex h-11 w-full items-center gap-2.5 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/35 px-3.5 text-left transition-colors hover:bg-schemafy-secondary/60"
+    >
+      <span className="min-w-0 flex-1 truncate font-overline-sm text-schemafy-text">
+        {schema.name}
+      </span>
+      <span className="flex shrink-0 items-center gap-1.5">
+        <button
+          type="button"
+          title="Edit"
+          onClick={(event) => {
+            event.stopPropagation();
+            onStartEdit(schema.id, schema.name);
+          }}
+          className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center"
+        >
+          <Edit size={12} />
+        </button>
+        <button
+          type="button"
+          title="Delete"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(schema.id);
+          }}
+          className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center hover:text-schemafy-destructive"
+        >
+          <Trash size={12} />
+        </button>
+      </span>
+      <span className="schemafy-badge shrink-0 px-2.5 py-0.5 font-body-xs">
+        {tableCount} entities
+      </span>
     </div>
   );
 };

--- a/apps/frontend/src/features/drawing/components/SchemaSelector.tsx
+++ b/apps/frontend/src/features/drawing/components/SchemaSelector.tsx
@@ -106,31 +106,26 @@ export const SchemaSelector = memo(() => {
   };
 
   return (
-    <div className="flex flex-col items-center bg-schemafy-bg rounded-[10px] shadow-lg p-4 transition-all duration-300 ease-in-out">
-      <div className="w-full flex justify-between">
-        <label className="text-sm font-heading-base text-schemafy-text">
+    <div className="schemafy-canvas-panel flex min-w-[14rem] flex-col rounded-2xl p-3 transition-all duration-300 ease-in-out">
+      <button
+        type="button"
+        className="schemafy-focus-ring flex h-10 w-full items-center justify-between gap-3 rounded-xl px-3 text-left transition-colors hover:bg-schemafy-secondary"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-label={isExpanded ? 'Collapse schemas' : 'Expand schemas'}
+      >
+        <span className="min-w-0 truncate text-sm font-heading-base text-schemafy-text">
           {isExpanded ? 'Schemas' : selectedSchemaName}
-        </label>
+        </span>
         {isExpanded ? (
-          <ChevronUp
-            size={16}
-            color="var(--color-schemafy-dark-gray)"
-            onClick={() => setIsExpanded(false)}
-            cursor="pointer"
-          />
+          <ChevronUp size={16} className="shrink-0 text-schemafy-dark-gray" />
         ) : (
-          <ChevronDown
-            size={16}
-            color="var(--color-schemafy-dark-gray)"
-            onClick={() => setIsExpanded(true)}
-            cursor="pointer"
-          />
+          <ChevronDown size={16} className="shrink-0 text-schemafy-dark-gray" />
         )}
-      </div>
+      </button>
       <div
-        className={`flex flex-col gap-2 transition-all duration-300 ${
+        className={`flex w-full flex-col gap-2.5 transition-all duration-300 ${
           isExpanded
-            ? 'mt-4 h-auto opacity-100'
+            ? 'mt-3 h-auto opacity-100'
             : 'h-0 opacity-0 overflow-hidden'
         }`}
       >
@@ -163,7 +158,12 @@ export const SchemaSelector = memo(() => {
             saveLabel="Add"
           />
         ) : (
-          <Button onClick={() => setIsAdding(true)} fullWidth size="dropdown">
+          <Button
+            onClick={() => setIsAdding(true)}
+            fullWidth
+            size="dropdown"
+            className="h-10"
+          >
             New Schema
           </Button>
         )}

--- a/apps/frontend/src/features/drawing/components/SearchEntitiesDialog.tsx
+++ b/apps/frontend/src/features/drawing/components/SearchEntitiesDialog.tsx
@@ -57,17 +57,17 @@ export const SearchEntitiesDialog = ({
             <DialogTitle>Entities</DialogTitle>
           </div>
         </DialogHeader>
-        <div className="py-2 px-3 flex justify-between items-center bg-schemafy-secondary rounded-[10px]">
+        <div className="schemafy-input flex items-center justify-between px-3 py-2">
           <input
             type="text"
             placeholder="Search for entities..."
-            className="w-full focus:border-none outline-none focus:outline-none placeholder:text-schemafy-dark-gray border-none text-schemafy-text font-body-xs"
+            className="w-full border-none bg-transparent font-body-xs text-schemafy-text outline-none placeholder:text-schemafy-dark-gray focus:border-none focus:outline-none"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           <Search size={16} color="var(--color-schemafy-dark-gray)" />
         </div>
-        <ul className="flex flex-col w-full max-h-[12.5rem] gap-2.5 overflow-y-scroll overflow-x-hidden pr-2 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-schemafy-light-gray [&::-webkit-scrollbar-track]:bg-transparent">
+        <ul className="schemafy-scrollbar flex max-h-[12.5rem] w-full flex-col gap-2.5 overflow-y-auto overflow-x-hidden pr-2">
           {filteredTables.map((table) => (
             <div
               key={table.id}

--- a/apps/frontend/src/features/drawing/components/ShortcutPanel.tsx
+++ b/apps/frontend/src/features/drawing/components/ShortcutPanel.tsx
@@ -27,17 +27,14 @@ export const ShortcutPanel = ({ onClose }: ShortcutPanelProps) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div
-        className="absolute bottom-4 left-24 bg-schemafy-bg rounded-xl shadow-xl border border-schemafy-light-gray px-6 py-4 min-w-[320px]"
-        style={{ boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}
-      >
+      <div className="schemafy-canvas-panel absolute bottom-6 left-28 min-w-[320px] rounded-2xl px-6 py-4">
         <div className="flex items-center justify-between mb-3">
           <span className="font-body-sm font-semibold text-schemafy-text">
             Keyboard Shortcuts
           </span>
           <button
             onClick={onClose}
-            className="p-1 rounded hover:bg-schemafy-secondary transition-colors"
+            className="schemafy-focus-ring rounded-lg p-1 transition-colors hover:bg-schemafy-secondary"
           >
             <X size={14} color="var(--color-schemafy-dark-gray)" />
           </button>
@@ -50,7 +47,7 @@ export const ShortcutPanel = ({ onClose }: ShortcutPanelProps) => {
                 <Icon size={14} color="var(--color-schemafy-dark-gray)" />
                 <span className="font-body-sm text-schemafy-text">{name}</span>
               </div>
-              <kbd className="px-2 py-0.5 rounded bg-schemafy-secondary border border-schemafy-light-gray font-mono text-xs text-schemafy-dark-gray">
+              <kbd className="rounded-md border border-schemafy-glass-border bg-schemafy-secondary/80 px-2 py-0.5 font-mono text-xs text-schemafy-dark-gray">
                 {key}
               </kbd>
             </div>

--- a/apps/frontend/src/features/drawing/components/TableHeader.tsx
+++ b/apps/frontend/src/features/drawing/components/TableHeader.tsx
@@ -1,4 +1,12 @@
-import { Edit, Check, Settings, Plus, Trash, Loader2 } from 'lucide-react';
+import {
+  Edit,
+  Check,
+  Settings,
+  Plus,
+  Trash,
+  Loader2,
+  Table2,
+} from 'lucide-react';
 
 interface TableHeaderProps {
   tableName: string;
@@ -37,35 +45,42 @@ export const TableHeader = ({
   };
 
   return (
-    <div className="bg-schemafy-table-header-bg text-schemafy-button-text p-3 flex items-center justify-between gap-4">
-      <div className="flex items-center gap-2 flex-1">
+    <div className="flex items-center justify-between gap-3 border-b border-schemafy-glass-border/65 bg-schemafy-table-header-bg px-3 py-2.5 text-schemafy-text">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         {isEditing ? (
-          <div className="flex items-center gap-2 flex-1">
+          <div className="flex flex-1 items-center gap-2">
             <input
               type="text"
               value={editingName}
               placeholder="Entity"
               onChange={(e) => onEditingNameChange(e.target.value)}
-              className="bg-transparent border-b border-schemafy-button-text text-schemafy-button-text placeholder-schemafy-dark-gray outline-none flex-1"
+              className="schemafy-focus-ring flex-1 border-b border-schemafy-glass-border bg-transparent text-sm text-schemafy-text placeholder:text-schemafy-dark-gray"
               onKeyDown={handleKeyDown}
               autoFocus
             />
             <button
+              type="button"
               onClick={onSaveEdit}
-              className="p-1 hover:bg-schemafy-dark-gray rounded"
+              className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
             >
               <Check size={14} />
             </button>
           </div>
         ) : (
-          <div className="flex items-center gap-2 flex-1">
-            <span className="font-medium">{tableName}</span>
+          <div className="flex min-w-0 flex-1 items-center gap-2.5">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-schemafy-secondary text-schemafy-dark-gray">
+              <Table2 size={13} />
+            </span>
+            <span className="min-w-0 max-w-44 truncate text-sm font-semibold">
+              {tableName}
+            </span>
             <button
+              type="button"
               onClick={onStartEdit}
-              className="p-1 hover:bg-schemafy-dark-gray rounded"
+              className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
               title="Edit Table Name"
             >
-              <Edit size={14} />
+              <Edit size={13} />
             </button>
           </div>
         )}
@@ -74,39 +89,43 @@ export const TableHeader = ({
       <div className="flex items-center gap-1">
         {isColumnEditMode ? (
           <button
+            type="button"
             onClick={onSaveAllPendingChanges}
-            className="p-1 hover:bg-schemafy-dark-gray rounded"
+            className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
             title="Save and Exit Edit Mode"
           >
             <Check size={14} />
           </button>
         ) : (
           <button
+            type="button"
             onClick={onToggleColumnEditMode}
-            className="p-1 hover:bg-schemafy-dark-gray rounded"
+            className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
             title="Edit Columns"
           >
-            <Settings size={14} />
+            <Settings size={13} />
           </button>
         )}
         <button
+          type="button"
           onClick={onAddColumn}
           disabled={isAddingColumn}
-          className="p-1 hover:bg-schemafy-dark-gray rounded disabled:opacity-50"
+          className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text disabled:opacity-50"
           title="Add Column"
         >
           {isAddingColumn ? (
-            <Loader2 size={14} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <Plus size={14} />
+            <Plus size={13} />
           )}
         </button>
         <button
+          type="button"
           onClick={onDeleteTable}
-          className="p-1 hover:bg-schemafy-dark-gray rounded"
+          className="schemafy-focus-ring flex h-7 w-7 items-center justify-center rounded-lg text-schemafy-dark-gray transition-colors hover:bg-schemafy-secondary hover:text-schemafy-text"
           title="Delete Table"
         >
-          <Trash size={14} />
+          <Trash size={13} />
         </button>
       </div>
     </div>

--- a/apps/frontend/src/features/drawing/components/TableNode/ConnectionHandles.tsx
+++ b/apps/frontend/src/features/drawing/components/TableNode/ConnectionHandles.tsx
@@ -6,6 +6,14 @@ interface ConnectionHandlesProps {
 }
 
 export const ConnectionHandles = ({ nodeId }: ConnectionHandlesProps) => {
+  const getHandleStyle = (position: Position) => ({
+    ...HANDLE_STYLE,
+    ...(position === Position.Top ? { top: 5 } : {}),
+    ...(position === Position.Bottom ? { bottom: 5 } : {}),
+    ...(position === Position.Left ? { left: 5 } : {}),
+    ...(position === Position.Right ? { right: 5 } : {}),
+  });
+
   const handles = [
     {
       position: Position.Top,
@@ -33,8 +41,8 @@ export const ConnectionHandles = ({ nodeId }: ConnectionHandlesProps) => {
           type={'source'}
           position={position}
           id={id}
-          style={HANDLE_STYLE}
-          className="group-hover:!opacity-100"
+          style={getHandleStyle(position)}
+          className="schemafy-connection-handle !z-20 group-hover:!opacity-100"
         />
       ))}
     </>

--- a/apps/frontend/src/features/drawing/components/TableNode/index.tsx
+++ b/apps/frontend/src/features/drawing/components/TableNode/index.tsx
@@ -123,77 +123,79 @@ const TableNodeComponent = ({ data, id }: TableProps) => {
   };
 
   return (
-    <div className="group bg-schemafy-bg border-2 border-schemafy-table-header-bg rounded-lg shadow-md min-w-48 overflow-hidden">
+    <div className="group relative min-w-56 overflow-visible rounded-xl">
       <ConnectionHandles nodeId={id} />
-      <TableHeader
-        tableName={data.tableName}
-        isEditing={tableActions.isEditingTableName}
-        editingName={tableActions.editingTableName}
-        isColumnEditMode={isColumnEditMode}
-        onStartEdit={() => tableActions.setIsEditingTableName(true)}
-        onSaveEdit={tableActions.saveTableName}
-        onCancelEdit={() => tableActions.setIsEditingTableName(false)}
-        onEditingNameChange={tableActions.setEditingTableName}
-        onToggleColumnEditMode={() => setIsColumnEditMode(!isColumnEditMode)}
-        onSaveAllPendingChanges={handleSaveAllPendingChanges}
-        isAddingColumn={columnActions.isAddingColumn}
-        onAddColumn={handleAddColumn}
-        onDeleteTable={tableActions.deleteTable}
-      />
-      <div className="max-h-96 overflow-y-auto">
-        {columns.map((column) => (
-          <ColumnRow
-            key={column.id}
-            column={column}
-            isEditMode={isColumnEditMode}
-            isLastColumn={columns.length === 1}
-            vendorTypes={vendorTypes}
-            draggedItem={dragAndDrop.draggedItem}
-            dragOverItem={dragAndDrop.dragOverItem}
-            onDragStart={dragAndDrop.handleDragStart}
-            onDragOver={dragAndDrop.handleDragOver}
-            onDragLeave={dragAndDrop.handleDragLeave}
-            onDrop={dragAndDrop.handleDrop}
-            onDragEnd={dragAndDrop.handleDragEnd}
-            onUpdateColumn={updateColumn}
-            onRemoveColumn={columnActions.removeColumn}
-            onPendingChange={handleColumnPendingChange}
-          />
-        ))}
-      </div>
-      {columns.length === 0 && (
-        <div className="p-4 text-center text-schemafy-dark-gray text-sm">
-          Click + to add a column.
+      <div className="schemafy-node-card overflow-hidden rounded-xl">
+        <TableHeader
+          tableName={data.tableName}
+          isEditing={tableActions.isEditingTableName}
+          editingName={tableActions.editingTableName}
+          isColumnEditMode={isColumnEditMode}
+          onStartEdit={() => tableActions.setIsEditingTableName(true)}
+          onSaveEdit={tableActions.saveTableName}
+          onCancelEdit={() => tableActions.setIsEditingTableName(false)}
+          onEditingNameChange={tableActions.setEditingTableName}
+          onToggleColumnEditMode={() => setIsColumnEditMode(!isColumnEditMode)}
+          onSaveAllPendingChanges={handleSaveAllPendingChanges}
+          isAddingColumn={columnActions.isAddingColumn}
+          onAddColumn={handleAddColumn}
+          onDeleteTable={tableActions.deleteTable}
+        />
+        <div className="schemafy-scrollbar max-h-96 overflow-y-auto">
+          {columns.map((column) => (
+            <ColumnRow
+              key={column.id}
+              column={column}
+              isEditMode={isColumnEditMode}
+              isLastColumn={columns.length === 1}
+              vendorTypes={vendorTypes}
+              draggedItem={dragAndDrop.draggedItem}
+              dragOverItem={dragAndDrop.dragOverItem}
+              onDragStart={dragAndDrop.handleDragStart}
+              onDragOver={dragAndDrop.handleDragOver}
+              onDragLeave={dragAndDrop.handleDragLeave}
+              onDrop={dragAndDrop.handleDrop}
+              onDragEnd={dragAndDrop.handleDragEnd}
+              onUpdateColumn={updateColumn}
+              onRemoveColumn={columnActions.removeColumn}
+              onPendingChange={handleColumnPendingChange}
+            />
+          ))}
         </div>
-      )}
-      <IndexSection
-        schemaId={data.schemaId}
-        tableId={id}
-        indexes={indexes}
-        tableColumns={columns.map((col) => ({ id: col.id, name: col.name }))}
-        isEditMode={isColumnEditMode}
-        onCreateIndex={indexActions.createIndex}
-        onDeleteIndex={indexActions.deleteIndex}
-        onUpdateIndexName={indexActions.updateIndexName}
-        onUpdateIndexType={indexActions.updateIndexType}
-        onAddColumnToIndex={indexActions.addColumnToIndex}
-        onRemoveColumnFromIndex={indexActions.removeColumnFromIndex}
-        onUpdateSortDir={indexActions.updateSortDir}
-      />
-      <ConstraintSection
-        schemaId={data.schemaId}
-        tableId={id}
-        constraints={constraints}
-        tableColumns={columns.map((col) => ({ id: col.id, name: col.name }))}
-        isEditMode={isColumnEditMode}
-        onCreateConstraint={constraintActions.createConstraint}
-        onDeleteConstraint={constraintActions.deleteConstraint}
-        onUpdateConstraintName={constraintActions.updateConstraintName}
-        onAddColumnToConstraint={constraintActions.addColumnToConstraint}
-        onRemoveColumnFromConstraint={
-          constraintActions.removeColumnFromConstraint
-        }
-      />
+        {columns.length === 0 && (
+          <div className="border-t border-schemafy-glass-border/70 p-4 text-center text-sm text-schemafy-dark-gray">
+            Click + to add a column.
+          </div>
+        )}
+        <IndexSection
+          schemaId={data.schemaId}
+          tableId={id}
+          indexes={indexes}
+          tableColumns={columns.map((col) => ({ id: col.id, name: col.name }))}
+          isEditMode={isColumnEditMode}
+          onCreateIndex={indexActions.createIndex}
+          onDeleteIndex={indexActions.deleteIndex}
+          onUpdateIndexName={indexActions.updateIndexName}
+          onUpdateIndexType={indexActions.updateIndexType}
+          onAddColumnToIndex={indexActions.addColumnToIndex}
+          onRemoveColumnFromIndex={indexActions.removeColumnFromIndex}
+          onUpdateSortDir={indexActions.updateSortDir}
+        />
+        <ConstraintSection
+          schemaId={data.schemaId}
+          tableId={id}
+          constraints={constraints}
+          tableColumns={columns.map((col) => ({ id: col.id, name: col.name }))}
+          isEditMode={isColumnEditMode}
+          onCreateConstraint={constraintActions.createConstraint}
+          onDeleteConstraint={constraintActions.deleteConstraint}
+          onUpdateConstraintName={constraintActions.updateConstraintName}
+          onAddColumnToConstraint={constraintActions.addColumnToConstraint}
+          onRemoveColumnFromConstraint={
+            constraintActions.removeColumnFromConstraint
+          }
+        />
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/features/drawing/components/TablePreview.tsx
+++ b/apps/frontend/src/features/drawing/components/TablePreview.tsx
@@ -19,7 +19,7 @@ export const TablePreview = () => {
   return (
     <div
       ref={divRef}
-      className="bg-schemafy-table-header-bg rounded-lg"
+      className="rounded-xl border border-schemafy-soft-blue/45 bg-schemafy-soft-blue/12"
       style={{
         display: 'none',
         position: 'absolute',

--- a/apps/frontend/src/features/drawing/components/TempMemoPreview.tsx
+++ b/apps/frontend/src/features/drawing/components/TempMemoPreview.tsx
@@ -53,7 +53,7 @@ export const TempMemoPreview = ({
   return (
     <div
       ref={containerRef}
-      className="absolute z-[1000] flex gap-4 items-center text-schemafy-text"
+      className="absolute z-[1000] flex items-center gap-3 text-schemafy-text"
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`,
@@ -61,7 +61,7 @@ export const TempMemoPreview = ({
       }}
       onKeyDown={handleKeyDown}
     >
-      <div className="memo-icon w-[32px] h-[32px] rounded-t-full rounded-br-full bg-schemafy-bg flex justify-center items-center shadow-md">
+      <div className="memo-icon schemafy-canvas-panel flex h-9 w-9 items-center justify-center rounded-t-full rounded-br-full">
         <Avatar
           size={'dropdown'}
           src="https://picsum.photos/200/300?random=1"
@@ -74,12 +74,12 @@ export const TempMemoPreview = ({
         onChange={(e) => setContent(e.target.value)}
         placeholder="Add a Memo"
         autoFocus
-        className="px-4 py-2 placeholder:text-schemafy-dark-gray text-schemafy-text font-body-sm rounded-lg outline-none focus:outline-none shadow-md bg-schemafy-bg"
+        className="schemafy-input px-4 py-2 font-body-sm shadow-md"
       />
 
       <button
         onClick={handleCreate}
-        className="w-8 h-8 flex justify-center items-center bg-schemafy-button-bg rounded-full shadow-md"
+        className="schemafy-focus-ring flex h-8 w-8 items-center justify-center rounded-full bg-schemafy-button-bg shadow-md transition-colors duration-200"
       >
         <MoveUp size={14} color="var(--color-schemafy-button-text)" />
       </button>

--- a/apps/frontend/src/features/drawing/components/Toolbar.tsx
+++ b/apps/frontend/src/features/drawing/components/Toolbar.tsx
@@ -62,12 +62,7 @@ export const Toolbar = memo(
 
     return (
       <>
-        <div
-          className="flex items-center gap-3 py-2 px-6 absolute bottom-4 left-1/2 -translate-x-1/2 z-20 bg-schemafy-bg rounded-lg"
-          style={{
-            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-          }}
-        >
+        <div className="schemafy-canvas-panel absolute bottom-4 left-1/2 z-20 flex h-12 -translate-x-1/2 items-center gap-1 rounded-2xl px-2 sm:bottom-6 sm:gap-1">
           {TOOLS.map((tool) => (
             <Tool
               key={tool.id}
@@ -116,7 +111,7 @@ const Tool = ({
   isActive: boolean;
 }) => {
   const color = isActive
-    ? 'var(--color-schemafy-text)'
+    ? 'var(--color-schemafy-soft-blue)'
     : 'var(--color-schemafy-tools)';
 
   return (
@@ -128,8 +123,9 @@ const Tool = ({
           size={'none'}
           data-testid={`toolbar-${id}`}
           className={`
-        p-2 rounded-md transition-colors duration-200
+        h-9 w-9 rounded-xl transition-all duration-200
         hover:bg-schemafy-secondary
+        ${isActive ? 'bg-schemafy-soft-blue/10 ring-1 ring-schemafy-soft-blue/30' : ''}
       `}
         >
           <Icon size={16} color={color} />

--- a/apps/frontend/src/features/drawing/types/relationship.ts
+++ b/apps/frontend/src/features/drawing/types/relationship.ts
@@ -4,14 +4,22 @@ export const RELATIONSHIP_TYPES = {
   'one-to-one': {
     label: '1:1',
     cardinality: 'ONE_TO_ONE',
-    style: { stroke: 'var(--color-schemafy-dark-gray)', strokeWidth: 2 },
+    style: {
+      stroke: 'var(--color-schemafy-edge)',
+      strokeWidth: 1.5,
+      strokeOpacity: 0.78,
+    },
     markerStart: 'erd-one-start',
     markerEnd: 'erd-one-end',
   },
   'one-to-many': {
     label: '1:N',
     cardinality: 'ONE_TO_MANY',
-    style: { stroke: 'var(--color-schemafy-dark-gray)', strokeWidth: 2 },
+    style: {
+      stroke: 'var(--color-schemafy-edge)',
+      strokeWidth: 1.5,
+      strokeOpacity: 0.78,
+    },
     markerStart: 'erd-many-start',
     markerEnd: 'erd-one-end',
   },
@@ -19,12 +27,14 @@ export const RELATIONSHIP_TYPES = {
 
 export const RELATIONSHIP_STYLE_TYPES = {
   solid: {
-    stroke: 'var(--color-schemafy-dark-gray)',
-    strokeWidth: 2,
+    stroke: 'var(--color-schemafy-edge)',
+    strokeWidth: 1.5,
+    strokeOpacity: 0.78,
   },
   dashed: {
-    stroke: 'var(--color-schemafy-dark-gray)',
-    strokeWidth: 2,
+    stroke: 'var(--color-schemafy-edge)',
+    strokeWidth: 1.5,
+    strokeOpacity: 0.78,
     strokeDasharray: '5 5',
   },
 } as const;

--- a/apps/frontend/src/features/drawing/types/table.ts
+++ b/apps/frontend/src/features/drawing/types/table.ts
@@ -12,11 +12,13 @@ export type TableData = {
 };
 
 export const HANDLE_STYLE = {
-  background: '#141414',
-  width: 10,
-  height: 10,
+  background: 'hsl(var(--schemafy-soft-blue) / 0.78)',
+  border: '1px solid var(--color-schemafy-bg)',
+  boxShadow: '0 0 0 1px hsl(var(--schemafy-soft-blue) / 0.16)',
+  width: 8,
+  height: 8,
   opacity: 0,
-  transition: 'opacity 0.2s ease-in-out',
+  transition: 'opacity 0.18s ease-in-out',
 };
 
 export interface TableProps {

--- a/apps/frontend/src/features/drawing/utils/relationshipHelpers.ts
+++ b/apps/frontend/src/features/drawing/utils/relationshipHelpers.ts
@@ -45,9 +45,9 @@ const convertRelationshipSnapshotToEdge = (
     markerEnd: baseConfig.markerEnd,
     label: relationship.name,
     labelStyle: {
-      fontSize: 12,
-      fontWeight: 'bold',
-      color: style.stroke,
+      fontSize: 11,
+      fontWeight: 600,
+      color: 'var(--color-schemafy-dark-gray)',
     },
     data: {
       relationshipType,

--- a/apps/frontend/src/features/memo/components/Memo.tsx
+++ b/apps/frontend/src/features/memo/components/Memo.tsx
@@ -28,8 +28,8 @@ export const Memo = ({ id, data }: MemoProps) => {
       <div className="relative">
         <div
           className={cn(
-            'memo-icon w-[32px] h-[32px] rounded-t-full rounded-br-full bg-schemafy-bg flex justify-center items-center shadow-md cursor-pointer',
-            showThread && 'ring-2 ring-schemafy-blue',
+            'memo-icon schemafy-canvas-panel flex h-9 w-9 cursor-pointer items-center justify-center rounded-t-full rounded-br-full transition-all duration-200',
+            showThread && 'ring-2 ring-schemafy-soft-blue',
           )}
           onClick={handleIconClick}
           onMouseEnter={() => setIsHovered(true)}

--- a/apps/frontend/src/features/memo/components/MemoHoverPreview.tsx
+++ b/apps/frontend/src/features/memo/components/MemoHoverPreview.tsx
@@ -12,7 +12,7 @@ export const MemoHoverPreview = ({
   comments,
 }: MemoHoverPreviewProps) => {
   return (
-    <div className="absolute left-full top-0 ml-2 bg-schemafy-bg rounded-lg shadow-lg p-3 min-w-[200px] max-w-[280px] pointer-events-none z-10 animate-in fade-in duration-150">
+    <div className="schemafy-canvas-panel pointer-events-none absolute left-full top-0 z-10 ml-2 min-w-[220px] max-w-[300px] animate-in rounded-2xl p-3 fade-in duration-150">
       <div className="flex gap-2">
         <Avatar
           size={'dropdown'}
@@ -33,7 +33,9 @@ export const MemoHoverPreview = ({
               )}
             </span>
           </div>
-          <p className="font-body-sm mt-1 line-clamp-2">{firstComment.body}</p>
+          <p className="mt-1 line-clamp-2 font-body-sm text-schemafy-text">
+            {firstComment.body}
+          </p>
         </div>
       </div>
       {comments.length > 1 && (

--- a/apps/frontend/src/features/memo/components/MemoThread.tsx
+++ b/apps/frontend/src/features/memo/components/MemoThread.tsx
@@ -38,33 +38,35 @@ export const MemoThread = ({
   };
 
   return (
-    <div className="bg-schemafy-bg rounded-lg shadow-lg p-4 min-w-[300px] text-schemafy-text flex-col gap-4 flex">
-      <div className="flex justify-between items-center">
+    <div className="schemafy-canvas-panel flex min-w-[320px] flex-col gap-4 rounded-2xl p-5 text-schemafy-text">
+      <div className="flex items-center justify-between">
         <h3 className="font-heading-xs">Memo</h3>
         <div className="flex gap-2">
           <button
+            type="button"
             title="Delete Memo"
             onClick={handleDeleteMemo}
-            className="text-schemafy-dark-gray hover:text-schemafy-text cursor-pointer transition-colors duration-200 hover:bg-schemafy-light-gray rounded-sm p-1"
+            className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center text-schemafy-dark-gray hover:text-schemafy-destructive"
           >
-            <Trash size={14} color="var(--color-schemafy-dark-gray)" />
+            <Trash size={14} />
           </button>
           <button
+            type="button"
             onClick={() => setShowThread(false)}
-            className="text-schemafy-dark-gray hover:text-schemafy-text cursor-pointer transition-colors duration-200 hover:bg-schemafy-light-gray rounded-sm p-1"
+            className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center text-schemafy-dark-gray"
           >
-            <X size={14} color="var(--color-schemafy-dark-gray)" />
+            <X size={14} />
           </button>
         </div>
       </div>
 
-      <ul className="flex flex-col gap-4">
+      <ul className="schemafy-scrollbar flex max-h-72 flex-col gap-3 overflow-y-auto pr-1">
         {comments.map((comment) => (
           <ReplyItem key={comment.id} memoId={id} comment={comment} />
         ))}
       </ul>
 
-      <div className="flex gap-2 items-center justify-between">
+      <div className="flex items-center justify-between gap-3 border-t border-schemafy-glass-border pt-4">
         <Avatar
           size={'dropdown'}
           src="https://picsum.photos/200/300?random=1"
@@ -75,11 +77,12 @@ export const MemoThread = ({
           onChange={(e) => setReplyInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Reply"
-          className="flex-1 bg-schemafy-secondary px-4 py-2 placeholder:text-schemafy-dark-gray text-schemafy-text font-body-sm rounded-lg outline-none focus:outline-none"
+          className="schemafy-input flex-1 px-4 py-2 font-body-sm"
         />
         <button
+          type="button"
           onClick={handleAddReply}
-          className="w-8 h-8 flex justify-center items-center bg-schemafy-button-bg rounded-full"
+          className="schemafy-focus-ring flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-schemafy-button-bg transition-colors duration-200"
         >
           <MoveUp size={14} color="var(--color-schemafy-button-text)" />
         </button>

--- a/apps/frontend/src/features/memo/components/ReplyItem.tsx
+++ b/apps/frontend/src/features/memo/components/ReplyItem.tsx
@@ -35,63 +35,80 @@ export const ReplyItem = ({
   };
 
   return (
-    <li className="flex gap-2 text-schemafy-text group">
-      <Avatar size={'dropdown'} src="https://picsum.photos/200/300?random=1" />
-      <div className="flex-1">
-        <div className="flex items-center gap-2">
-          <span className="font-overline-sm">{comment.author.name}</span>
-          <span className="font-body-xs text-schemafy-dark-gray">
-            {formatDate(
-              new Date(comment.updatedAt ?? comment.createdAt ?? new Date()),
-            )}
-          </span>
+    <li className="group flex w-full items-start gap-3 rounded-xl border border-transparent px-3 py-2.5 text-schemafy-text transition-colors duration-200 hover:border-schemafy-glass-border hover:bg-schemafy-secondary/50">
+      <div className="shrink-0 pt-0.5">
+        <Avatar
+          size={'dropdown'}
+          src="https://picsum.photos/200/300?random=1"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-h-7 items-start justify-between gap-3">
+          <div className="min-w-0 flex flex-wrap items-center gap-x-2 gap-y-1 pr-2">
+            <span className="truncate font-overline-sm">
+              {comment.author.name}
+            </span>
+            <span className="font-body-xs text-schemafy-dark-gray">
+              {formatDate(
+                new Date(comment.updatedAt ?? comment.createdAt ?? new Date()),
+              )}
+            </span>
+          </div>
           {!isEditing && (
-            <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              <Pencil
-                size={14}
-                color="var(--color-schemafy-dark-gray)"
+            <div className="flex shrink-0 gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+              <button
+                type="button"
+                title="Edit Reply"
                 onClick={() => {
                   setIsEditing(true);
                   setEditInput(comment.body);
                 }}
-                className="cursor-pointer hover:text-schemafy-text"
-              />
-              <Trash
-                size={14}
-                color="var(--color-schemafy-dark-gray)"
+                className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center"
+              >
+                <Pencil size={14} />
+              </button>
+              <button
+                type="button"
+                title="Delete Reply"
                 onClick={() => deleteComment(memoId, comment.id)}
-                className="cursor-pointer hover:text-red-500"
-              />
+                className="schemafy-icon-button schemafy-focus-ring flex h-7 w-7 items-center justify-center hover:text-schemafy-destructive"
+              >
+                <Trash size={14} />
+              </button>
             </div>
           )}
         </div>
 
         {isEditing ? (
-          <div className="mt-1 flex flex-col gap-2">
+          <div className="mt-2 flex flex-col gap-2.5">
             <input
               value={editInput}
               onChange={(e) => setEditInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              className="w-full bg-schemafy-secondary px-2 py-1 text-schemafy-text font-body-sm rounded outline-none border border-schemafy-blue"
+              className="schemafy-input w-full px-3 py-2 font-body-sm"
               autoFocus
             />
-            <div className="flex gap-2 justify-end">
+            <div className="flex justify-end gap-2">
               <button
+                type="button"
                 onClick={() => setIsEditing(false)}
-                className="text-xs text-schemafy-dark-gray hover:text-schemafy-text"
+                className="schemafy-menu-button schemafy-focus-ring px-3 py-1.5 font-body-xs"
               >
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={handleSave}
-                className="text-xs text-schemafy-blue hover:text-blue-400 font-medium"
+                className="schemafy-focus-ring rounded-full bg-schemafy-button-bg px-3 py-1.5 font-body-xs font-medium text-schemafy-button-text transition-colors duration-200"
               >
                 Save
               </button>
             </div>
           </div>
         ) : (
-          <p className="font-body-sm mt-1">{comment.body}</p>
+          <p className="mt-1 break-words font-body-sm leading-relaxed">
+            {comment.body}
+          </p>
         )}
       </div>
     </li>

--- a/apps/frontend/src/features/workspace/components/ChangeRoleDialog.tsx
+++ b/apps/frontend/src/features/workspace/components/ChangeRoleDialog.tsx
@@ -42,7 +42,7 @@ export const ChangeRoleDialog = ({
             Role
           </label>
           <Select value={selectedRole} onValueChange={onSelectedRoleChange}>
-            <SelectTrigger className="px-4 py-3 rounded-[12px] font-body-sm">
+            <SelectTrigger className="px-4 py-3 font-body-sm">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/apps/frontend/src/features/workspace/components/InviteDialog.tsx
+++ b/apps/frontend/src/features/workspace/components/InviteDialog.tsx
@@ -70,7 +70,7 @@ export const InviteDialog = ({
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="member@example.com"
-              className="w-full px-4 py-3 border border-schemafy-light-gray rounded-[12px] font-body-sm placeholder-schemafy-dark-gray bg-schemafy-bg focus:outline-none"
+              className="schemafy-input w-full px-4 py-3 font-body-sm"
             />
           </div>
           <div className="flex flex-col gap-1.5">
@@ -78,7 +78,7 @@ export const InviteDialog = ({
               Role
             </label>
             <Select value={role} onValueChange={setRole}>
-              <SelectTrigger className="px-4 py-3 rounded-[12px] font-body-sm">
+              <SelectTrigger className="px-4 py-3 font-body-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/apps/frontend/src/features/workspace/components/WorkspaceMembersTab.tsx
+++ b/apps/frontend/src/features/workspace/components/WorkspaceMembersTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { MoreHorizontal, Search } from 'lucide-react';
+import { MoreHorizontal, Search, UsersRound } from 'lucide-react';
 import {
   Button,
   DropdownMenu,
@@ -79,37 +79,83 @@ export const WorkspaceMembersTab = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="relative">
-        <Search
-          size={16}
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-schemafy-dark-gray pointer-events-none"
-        />
-        <input
-          type="text"
-          placeholder="Search member"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full pl-10 pr-4 py-3 border border-schemafy-light-gray rounded-[12px] font-body-sm placeholder-schemafy-dark-gray bg-schemafy-bg focus:outline-none"
-        />
+      <div>
+        <div className="relative">
+          <Search
+            size={16}
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-schemafy-dark-gray"
+          />
+          <input
+            type="text"
+            placeholder="Search member"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="schemafy-input h-11 w-full pl-10 pr-4 font-body-sm"
+          />
+        </div>
       </div>
 
-      <div className="border border-schemafy-light-gray rounded-[12px] overflow-hidden">
-        <table className="w-full">
+      <div className="grid gap-3 md:hidden">
+        {isLoadingMembers ? (
+          <div className="schemafy-subtle-card px-4 py-8 text-center font-body-sm text-schemafy-dark-gray">
+            Loading...
+          </div>
+        ) : (
+          members.map((member) => (
+            <article
+              key={member.userId}
+              className="schemafy-subtle-card flex flex-col gap-4 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <MemberAvatar name={member.userName} />
+                  <div className="min-w-0">
+                    <h3 className="truncate font-heading-sm text-schemafy-text">
+                      {member.userName}
+                    </h3>
+                    <p className="mt-1 truncate font-caption-md text-schemafy-dark-gray">
+                      {member.userEmail}
+                    </p>
+                  </div>
+                </div>
+                {currentUserRole === 'ADMIN' && user?.id !== member.userId && (
+                  <MemberActions
+                    handleOpenRoleChange={handleOpenRoleChange}
+                    onRemoveClick={setRemoveTarget}
+                    member={member}
+                  />
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="schemafy-badge px-3 py-1 font-caption-md">
+                  {toCapitalized(member.role)}
+                </span>
+                <span className="font-caption-md text-schemafy-dark-gray">
+                  Joined {formatDate(new Date(member.joinedAt))}
+                </span>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+
+      <div className="schemafy-table-shell schemafy-scrollbar hidden overflow-x-auto md:block">
+        <table className="w-full min-w-[720px]">
           <thead>
-            <tr className="border-b border-schemafy-light-gray">
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text w-[35%]">
+            <tr className="border-b border-schemafy-glass-border bg-schemafy-secondary/50">
+              <th className="w-[35%] px-5 py-3 text-left font-overline-sm text-schemafy-text">
                 Name
               </th>
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text">
+              <th className="px-5 py-3 text-left font-overline-sm text-schemafy-text">
                 Email
               </th>
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text">
+              <th className="px-5 py-3 text-left font-overline-sm text-schemafy-text">
                 Role
               </th>
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text">
+              <th className="px-5 py-3 text-left font-overline-sm text-schemafy-text">
                 Joined
               </th>
-              {currentUserRole === 'ADMIN' && <th className="px-6 py-4 w-10" />}
+              {currentUserRole === 'ADMIN' && <th className="w-10 px-5 py-3" />}
             </tr>
           </thead>
           <tbody>
@@ -117,29 +163,43 @@ export const WorkspaceMembersTab = ({
               <tr>
                 <td
                   colSpan={5}
-                  className="px-6 py-8 text-center font-body-sm text-schemafy-dark-gray"
+                  className="px-5 py-8 text-center font-body-sm text-schemafy-dark-gray"
                 >
                   Loading...
+                </td>
+              </tr>
+            ) : members.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-5 py-10 text-center font-body-sm text-schemafy-dark-gray"
+                >
+                  No members match your search.
                 </td>
               </tr>
             ) : (
               members.map((member) => (
                 <tr
                   key={member.userId}
-                  className="border-b border-schemafy-light-gray last:border-b-0 hover:bg-schemafy-secondary transition-colors"
+                  className="border-b border-schemafy-glass-border transition-colors last:border-b-0 hover:bg-schemafy-secondary/40"
                 >
-                  <td className="px-6 py-4 font-body-sm text-schemafy-text">
-                    {member.userName}
+                  <td className="px-5 py-4">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <MemberAvatar name={member.userName} />
+                      <span className="truncate font-body-sm text-schemafy-text">
+                        {member.userName}
+                      </span>
+                    </div>
                   </td>
-                  <td className="px-6 py-4 font-body-sm text-schemafy-dark-gray">
+                  <td className="px-5 py-4 font-body-sm text-schemafy-dark-gray">
                     {member.userEmail}
                   </td>
-                  <td className="px-6 py-4">
-                    <span className="px-3 py-1 bg-schemafy-secondary text-schemafy-dark-gray font-caption-md rounded-full">
+                  <td className="px-5 py-4">
+                    <span className="schemafy-badge px-3 py-1 font-caption-md">
                       {toCapitalized(member.role)}
                     </span>
                   </td>
-                  <td className="px-6 py-4 font-body-sm text-schemafy-dark-gray text-nowrap">
+                  <td className="text-nowrap px-5 py-4 font-body-sm text-schemafy-dark-gray">
                     {formatDate(new Date(member.joinedAt))}
                   </td>
                   {currentUserRole === 'ADMIN' &&
@@ -150,24 +210,21 @@ export const WorkspaceMembersTab = ({
                         member={member}
                       />
                     ) : (
-                      <td className="px-6 py-4" />
+                      <td className="px-5 py-4" />
                     ))}
                 </tr>
               ))
             )}
-            <tr>
-              <td colSpan={5} className="py-2">
-                <div className="flex justify-center">
-                  <Pagination
-                    currentPage={currentPage}
-                    totalPages={totalPages}
-                    onPageChange={setCurrentPage}
-                  />
-                </div>
-              </td>
-            </tr>
           </tbody>
         </table>
+      </div>
+
+      <div className="flex justify-center">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
       </div>
 
       <ChangeRoleDialog
@@ -192,6 +249,21 @@ export const WorkspaceMembersTab = ({
   );
 };
 
+const MemberAvatar = ({ name }: { name: string }) => {
+  const initials = name
+    .split(' ')
+    .map((part) => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-schemafy-glass-border bg-schemafy-secondary font-caption-md text-schemafy-text">
+      {initials || <UsersRound className="h-4 w-4 text-schemafy-soft-blue" />}
+    </span>
+  );
+};
+
 const MemberOptions = ({
   handleOpenRoleChange,
   onRemoveClick,
@@ -202,38 +274,59 @@ const MemberOptions = ({
   member: WorkspaceMemberResponse;
 }) => {
   return (
-    <td className="px-6 py-4">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button className="text-schemafy-dark-gray hover:text-schemafy-text transition-colors">
-            <MoreHorizontal size={16} />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          sideOffset={4}
-          align="end"
-          className="!p-1.5 !min-w-0 flex flex-col gap-0.5"
-        >
-          <Button
-            variant="none"
-            size="none"
-            className="font-caption-md px-2 py-1 whitespace-nowrap text-left"
-            onClick={() => {
-              handleOpenRoleChange(member.userId, member.role);
-            }}
-          >
-            Change Role
-          </Button>
-          <Button
-            variant="none"
-            size="none"
-            className="text-schemafy-destructive font-caption-md px-2 py-1 whitespace-nowrap text-left"
-            onClick={() => onRemoveClick(member)}
-          >
-            Delete
-          </Button>
-        </DropdownMenuContent>
-      </DropdownMenu>
+    <td className="px-5 py-4">
+      <MemberActions
+        handleOpenRoleChange={handleOpenRoleChange}
+        onRemoveClick={onRemoveClick}
+        member={member}
+      />
     </td>
+  );
+};
+
+const MemberActions = ({
+  handleOpenRoleChange,
+  onRemoveClick,
+  member,
+}: {
+  handleOpenRoleChange: (userId: string, currentRole: string) => void;
+  onRemoveClick: (member: WorkspaceMemberResponse) => void;
+  member: WorkspaceMemberResponse;
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center"
+        >
+          <MoreHorizontal size={16} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        sideOffset={4}
+        align="end"
+        className="!min-w-0 flex flex-col gap-0.5 !p-1.5"
+      >
+        <Button
+          variant="none"
+          size="none"
+          className="schemafy-menu-button whitespace-nowrap px-3 py-2 text-left font-caption-md"
+          onClick={() => {
+            handleOpenRoleChange(member.userId, member.role);
+          }}
+        >
+          Change Role
+        </Button>
+        <Button
+          variant="none"
+          size="none"
+          className="schemafy-menu-button whitespace-nowrap px-3 py-2 text-left font-caption-md text-schemafy-destructive"
+          onClick={() => onRemoveClick(member)}
+        >
+          Delete
+        </Button>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/apps/frontend/src/features/workspace/components/WorkspaceProjectsTab.tsx
+++ b/apps/frontend/src/features/workspace/components/WorkspaceProjectsTab.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizontal, Search } from 'lucide-react';
+import { FolderKanban, MoreHorizontal, Plus, Search } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -46,50 +46,73 @@ export const WorkspaceProjectsTab = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="relative">
-        <Search
-          size={16}
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-schemafy-dark-gray pointer-events-none"
-        />
-        <input
-          type="text"
-          placeholder="Search project"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full pl-10 pr-4 py-3 border border-schemafy-light-gray rounded-[12px] font-body-sm placeholder-schemafy-dark-gray bg-schemafy-bg focus:outline-none"
-        />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative min-w-0 flex-1">
+          <Search
+            size={16}
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-schemafy-dark-gray"
+          />
+          <input
+            type="text"
+            placeholder="Search project"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="schemafy-input h-11 w-full pl-10 pr-4 font-body-sm"
+          />
+        </div>
+        {currentUserRole === 'ADMIN' && (
+          <Button
+            className="h-11 w-full px-4 sm:w-auto"
+            onClick={() => setIsCreateDialogOpen(true)}
+          >
+            <Plus className="h-4 w-4" />
+            Create Project
+          </Button>
+        )}
       </div>
 
-      {currentUserRole === 'ADMIN' && (
-        <div className="w-full flex justify-end items-center">
-          <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
-            Create
-          </Button>
-        </div>
-      )}
-
-      <div className="border border-schemafy-light-gray rounded-[12px] overflow-hidden">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-schemafy-light-gray">
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text w-[40%]">
-                Name
-              </th>
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text whitespace-nowrap">
-                Last Modified
-              </th>
-              <th className="text-left px-6 py-4 font-overline-sm text-schemafy-text">
-                Access
-              </th>
-              <th className="px-6 py-4 w-10" />
-            </tr>
-          </thead>
-          <tbody>
-            {filtered &&
-              filtered.map((project) => (
-                <tr
-                  key={project.id}
-                  className="border-b border-schemafy-light-gray last:border-b-0 hover:bg-schemafy-secondary transition-colors cursor-pointer"
+      <div className="grid gap-3 md:hidden">
+        {filtered.length === 0 ? (
+          <EmptyProjectsState />
+        ) : (
+          filtered.map((project) => (
+            <article
+              key={project.id}
+              className="schemafy-subtle-card flex flex-col gap-4 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-schemafy-glass-border bg-schemafy-secondary text-schemafy-soft-blue">
+                    <FolderKanban className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="truncate font-heading-sm text-schemafy-text">
+                      {project.name}
+                    </h3>
+                    {project.description && (
+                      <p className="mt-1 line-clamp-2 font-body-sm text-schemafy-dark-gray">
+                        {project.description}
+                      </p>
+                    )}
+                    <p className="mt-1 font-caption-md text-schemafy-dark-gray">
+                      Updated {formatDate(new Date(project.updatedAt))}
+                    </p>
+                  </div>
+                </div>
+                <ProjectActions
+                  project={project}
+                  onEditClick={setEditTarget}
+                  onLeaveClick={setLeaveTarget}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="schemafy-badge px-3 py-1 font-caption-md">
+                  {toCapitalized(project.myRole)}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 px-4"
                   onClick={() =>
                     void navigate({
                       to: '/project/$projectId',
@@ -97,14 +120,71 @@ export const WorkspaceProjectsTab = ({
                     })
                   }
                 >
-                  <td className="px-6 py-4 font-body-sm text-schemafy-text">
-                    {project.name}
+                  Open
+                </Button>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+
+      <div className="schemafy-table-shell schemafy-scrollbar hidden overflow-x-auto md:block">
+        <table className="w-full min-w-[600px]">
+          <thead>
+            <tr className="border-b border-schemafy-glass-border bg-schemafy-secondary/50">
+              <th className="w-[46%] px-5 py-3 text-left font-overline-sm text-schemafy-text">
+                Project
+              </th>
+              <th className="whitespace-nowrap px-5 py-3 text-left font-overline-sm text-schemafy-text">
+                Last Modified
+              </th>
+              <th className="px-5 py-3 text-left font-overline-sm text-schemafy-text">
+                Access
+              </th>
+              <th className="w-10 px-5 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-5 py-10 text-center font-body-sm text-schemafy-dark-gray"
+                >
+                  No projects match your search.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((project) => (
+                <tr
+                  key={project.id}
+                  className="cursor-pointer border-b border-schemafy-glass-border transition-colors last:border-b-0 hover:bg-schemafy-secondary/40"
+                  onClick={() =>
+                    void navigate({
+                      to: '/project/$projectId',
+                      params: { projectId: project.id },
+                    })
+                  }
+                >
+                  <td className="px-5 py-4">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-heading-xs text-schemafy-text">
+                          {project.name}
+                        </p>
+                        {project.description && (
+                          <p className="truncate font-caption-md text-schemafy-dark-gray">
+                            {project.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
                   </td>
-                  <td className="px-6 py-4 font-body-sm text-schemafy-dark-gray">
+                  <td className="px-5 py-4 font-body-sm text-schemafy-dark-gray">
                     {formatDate(new Date(project.updatedAt))}
                   </td>
-                  <td className="px-6 py-4">
-                    <span className="px-3 py-1 bg-schemafy-secondary text-schemafy-dark-gray font-body-sm rounded-full">
+                  <td className="px-5 py-4">
+                    <span className="schemafy-badge px-3 py-1 font-body-sm">
                       {toCapitalized(project.myRole)}
                     </span>
                   </td>
@@ -114,20 +194,18 @@ export const WorkspaceProjectsTab = ({
                     onLeaveClick={setLeaveTarget}
                   />
                 </tr>
-              ))}
-            <tr>
-              <td colSpan={4} className="py-2">
-                <div className="flex justify-center">
-                  <Pagination
-                    currentPage={currentPage}
-                    totalPages={projectsData?.totalPages ?? 1}
-                    onPageChange={setCurrentPage}
-                  />
-                </div>
-              </td>
-            </tr>
+              ))
+            )}
           </tbody>
         </table>
+      </div>
+
+      <div className="flex justify-center">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={projectsData?.totalPages ?? 1}
+          onPageChange={setCurrentPage}
+        />
       </div>
 
       <ProjectFormDialog
@@ -159,6 +237,12 @@ export const WorkspaceProjectsTab = ({
   );
 };
 
+const EmptyProjectsState = () => (
+  <div className="schemafy-subtle-card px-4 py-8 text-center font-body-sm text-schemafy-dark-gray">
+    No projects match your search.
+  </div>
+);
+
 const ProjectOption = ({
   project,
   onEditClick,
@@ -169,38 +253,59 @@ const ProjectOption = ({
   onLeaveClick: (project: ProjectSummaryResponse) => void;
 }) => {
   return (
-    <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button className="text-schemafy-dark-gray hover:text-schemafy-text transition-colors">
-            <MoreHorizontal size={16} />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          sideOffset={4}
-          align="end"
-          className="!p-1.5 !min-w-0 flex flex-col gap-0.5"
+    <td className="px-5 py-4" onClick={(e) => e.stopPropagation()}>
+      <ProjectActions
+        project={project}
+        onEditClick={onEditClick}
+        onLeaveClick={onLeaveClick}
+      />
+    </td>
+  );
+};
+
+const ProjectActions = ({
+  project,
+  onEditClick,
+  onLeaveClick,
+}: {
+  project: ProjectSummaryResponse;
+  onEditClick: (project: ProjectSummaryResponse) => void;
+  onLeaveClick: (project: ProjectSummaryResponse) => void;
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center"
         >
-          {project.myRole === 'ADMIN' && (
-            <Button
-              variant="none"
-              size="none"
-              className="font-caption-md px-2 py-1 whitespace-nowrap"
-              onClick={() => onEditClick(project)}
-            >
-              Edit
-            </Button>
-          )}
+          <MoreHorizontal size={16} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        sideOffset={4}
+        align="end"
+        className="!min-w-0 flex flex-col gap-0.5 !p-1.5"
+      >
+        {project.myRole === 'ADMIN' && (
           <Button
             variant="none"
             size="none"
-            className="text-schemafy-destructive font-caption-md px-2 py-1 whitespace-nowrap"
-            onClick={() => onLeaveClick(project)}
+            className="schemafy-menu-button whitespace-nowrap px-3 py-2 font-caption-md"
+            onClick={() => onEditClick(project)}
           >
-            Leave
+            Edit
           </Button>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </td>
+        )}
+        <Button
+          variant="none"
+          size="none"
+          className="schemafy-menu-button whitespace-nowrap px-3 py-2 font-caption-md text-schemafy-destructive"
+          onClick={() => onLeaveClick(project)}
+        >
+          Leave
+        </Button>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/apps/frontend/src/features/workspace/components/WorkspaceSidebar.tsx
+++ b/apps/frontend/src/features/workspace/components/WorkspaceSidebar.tsx
@@ -27,33 +27,41 @@ export const WorkspaceSidebar = ({
   return (
     <aside
       className={cn(
-        'min-h-full border-r border-schemafy-light-gray flex flex-col shrink-0 relative z-10 bg-schemafy-bg overflow-hidden transition-[width] duration-300',
-        isOpen ? 'w-64' : 'w-12',
+        'relative z-10 flex shrink-0 flex-col overflow-hidden border-b border-schemafy-glass-border bg-schemafy-bg transition-[width] duration-300 md:min-h-full md:border-b-0 md:border-r',
+        isOpen ? 'w-full md:w-72' : 'w-full md:w-16',
       )}
     >
       <div
         className={cn(
-          'flex items-center py-5 px-3 transition-all duration-300',
+          'flex items-center border-b border-schemafy-glass-border/70 px-4 py-4 transition-all duration-300',
           isOpen ? 'justify-between' : 'justify-center',
         )}
       >
         {isOpen && (
-          <span className="font-caption-sm text-schemafy-dark-gray tracking-widest uppercase whitespace-nowrap">
-            Workspaces
-          </span>
+          <div className="min-w-0">
+            <p className="truncate font-heading-xs text-schemafy-text">
+              Workspaces
+            </p>
+          </div>
         )}
         <div className={cn('flex items-center gap-1', isOpen && 'gap-2')}>
           {isOpen && (
             <button
+              type="button"
               onClick={onAdd}
-              className="text-schemafy-dark-gray hover:text-schemafy-text transition-colors"
+              className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center"
+              aria-label="Add workspace"
             >
               <Plus size={14} />
             </button>
           )}
           <button
+            type="button"
             onClick={onToggle}
-            className="text-schemafy-dark-gray hover:text-schemafy-text transition-colors"
+            className="schemafy-icon-button schemafy-focus-ring flex h-8 w-8 items-center justify-center"
+            aria-label={
+              isOpen ? 'Collapse workspace sidebar' : 'Open workspace sidebar'
+            }
           >
             {isOpen ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
           </button>
@@ -62,8 +70,10 @@ export const WorkspaceSidebar = ({
 
       <ul
         className={cn(
-          'flex flex-col gap-0.5 px-3 transition-opacity duration-200',
-          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+          'schemafy-scrollbar flex flex-col gap-1 overflow-y-auto px-3 py-3 transition-opacity duration-200',
+          isOpen
+            ? 'opacity-100'
+            : 'pointer-events-none h-0 opacity-0 md:h-auto',
         )}
       >
         {workspaces.map((workspace) => (
@@ -71,17 +81,27 @@ export const WorkspaceSidebar = ({
             <button
               onClick={() => onSelect(workspace.id)}
               className={cn(
-                'w-full text-left px-3 py-2.5 rounded-[10px] transition-colors',
+                'schemafy-focus-ring group w-full rounded-xl px-3 py-2.5 text-left transition-colors duration-200',
                 selectedId === workspace.id
-                  ? 'bg-schemafy-secondary'
-                  : 'hover:bg-schemafy-secondary',
+                  ? 'bg-schemafy-secondary text-schemafy-text'
+                  : 'text-schemafy-dark-gray hover:bg-schemafy-secondary/70 hover:text-schemafy-text',
               )}
             >
-              <p className="font-overline-sm text-schemafy-text">
-                {workspace.name}
-              </p>
+              <div className="flex items-center gap-3">
+                <span
+                  className={cn(
+                    'h-2.5 w-2.5 shrink-0 rounded-full border border-schemafy-glass-border',
+                    selectedId === workspace.id
+                      ? 'bg-schemafy-soft-blue'
+                      : 'bg-schemafy-dark-gray/30 group-hover:bg-schemafy-dark-gray/50',
+                  )}
+                />
+                <p className="min-w-0 truncate font-overline-sm text-schemafy-text">
+                  {workspace.name}
+                </p>
+              </div>
               {workspace.description && (
-                <p className="font-caption-sm text-schemafy-dark-gray mt-0.5 truncate">
+                <p className="mt-1.5 truncate pl-5 font-caption-sm text-schemafy-dark-gray">
                   {workspace.description}
                 </p>
               )}

--- a/apps/frontend/src/pages/CanvasPage.tsx
+++ b/apps/frontend/src/pages/CanvasPage.tsx
@@ -58,7 +58,7 @@ const CanvasContent = observer(() => {
 
   return (
     <>
-      <div className="flex flex-1">
+      <div className="flex flex-1 overflow-hidden bg-schemafy-canvas">
         <Toolbar
           setActiveTool={setActiveTool}
           activeTool={activeTool}
@@ -66,8 +66,8 @@ const CanvasContent = observer(() => {
           onRelationshipConfigChange={setRelationshipConfig}
         />
 
-        <div className="flex-1 bg-schemafy-secondary relative">
-          <div className="absolute top-4 right-4 z-10">
+        <div className="relative flex-1 overflow-hidden">
+          <div className="absolute right-6 top-6 z-10">
             <SchemaSelector />
           </div>
 

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -7,7 +7,7 @@ import {
 
 export const LandingPage = () => {
   return (
-    <div className="flex-col">
+    <div className="flex w-full flex-col px-4 sm:px-6 lg:px-8">
       <Description />
       <Features />
       <Benefits />

--- a/apps/frontend/src/pages/SignInPage.tsx
+++ b/apps/frontend/src/pages/SignInPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { CheckCircle2, Database, GitBranch, KeyRound } from 'lucide-react';
 import { ButtonLink } from '@/components';
 import { SignInForm } from '@/features/auth';
 import { useNavigate, useSearch } from '@tanstack/react-router';
@@ -22,21 +23,97 @@ export const SignInPage = () => {
   }, [authRequired, navigate, oauthError]);
 
   return (
-    <div className="py-5 flex flex-col justify-center items-center w-full">
-      <h2 className="font-heading-xl mb-3 mt-5">Sign in to your account</h2>
-      <SignInForm oauthError={oauthError} />
-      <div className="flex gap-2 pt-1 pb-3 items-center justify-center">
-        <p className="font-body-sm text-schemafy-dark-gray">
-          Don't have an account?
-        </p>
-        <ButtonLink
-          variant={'none'}
-          size={'none'}
-          className="text-schemafy-dark-gray"
-          to="/signup"
-        >
-          Sign Up
-        </ButtonLink>
+    <div className="relative flex min-h-[calc(100vh-4.25rem)] w-full items-center justify-center overflow-hidden px-4 py-8 sm:px-6 lg:px-8">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,hsl(var(--schemafy-light-gray)/0.12)_1px,transparent_1px),linear-gradient(180deg,hsl(var(--schemafy-light-gray)/0.12)_1px,transparent_1px)] bg-[size:32px_32px]" />
+      <div className="schemafy-page-card relative grid w-full max-w-5xl overflow-hidden lg:grid-cols-[1.05fr_0.95fr]">
+        <section className="hidden min-h-[34rem] flex-col justify-between border-r border-schemafy-glass-border bg-schemafy-panel/70 p-8 lg:flex">
+          <div className="flex flex-col gap-5">
+            <span className="schemafy-badge w-fit px-3 py-1 font-caption-md">
+              ERD workspace
+            </span>
+            <div className="flex flex-col gap-3">
+              <h2 className="font-heading-xl text-schemafy-text">
+                Design schemas with a calm, precise canvas.
+              </h2>
+              <p className="font-body-sm text-schemafy-dark-gray">
+                Open your projects, collaborate with your team, and keep schema
+                decisions in one polished workspace.
+              </p>
+            </div>
+          </div>
+          <AuthCanvasPreview />
+          <div className="grid grid-cols-2 gap-3">
+            {['ERD canvas', 'DDL export', 'Team roles', 'Memo threads'].map(
+              (item) => (
+                <div
+                  key={item}
+                  className="rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/60 px-3 py-2 font-caption-md text-schemafy-dark-gray"
+                >
+                  {item}
+                </div>
+              ),
+            )}
+          </div>
+        </section>
+        <section className="flex flex-col items-center justify-center px-5 py-8 sm:px-10 sm:py-10 lg:px-12">
+          <div className="mb-6 flex w-full max-w-[480px] flex-col gap-2">
+            <h2 className="font-heading-xl text-schemafy-text">
+              Sign in to Schemafy
+            </h2>
+            <p className="font-body-sm text-schemafy-dark-gray">
+              Continue to your database design workspace.
+            </p>
+          </div>
+          <SignInForm oauthError={oauthError} />
+          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 pb-2 pt-4">
+            <p className="font-body-sm text-schemafy-dark-gray">
+              Don't have an account?
+            </p>
+            <ButtonLink
+              variant={'none'}
+              size={'none'}
+              className="schemafy-menu-button px-2 py-1 text-schemafy-text"
+              to="/signup"
+            >
+              Sign Up
+            </ButtonLink>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const AuthCanvasPreview = () => {
+  const checks = [
+    ['Primary keys visible', KeyRound],
+    ['Relations visible', GitBranch],
+    ['Memos attached', CheckCircle2],
+  ] as const;
+
+  return (
+    <div className="schemafy-strong-panel rounded-2xl p-4">
+      <div className="mb-4 flex items-center justify-between gap-4 border-b border-schemafy-glass-border pb-3">
+        <div className="flex items-center gap-2">
+          <Database className="h-4 w-4 text-schemafy-soft-blue" />
+          <span className="font-heading-xs text-schemafy-text">
+            Design Preview
+          </span>
+        </div>
+        <span className="rounded-full bg-schemafy-green/12 px-2.5 py-1 font-caption-sm text-schemafy-green">
+          Ready
+        </span>
+      </div>
+      <div className="grid gap-3">
+        {checks.map(([label, Icon]) => (
+          <div
+            key={label}
+            className="flex items-center justify-between gap-3 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/55 px-3 py-2.5"
+          >
+            <span className="font-caption-md text-schemafy-text">{label}</span>
+            <Icon className="h-4 w-4 text-schemafy-soft-blue" />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/SignUpPage.tsx
+++ b/apps/frontend/src/pages/SignUpPage.tsx
@@ -1,28 +1,109 @@
+import {
+  CheckCircle2,
+  LockKeyhole,
+  MessageSquare,
+  UsersRound,
+} from 'lucide-react';
 import { ButtonLink } from '@/components';
 import { SignUpForm } from '@/features/auth';
 
 export const SignUpPage = () => {
   return (
-    <div className="py-5 flex flex-col justify-center items-center w-full">
-      <section className="flex flex-col px-4 py-3 w-full items-center justify-center">
-        <h2 className="font-heading-xl">Join Us</h2>
-        <p className="font-body-md text-schemafy-dark-gray mb-2.5">
-          Create your account to get started
-        </p>
-      </section>
-      <SignUpForm />
-      <div className="flex gap-2 pt-1 pb-3 items-center justify-center">
-        <p className="font-body-sm text-schemafy-dark-gray">
-          Already have an account?
-        </p>
-        <ButtonLink
-          variant={'none'}
-          size={'none'}
-          className="text-schemafy-dark-gray"
-          to="/signin"
-        >
-          Sign In
-        </ButtonLink>
+    <div className="relative flex min-h-[calc(100vh-4.25rem)] w-full items-center justify-center overflow-hidden px-4 py-8 sm:px-6 lg:px-8">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,hsl(var(--schemafy-light-gray)/0.12)_1px,transparent_1px),linear-gradient(180deg,hsl(var(--schemafy-light-gray)/0.12)_1px,transparent_1px)] bg-[size:32px_32px]" />
+      <div className="schemafy-page-card relative grid w-full max-w-5xl overflow-hidden lg:grid-cols-[0.95fr_1.05fr]">
+        <section className="flex flex-col items-center justify-center px-5 py-8 sm:px-10 sm:py-10 lg:px-12">
+          <div className="mb-6 flex w-full max-w-[480px] flex-col gap-2">
+            <span className="schemafy-badge w-fit px-3 py-1 font-caption-md">
+              Create workspace access
+            </span>
+            <h2 className="font-heading-xl text-schemafy-text">
+              Join Schemafy
+            </h2>
+            <p className="font-body-sm text-schemafy-dark-gray">
+              Create your account and start designing ERDs with a focused team
+              workspace.
+            </p>
+          </div>
+          <SignUpForm />
+          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 pb-2 pt-4">
+            <p className="font-body-sm text-schemafy-dark-gray">
+              Already have an account?
+            </p>
+            <ButtonLink
+              variant={'none'}
+              size={'none'}
+              className="schemafy-menu-button px-2 py-1 text-schemafy-text"
+              to="/signin"
+            >
+              Sign In
+            </ButtonLink>
+          </div>
+        </section>
+        <section className="hidden min-h-[36rem] flex-col justify-between border-l border-schemafy-glass-border bg-schemafy-panel/70 p-8 lg:flex">
+          <div className="flex flex-col gap-4">
+            <span className="schemafy-badge w-fit px-3 py-1 font-caption-md">
+              Team-ready by default
+            </span>
+            <h3 className="font-heading-lg text-schemafy-text">
+              Everything stays structured from the first table.
+            </h3>
+            <p className="font-body-sm text-schemafy-dark-gray">
+              Invite collaborators, annotate schema decisions, and keep project
+              context close to the ERD canvas.
+            </p>
+          </div>
+          <SignUpAccessPreview />
+          <div className="flex flex-col gap-3">
+            {['Workspaces', 'Role-based access', 'Project sharing'].map(
+              (item) => (
+                <div
+                  key={item}
+                  className="rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/60 px-4 py-3 font-body-sm text-schemafy-text"
+                >
+                  {item}
+                </div>
+              ),
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const SignUpAccessPreview = () => {
+  const rows = [
+    ['Workspace access', UsersRound],
+    ['Email/password account', LockKeyhole],
+    ['Memo comments', MessageSquare],
+  ] as const;
+
+  return (
+    <div className="schemafy-strong-panel rounded-2xl p-4">
+      <div className="mb-4 flex items-center justify-between gap-4 border-b border-schemafy-glass-border pb-3">
+        <span className="font-heading-xs text-schemafy-text">
+          Onboarding checklist
+        </span>
+        <span className="rounded-full bg-schemafy-soft-blue/12 px-2.5 py-1 font-caption-sm text-schemafy-soft-blue">
+          Ready
+        </span>
+      </div>
+      <div className="grid gap-3">
+        {rows.map(([label, Icon]) => (
+          <div
+            key={label}
+            className="flex items-center justify-between gap-3 rounded-xl border border-schemafy-glass-border bg-schemafy-secondary/55 px-3 py-2.5"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <Icon className="h-4 w-4 shrink-0 text-schemafy-violet" />
+              <span className="truncate font-caption-md text-schemafy-text">
+                {label}
+              </span>
+            </div>
+            <CheckCircle2 className="h-4 w-4 shrink-0 text-schemafy-green" />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/WorkspacePage.tsx
+++ b/apps/frontend/src/pages/WorkspacePage.tsx
@@ -63,7 +63,7 @@ export const WorkspacePage = () => {
       onRetry={() => void refetchWorkspaces()}
     >
       {(loadedWorkspacesData) => (
-        <div className="flex w-full min-h-full">
+        <div className="flex min-h-full w-full flex-col overflow-x-hidden md:flex-row md:overflow-hidden">
           <WorkspaceSidebar
             workspaces={workspaces}
             selectedId={selectedWorkspaceId}
@@ -74,65 +74,80 @@ export const WorkspacePage = () => {
           />
 
           {loadedWorkspacesData.totalElements === 0 ? (
-            <div className="flex w-full min-h-full justify-center items-center">
-              워크스페이스를 추가해 주세요
+            <div className="flex min-h-full w-full items-center justify-center px-6">
+              <div className="flex max-w-md flex-col items-center gap-3 border-t border-schemafy-glass-border/70 px-2 py-6 text-center">
+                <h1 className="font-heading-lg text-schemafy-text">
+                  Add your first workspace
+                </h1>
+                <p className="font-body-sm text-schemafy-dark-gray">
+                  Use the workspace action in the sidebar to organize projects,
+                  members, and ERD collaboration.
+                </p>
+              </div>
             </div>
           ) : (
-            <div className="flex-1 flex justify-center py-6 px-8 overflow-hidden">
-              <div
-                className={cn(
-                  'w-full max-w-2xl flex flex-col gap-6 transition-transform duration-300',
-                  isSidebarOpen ? '-translate-x-32' : '-translate-x-6',
-                )}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <h1 className="font-heading-xl text-schemafy-text">
-                      {selectedWorkspace?.name}
-                    </h1>
-                    <span className="px-3 py-1 bg-schemafy-button-bg text-schemafy-button-text font-caption-md rounded-full">
-                      {toCapitalized(currentUserRole)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {currentUserRole === 'ADMIN' && (
-                      <>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setIsEditDialogOpen(true)}
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          size="sm"
-                          onClick={() => setIsInviteDialogOpen(true)}
-                        >
-                          Invite
-                        </Button>
-                      </>
-                    )}
-                  </div>
-                </div>
-
-                <div className="flex gap-6 border-b border-schemafy-light-gray">
-                  {tabs.map((tab) => (
-                    <button
-                      key={tab.key}
-                      onClick={() => setActiveTab(tab.key)}
-                      className={cn(
-                        'pb-3 font-overline-sm flex items-center gap-1.5 border-b-2 -mb-px transition-colors',
-                        activeTab === tab.key
-                          ? 'border-schemafy-text text-schemafy-text'
-                          : 'border-transparent text-schemafy-dark-gray hover:text-schemafy-text',
+            <div className="flex min-w-0 flex-1 justify-center overflow-x-hidden px-4 py-6 sm:px-6 lg:px-10">
+              <div className="flex w-full max-w-6xl flex-col gap-5 transition-transform duration-300">
+                <section className="border-b border-schemafy-glass-border/70 pb-5">
+                  <div className="flex flex-col gap-5">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0">
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                          <h1 className="truncate font-heading-xl text-schemafy-text">
+                            {selectedWorkspace?.name}
+                          </h1>
+                          {currentUserRole && (
+                            <span className="schemafy-badge px-2.5 py-1 font-caption-md">
+                              {toCapitalized(currentUserRole)}
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-2 max-w-2xl font-body-sm text-schemafy-dark-gray">
+                          {selectedWorkspace?.description ||
+                            'Manage projects, members, and schema work in one workspace.'}
+                        </p>
+                      </div>
+                      {currentUserRole === 'ADMIN' && (
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-9 px-4"
+                            onClick={() => setIsEditDialogOpen(true)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            size="sm"
+                            className="h-9 px-4"
+                            onClick={() => setIsInviteDialogOpen(true)}
+                          >
+                            Invite
+                          </Button>
+                        </div>
                       )}
-                    >
-                      {tab.label}
-                    </button>
-                  ))}
-                </div>
+                    </div>
 
-                <div className="flex-1">
+                    <div className="flex w-full gap-6 border-b border-schemafy-glass-border/60 sm:w-fit">
+                      {tabs.map((tab) => (
+                        <button
+                          key={tab.key}
+                          onClick={() => setActiveTab(tab.key)}
+                          className={cn(
+                            'schemafy-focus-ring -mb-px flex flex-1 items-center justify-center border-b-2 px-0 pb-2 font-overline-sm transition-colors sm:flex-none',
+                            activeTab === tab.key
+                              ? 'border-schemafy-soft-blue text-schemafy-text'
+                              : 'border-transparent text-schemafy-dark-gray hover:text-schemafy-text',
+                          )}
+                        >
+                          {tab.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </section>
+
+                <section>
                   {activeTab === 'projects' ? (
                     <WorkspaceProjectsTab
                       key={selectedWorkspaceId}
@@ -145,7 +160,7 @@ export const WorkspacePage = () => {
                       currentUserRole={currentUserRole}
                     />
                   )}
-                </div>
+                </section>
 
                 <LeaveWarningComponent
                   onLeave={() => setIsLeaveConfirmOpen(true)}
@@ -191,9 +206,9 @@ export const WorkspacePage = () => {
 
 const LeaveWarningComponent = ({ onLeave }: { onLeave: () => void }) => {
   return (
-    <div className="border border-schemafy-yellow/30 bg-schemafy-yellow/10 rounded-[12px] px-6 py-5 flex items-center justify-between gap-6">
+    <div className="flex flex-col gap-4 border-t border-schemafy-glass-border/70 pt-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
       <div className="flex flex-col gap-1">
-        <span className="font-heading-xs text-schemafy-yellow">
+        <span className="font-heading-xs text-schemafy-destructive">
           Leave Workspace
         </span>
         <span className="font-body-sm text-schemafy-dark-gray">
@@ -202,9 +217,9 @@ const LeaveWarningComponent = ({ onLeave }: { onLeave: () => void }) => {
         </span>
       </div>
       <Button
-        variant="none"
+        variant="destructive"
         size="sm"
-        className="shrink-0 bg-schemafy-yellow text-white"
+        className="h-9 w-full shrink-0 px-4 sm:w-auto"
         onClick={onLeave}
       >
         Leave

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -41,6 +41,14 @@
   --color-schemafy-button-bg: hsl(var(--schemafy-button-bg));
   --color-schemafy-button-text: hsl(var(--schemafy-button-text));
   --color-schemafy-table-header-bg: hsl(var(--schemafy-table-header-bg));
+  --color-schemafy-canvas: hsl(var(--schemafy-canvas));
+  --color-schemafy-panel: hsl(var(--schemafy-panel));
+  --color-schemafy-panel-strong: hsl(var(--schemafy-panel-strong));
+  --color-schemafy-glass-border: hsl(var(--schemafy-glass-border));
+  --color-schemafy-soft-blue: hsl(var(--schemafy-soft-blue));
+  --color-schemafy-violet: hsl(var(--schemafy-violet));
+  --color-schemafy-edge: hsl(var(--schemafy-edge));
+  --color-schemafy-focus: hsl(var(--schemafy-focus));
   --color-schemafy-bg-80: hsl(var(--schemafy-bg) / 0.8);
   --color-schemafy-tools: hsl(var(--schemafy-tools));
   --color-schemafy-canvas-dot: hsl(var(--schemafy-canvas-dot));
@@ -55,57 +63,69 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 8%;
+    --background: 220 33% 99%;
+    --foreground: 222 47% 11%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 8%;
+    --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 8%;
-    --primary: 0 0% 8%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 222 47% 11%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 218 14% 97%;
-    --secondary-foreground: 0 0% 8%;
-    --muted: 218 14% 97%;
-    --muted-foreground: 0 0% 46%;
-    --accent: 218 14% 97%;
-    --accent-foreground: 0 0% 8%;
+    --secondary: 220 32% 96%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 220 32% 96%;
+    --muted-foreground: 215 16% 44%;
+    --accent: 216 40% 94%;
+    --accent-foreground: 222 47% 11%;
     --destructive: 0 73% 60%;
     --destructive-foreground: 0 0% 100%;
-    --border: 220 13% 91%;
-    --input: 218 14% 97%;
-    --ring: 0 0% 8%;
+    --border: 214 32% 90%;
+    --input: 220 32% 96%;
+    --ring: 217 91% 60%;
     --radius: 0.5rem;
 
-    --schemafy-bg: 0 0% 100%;
-    --schemafy-text: 0 0% 8%;
-    --schemafy-secondary: 218 14% 97%;
-    --schemafy-dark-gray: 0 0% 46%;
-    --schemafy-light-gray: 220 13% 91%;
-    --schemafy-dark-gray-40: 0 0% 46% / 0.4;
+    --schemafy-bg: 220 33% 99%;
+    --schemafy-text: 222 47% 11%;
+    --schemafy-secondary: 220 32% 96%;
+    --schemafy-dark-gray: 215 16% 44%;
+    --schemafy-light-gray: 214 32% 90%;
+    --schemafy-dark-gray-40: 215 16% 44% / 0.4;
     --schemafy-destructive: 0 84% 60%;
-    --schemafy-button-bg: 0 0% 8%;
+    --schemafy-button-bg: 222 47% 11%;
     --schemafy-button-text: 0 0% 100%;
-    --schemafy-table-header-bg: var(--schemafy-button-bg);
-    --schemafy-tools: 0 0% 46% / 0.8;
-    --schemafy-canvas-dot: 0 0% 46% / 0.35;
-    --schemafy-yellow: 40 96% 40%;
-    --schemafy-blue: 218 70% 50%;
-    --schemafy-green: 160 84% 36%;
+    --schemafy-table-header-bg: 0 0% 100% / 0.92;
+    --schemafy-canvas: 222 40% 97%;
+    --schemafy-panel: 0 0% 100% / 0.82;
+    --schemafy-panel-strong: 0 0% 100% / 0.94;
+    --schemafy-glass-border: 214 32% 82% / 0.68;
+    --schemafy-soft-blue: 214 88% 58%;
+    --schemafy-violet: 252 72% 66%;
+    --schemafy-edge: 218 30% 42% / 0.82;
+    --schemafy-focus: 217 91% 60%;
+    --schemafy-tools: 215 16% 44% / 0.82;
+    --schemafy-canvas-dot: 214 30% 70% / 0.32;
+    --schemafy-yellow: 40 88% 45%;
+    --schemafy-blue: 214 82% 54%;
+    --schemafy-green: 160 70% 36%;
+
+    --shadow-schemafy-panel: 0 20px 60px -34px rgb(15 23 42 / 0.55);
+    --shadow-schemafy-float: 0 18px 48px -28px rgb(15 23 42 / 0.72);
+    --shadow-schemafy-node: 0 18px 42px -30px rgb(15 23 42 / 0.55);
 
     /* Font Sizes - Display */
     --text-display-lg: 48px;
     --text-display-lg--line-height: 60px;
-    --text-display-lg--letter-spacing: -2px;
+    --text-display-lg--letter-spacing: 0px;
     --text-display-lg--font-weight: 900;
 
     --text-display-md: 36px;
     --text-display-md--line-height: 45px;
-    --text-display-md--letter-spacing: -2%;
+    --text-display-md--letter-spacing: 0px;
     --text-display-md--font-weight: 900;
 
     --text-display-sm: 30px;
     --text-display-sm--line-height: 39px;
-    --text-display-sm--letter-spacing: -1px;
+    --text-display-sm--letter-spacing: 0px;
     --text-display-sm--font-weight: 900;
 
     /* Font Sizes - Heading */
@@ -161,7 +181,7 @@
     /* Font Sizes - Caption */
     --text-caption-md: 12px;
     --text-caption-md--line-height: 16px;
-    --text-caption-md--letter-spacing: -2%;
+    --text-caption-md--letter-spacing: 0px;
     --text-caption-md--font-weight: 500;
 
     --text-caption-sm: 10px;
@@ -201,41 +221,272 @@
   }
 
   .dark {
-    --background: 240 4% 11%;
-    --foreground: 0 0% 88%;
-    --card: 240 4% 14%;
-    --card-foreground: 0 0% 88%;
-    --popover: 240 4% 14%;
-    --popover-foreground: 0 0% 88%;
-    --primary: 0 0% 88%;
-    --primary-foreground: 240 4% 11%;
-    --secondary: 240 4% 18%;
-    --secondary-foreground: 0 0% 88%;
-    --muted: 240 4% 18%;
-    --muted-foreground: 0 0% 60%;
-    --accent: 240 4% 22%;
-    --accent-foreground: 0 0% 88%;
+    --background: 220 18% 8%;
+    --foreground: 220 18% 92%;
+    --card: 220 15% 12%;
+    --card-foreground: 220 18% 92%;
+    --popover: 220 15% 12%;
+    --popover-foreground: 220 18% 92%;
+    --primary: 220 18% 92%;
+    --primary-foreground: 220 18% 8%;
+    --secondary: 220 13% 15%;
+    --secondary-foreground: 220 18% 92%;
+    --muted: 220 13% 15%;
+    --muted-foreground: 218 11% 66%;
+    --accent: 212 19% 20%;
+    --accent-foreground: 220 18% 92%;
     --destructive: 0 66% 58%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 4% 26%;
-    --input: 240 4% 18%;
-    --ring: 0 0% 64%;
+    --border: 218 14% 27%;
+    --input: 220 13% 15%;
+    --ring: 205 68% 62%;
 
-    --schemafy-bg: 240 4% 11%;
-    --schemafy-text: 0 0% 88%;
-    --schemafy-secondary: 240 4% 18%;
-    --schemafy-dark-gray: 0 0% 60%;
-    --schemafy-light-gray: 240 4% 26%;
-    --schemafy-dark-gray-40: 0 0% 60% / 0.4;
+    --schemafy-bg: 220 18% 8%;
+    --schemafy-text: 220 18% 92%;
+    --schemafy-secondary: 220 13% 15%;
+    --schemafy-dark-gray: 218 11% 66%;
+    --schemafy-light-gray: 218 14% 27%;
+    --schemafy-dark-gray-40: 218 11% 66% / 0.4;
     --schemafy-destructive: 0 66% 58%;
-    --schemafy-button-bg: 240 4% 25%;
-    --schemafy-button-text: 0 0% 88%;
-    --schemafy-table-header-bg: 0 0% 22%;
-    --schemafy-tools: 0 0% 60% / 0.8;
-    --schemafy-canvas-dot: 0 0% 60% / 0.28;
-    --schemafy-yellow: 42 78% 58%;
-    --schemafy-blue: 218 58% 60%;
-    --schemafy-green: 160 54% 44%;
+    --schemafy-button-bg: 220 18% 92%;
+    --schemafy-button-text: 220 18% 8%;
+    --schemafy-table-header-bg: 220 12% 14% / 0.92;
+    --schemafy-canvas: 220 16% 7%;
+    --schemafy-panel: 220 13% 12% / 0.8;
+    --schemafy-panel-strong: 220 12% 14% / 0.94;
+    --schemafy-glass-border: 214 16% 32% / 0.6;
+    --schemafy-soft-blue: 205 68% 64%;
+    --schemafy-violet: 255 48% 70%;
+    --schemafy-edge: 210 22% 68% / 0.74;
+    --schemafy-focus: 205 68% 64%;
+    --schemafy-tools: 218 11% 66% / 0.84;
+    --schemafy-canvas-dot: 214 18% 54% / 0.22;
+    --schemafy-yellow: 40 70% 58%;
+    --schemafy-blue: 205 56% 62%;
+    --schemafy-green: 158 52% 47%;
+
+    --shadow-schemafy-panel: 0 22px 64px -36px rgb(0 0 0 / 0.9);
+    --shadow-schemafy-float: 0 18px 52px -30px rgb(0 0 0 / 0.9);
+    --shadow-schemafy-node: 0 22px 48px -34px rgb(0 0 0 / 0.85);
+  }
+}
+
+@layer components {
+  .schemafy-glass-panel {
+    background: hsl(var(--schemafy-panel));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    box-shadow: var(--shadow-schemafy-panel);
+    backdrop-filter: blur(18px) saturate(1.18);
+  }
+
+  .schemafy-strong-panel {
+    background: hsl(var(--schemafy-panel-strong));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    box-shadow: var(--shadow-schemafy-float);
+    backdrop-filter: blur(16px) saturate(1.14);
+  }
+
+  .schemafy-canvas-panel {
+    background: hsl(var(--schemafy-panel-strong));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    box-shadow: 0 14px 32px -28px rgb(0 0 0 / 0.78);
+    backdrop-filter: none;
+  }
+
+  .schemafy-node-card {
+    background: hsl(var(--schemafy-panel-strong));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    box-shadow: 0 12px 28px -24px rgb(0 0 0 / 0.68);
+    backdrop-filter: none;
+  }
+
+  .schemafy-edge-control {
+    box-shadow: none;
+  }
+
+  .schemafy-focus-ring {
+    outline: none;
+  }
+
+  .schemafy-focus-ring:focus-visible {
+    box-shadow:
+      0 0 0 2px hsl(var(--schemafy-bg)),
+      0 0 0 4px hsl(var(--schemafy-focus) / 0.78);
+  }
+
+  .schemafy-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--schemafy-light-gray)) transparent;
+  }
+
+  .schemafy-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .schemafy-scrollbar::-webkit-scrollbar-thumb {
+    background: hsl(var(--schemafy-light-gray));
+    border-radius: 999px;
+  }
+
+  .schemafy-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .schemafy-page-gradient {
+    background:
+      radial-gradient(
+        circle at 12% 12%,
+        hsl(var(--schemafy-soft-blue) / 0.08),
+        transparent 30%
+      ),
+      radial-gradient(
+        circle at 86% 8%,
+        hsl(var(--schemafy-violet) / 0.08),
+        transparent 28%
+      ),
+      linear-gradient(
+        180deg,
+        hsl(var(--schemafy-bg)),
+        hsl(var(--schemafy-canvas))
+      );
+  }
+
+  .schemafy-page-card {
+    background: hsl(var(--schemafy-panel));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    border-radius: 1.25rem;
+    box-shadow: var(--shadow-schemafy-panel);
+    backdrop-filter: blur(16px) saturate(1.12);
+  }
+
+  .schemafy-subtle-card {
+    background: hsl(var(--schemafy-panel));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    border-radius: 0.875rem;
+    transition:
+      border-color 200ms ease,
+      background-color 200ms ease,
+      box-shadow 200ms ease;
+  }
+
+  .schemafy-subtle-card:hover {
+    border-color: hsl(var(--schemafy-soft-blue) / 0.48);
+    box-shadow: var(--shadow-schemafy-float);
+  }
+
+  .schemafy-input {
+    background: hsl(var(--schemafy-panel-strong));
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    border-radius: 0.875rem;
+    color: hsl(var(--schemafy-text));
+    outline: none;
+    transition:
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .schemafy-input::placeholder {
+    color: hsl(var(--schemafy-dark-gray));
+  }
+
+  .schemafy-input:focus-visible {
+    border-color: hsl(var(--schemafy-soft-blue) / 0.76);
+    box-shadow:
+      0 0 0 1px hsl(var(--schemafy-soft-blue) / 0.22),
+      0 0 0 4px hsl(var(--schemafy-soft-blue) / 0.14);
+  }
+
+  .schemafy-menu-button {
+    border-radius: 999px;
+    color: hsl(var(--schemafy-dark-gray));
+    transition:
+      color 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .schemafy-menu-button:hover {
+    background: hsl(var(--schemafy-secondary));
+    color: hsl(var(--schemafy-text));
+  }
+
+  .schemafy-header-button {
+    transform: none !important;
+    translate: none !important;
+    scale: none !important;
+    transition-property:
+      color, background-color, border-color, box-shadow !important;
+  }
+
+  .schemafy-header-button:hover,
+  .schemafy-header-button:active,
+  .schemafy-header-button[data-state='open'] {
+    transform: none !important;
+    translate: none !important;
+    scale: none !important;
+  }
+
+  .schemafy-header-button[data-state='open'] {
+    background: hsl(var(--schemafy-secondary));
+    color: hsl(var(--schemafy-text));
+  }
+
+  .schemafy-icon-button {
+    border-radius: 0.75rem;
+    color: hsl(var(--schemafy-dark-gray));
+    transition:
+      color 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .schemafy-icon-button:hover {
+    background: hsl(var(--schemafy-secondary));
+    color: hsl(var(--schemafy-text));
+  }
+
+  .schemafy-badge {
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    background: hsl(var(--schemafy-secondary) / 0.72);
+    color: hsl(var(--schemafy-dark-gray));
+    border-radius: 999px;
+  }
+
+  .schemafy-table-shell {
+    background: hsl(var(--schemafy-bg) / 0.45);
+    border: 1px solid hsl(var(--schemafy-glass-border));
+    border-radius: 0.875rem;
+    box-shadow: none;
+    overflow: hidden;
+    backdrop-filter: none;
+  }
+
+  .react-flow__node.selected .schemafy-node-card {
+    border-color: hsl(var(--schemafy-soft-blue) / 0.58);
+    box-shadow: 0 0 0 1px hsl(var(--schemafy-soft-blue) / 0.18);
+  }
+
+  .react-flow__node.selected .react-flow__handle {
+    opacity: 1 !important;
+  }
+
+  .react-flow__edge.selected path.react-flow__edge-path,
+  .react-flow__edge:focus path.react-flow__edge-path {
+    stroke: hsl(var(--schemafy-soft-blue));
+    filter: none;
+  }
+
+  @media (max-width: 640px) {
+    .react-flow__minimap {
+      bottom: 5rem !important;
+      right: 1rem !important;
+      width: 7.5rem !important;
+      height: 5rem !important;
+    }
+
+    .schemafy-canvas-controls {
+      right: 1rem !important;
+      bottom: 10.75rem !important;
+    }
   }
 }
 


### PR DESCRIPTION
## 개요

- Schemafy 전반 톤 정리 + 일부 레이아웃 수정
- 랜딩, 인증, 워크스페이스, ERD 캔버스, 메모, 헤더 메뉴의 여백과 정렬, hover/focus 상태 개선, 축 정렬
- 다크/라이트 모드 디자인 토큰과 글래스 패널, 테이블 카드, 관계선, 미니맵 스타일 정리

## 참고

| 화면 | Light mode | Dark mode |
| --- | --- | --- |
| Landing | <img width="420" alt="Landing Light" src="https://github.com/user-attachments/assets/4670bb04-4994-42b7-b7fe-243545fae868" /><br/><sub>`light/01-landing.png`</sub> | <img width="420" alt="Landing Dark" src="https://github.com/user-attachments/assets/f7aeb569-81f7-4322-96d5-acf7eead59e1" /><br/><sub>`dark/01-landing.png`</sub> |
| Sign In | <img width="420" alt="Sign In Light" src="https://github.com/user-attachments/assets/3f2f959f-9c2c-40de-99ea-b4dc2d167e4c" /><br/><sub>`light/02-sign-in.png`</sub> | <img width="420" alt="Sign In Dark" src="https://github.com/user-attachments/assets/4d2ceebd-7888-48b7-8048-eaec773d51ad" /><br/><sub>`dark/02-sign-in.png`</sub> |
| Sign Up | <img width="420" alt="Sign Up Light" src="https://github.com/user-attachments/assets/d006bef9-2e4c-405d-b329-32647e73bd05" /><br/><sub>`light/03-sign-up.png`</sub> | <img width="420" alt="Sign Up Dark" src="https://github.com/user-attachments/assets/e7f88f52-497b-42ec-9878-414828b31151" /><br/><sub>`dark/03-sign-up.png`</sub> |
| Workspace Projects | <img width="420" alt="Workspace Projects Light" src="https://github.com/user-attachments/assets/49c6754e-0beb-451e-bf4b-098f819ca173" /><br/><sub>`light/04-workspace-projects.png`</sub> | <img width="420" alt="Workspace Projects Dark" src="https://github.com/user-attachments/assets/4ee07545-48ec-473a-8cd3-d37cd262e2a7" /><br/><sub>`dark/04-workspace-projects.png`</sub> |
| Workspace Members | <img width="420" alt="Workspace Members Light" src="https://github.com/user-attachments/assets/f1e85339-2bda-4d7d-a2ea-68171aabfe05" /><br/><sub>`light/05-workspace-members.png`</sub> | <img width="420" alt="Workspace Members Dark" src="https://github.com/user-attachments/assets/8b7ed8de-9d23-480e-b920-fdfccce8f692" /><br/><sub>`dark/05-workspace-members.png`</sub> |
| ERD Canvas | <img width="420" alt="ERD Canvas Light" src="https://github.com/user-attachments/assets/b6e28556-63db-4de7-9bf9-1937e85e7716" /><br/><sub>`light/06-erd-canvas-tables-relationships-memo.png`</sub> | <img width="420" alt="ERD Canvas Dark" src="https://github.com/user-attachments/assets/312fe0ed-bd19-4dcd-98fa-050acbdfea64" /><br/><sub>`dark/06-erd-canvas-tables-relationships-memo.png`</sub> |
| Schema Panel | <img width="420" alt="Schema Panel Light" src="https://github.com/user-attachments/assets/26a26582-708e-478d-be56-80d06a26a8fe" /><br/><sub>`light/07-erd-canvas-schema-panel.png`</sub> | <img width="420" alt="Schema Panel Dark" src="https://github.com/user-attachments/assets/317e0ba6-6709-4cef-9e8b-e98c3a041e46" /><br/><sub>`dark/07-erd-canvas-schema-panel.png`</sub> |
