### PR TITLE
fix(#384): validate all fields on form submit instead of relying on stale errors state

### DIFF
--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -68,7 +68,14 @@ const validationRules: ValidationRules<SignUpFormValues> = {
 };
 
 export const SignUpForm = () => {
-  const { form, errors, handleChange, handleBlur, resetForm } = useFormState(
+  const {
+    form,
+    errors,
+    handleChange,
+    handleBlur,
+    runAllValidations,
+    resetForm,
+  } = useFormState(
     initialForm,
     validationRules,
   );
@@ -78,8 +85,7 @@ export const SignUpForm = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const hasErrors = Object.keys(errors).length > 0;
-    if (hasErrors) {
+    if (!runAllValidations(form)) {
       return;
     }
 

--- a/apps/frontend/src/features/auth/components/SignUpForm.tsx
+++ b/apps/frontend/src/features/auth/components/SignUpForm.tsx
@@ -75,10 +75,7 @@ export const SignUpForm = () => {
     handleBlur,
     runAllValidations,
     resetForm,
-  } = useFormState(
-    initialForm,
-    validationRules,
-  );
+  } = useFormState(initialForm, validationRules);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
 

--- a/apps/frontend/src/features/auth/hooks/useFormState.ts
+++ b/apps/frontend/src/features/auth/hooks/useFormState.ts
@@ -10,7 +10,7 @@ export const useFormState = <T extends FormValues>(
   const touchedRef = useRef<Partial<Record<keyof T, boolean>>>({});
 
   const validateField = useCallback(
-    (name: keyof T, value: T[keyof T], currentForm: T) => {
+    (name: keyof T, value: T[keyof T], currentForm: T): string => {
       const validator = validationRules[name];
       if (validator) {
         const error = validator(value, currentForm);
@@ -22,7 +22,9 @@ export const useFormState = <T extends FormValues>(
           }
           return { ...prev, [name]: error };
         });
+        return error;
       }
+      return '';
     },
     [validationRules],
   );
@@ -62,6 +64,27 @@ export const useFormState = <T extends FormValues>(
     [validateField],
   );
 
+  const runAllValidations = useCallback(
+    (currentForm: T): boolean => {
+      let isValid = true;
+
+      (Object.keys(validationRules) as Array<keyof T>).forEach((field) => {
+        const error = validateField(field, currentForm[field], currentForm);
+        if (error) {
+          isValid = false;
+        }
+      });
+
+      touchedRef.current = Object.keys(validationRules).reduce(
+        (acc, key) => ({ ...acc, [key]: true }),
+        {} as Partial<Record<keyof T, boolean>>,
+      );
+
+      return isValid;
+    },
+    [validateField, validationRules],
+  );
+
   const resetForm = useCallback(() => {
     setForm(initialForm);
     setErrors({});
@@ -72,6 +95,7 @@ export const useFormState = <T extends FormValues>(
     errors,
     handleChange,
     handleBlur,
+    runAllValidations,
     resetForm,
   };
 };


### PR DESCRIPTION
## 개요
- 회원가입 시 validate를 스킵하는 문제를 수정하였습니다.
- validate가 blur, textchange에만 의존하고 있었기 때문에 엔터키를 통한 회원가입 시 비밀번호 확인이 스킵되었습니다.
- submit을 진행할 때 모든 필드에 대한 validation을 진행하고, 적합하지 않으면 api 요청을 진행하지 않도록 수정하였습니다.

- close #384