### PR TITLE
fix(#472): enforce lint and format checks

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -7,8 +7,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   lint-and-format:
@@ -62,33 +61,6 @@ jobs:
     
     - name: Run linters
       run: pnpm run lint
-      continue-on-error: true
 
-    - name: Apply formatting (no cache)
-      run: pnpm run format --force
-      continue-on-error: true
-    
-    - name: Check for changes
-      id: check-changes
-      run: |
-        echo "Checking for changes after formatting..."
-        git status --porcelain
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "changes=true" >> $GITHUB_OUTPUT
-        else
-          echo "changes=false" >> $GITHUB_OUTPUT
-        fi
-    
-    - name: Show changes
-      if: steps.check-changes.outputs.changes == 'true'
-      run: |
-        git diff --stat
-    
-    - name: Commit and push changes
-      if: steps.check-changes.outputs.changes == 'true'
-      run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add -A
-        git diff --staged --quiet || git commit -m "style: auto-format code"
-        git push
+    - name: Check formatting (no cache)
+      run: pnpm run format:check --force

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,8 +1,6 @@
 name: Lint and Format Check
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -15,10 +13,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        fetch-depth: 0
-        ref: ${{ github.head_ref }}
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4


### PR DESCRIPTION
## 개요

- Lint 오류를 PR 검사 실패로 전파
- Formatter를 자동 수정·커밋 방식에서 포맷 검증 방식으로 변경
- Lint/Formatter 워크플로를 PR 이벤트에서만 실행하고 read-only 권한과 기본 merge checkout 적용

## 참고

- 기존 Frontend Lint parsing error 및 경고는 이번 범위에서 수정하지 않음

## 이슈

- close #472
