### PR TITLE
fix: clear MySQL DDL SpotBugs dead stores

### DIFF
--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/ddl/domain/mysql/MySqlDdlGenerator.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/ddl/domain/mysql/MySqlDdlGenerator.java
@@ -344,7 +344,7 @@ public class MySqlDdlGenerator implements DdlGenerator {
 
   private List<String> uniqueKeyStatements(TableSnapshot snapshot,
       DdlContext context) {
-    Table table = requireTable(snapshot);
+    requireTable(snapshot);
     return constraintsOf(snapshot, ConstraintKind.UNIQUE).stream()
         .sorted(comparingNullableStrings(
             constraint -> constraint.constraint().name(),
@@ -384,7 +384,7 @@ public class MySqlDdlGenerator implements DdlGenerator {
 
   private List<String> indexStatements(TableSnapshot snapshot,
       DdlContext context) {
-    Table table = requireTable(snapshot);
+    requireTable(snapshot);
     return snapshot.indexes().stream()
         .map(MySqlDdlGenerator::requireIndex)
         .sorted(comparingNullableStrings(


### PR DESCRIPTION
## 개요

- MySQL DDL generator의 unique/index statement 생성 경로에서 사용하지 않는 `table` 로컬 변수 제거
