### PR TITLE
fix: align reorder fixture with schema creation contract

### DIFF
--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/operation/integration/ErdOperationLedgerIntegrationTest.java
@@ -1654,7 +1654,6 @@ class ErdOperationLedgerIntegrationTest extends ErdProjectIntegrationSupport {
     String projectId = createActiveProjectId(suffix);
     String schemaId = createSchemaUseCase.createSchema(new CreateSchemaCommand(
         projectId,
-        "MySQL",
         suffix + "_schema",
         "utf8mb4",
         "utf8mb4_general_ci")).block().result().id();


### PR DESCRIPTION
## 개요

- Project DB Vendor profile 적용 이후 변경된 `CreateSchemaCommand` 계약에 맞춰 reorder 통합 테스트 fixture의 stale `dbVendorName` 인자 제거
- `main`의 `:core:compileTestJava` 실패 복구
