### PR TITLE
refactor(#271): serialize project lifecycle mutations

### DIFF
--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
@@ -734,26 +734,6 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
   }
 
   @Test
-  @DisplayName("마지막 멤버 탈퇴시 프로젝트도 삭제된다")
-  void leaveProject_LastMember_ProjectDeleted() {
-    Project project = saveProject(testWorkspaceId, "Test Project", "Description");
-
-    ProjectMember loneProjectMember = addProjectMember(project.getId(), testUser2Id,
-        ProjectRole.VIEWER);
-
-    webTestClient.delete()
-        .uri(ApiPath.API.replace("{version}", "v1.0")
-            + "/projects/{projectId}/members/me",
-            project.getId())
-        .header("Authorization", "Bearer " + accessToken2).exchange()
-        .expectStatus().isNoContent();
-
-    Project deletedProject = projectRepository
-        .findByIdAndNotDeleted(project.getId()).block();
-    assertThat(deletedProject).isNull();
-  }
-
-  @Test
   @DisplayName("마지막 ADMIN도 워크스페이스 내에 멤버가 존재하면 탈퇴할 수 있다")
   void leaveProject_LastAdmin_Allowed() {
     Project project = saveProject(testWorkspaceId, "Test Project", "Description");

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
+import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
@@ -28,6 +29,28 @@ public interface ProjectMemberRepository
 
   @Query("UPDATE project_members SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE project_id = :projectId AND deleted_at IS NULL")
   Mono<Void> softDeleteByProjectId(String projectId);
+
+  @Modifying
+  @Query("""
+      UPDATE project_members
+      SET deleted_at = CURRENT_TIMESTAMP,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE project_id = :projectId
+        AND user_id = :userId
+        AND deleted_at IS NULL
+      """)
+  Mono<Long> softDeleteByProjectIdAndUserId(String projectId, String userId);
+
+  @Modifying
+  @Query("""
+      UPDATE project_members
+      SET role = :role,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE project_id = :projectId
+        AND user_id = :userId
+        AND deleted_at IS NULL
+      """)
+  Mono<Long> updateRoleIfActive(String projectId, String userId, String role);
 
   @Query("SELECT COUNT(*) FROM project_members WHERE project_id = :projectId AND role = :role AND deleted_at IS NULL")
   Mono<Long> countByProjectIdAndRoleAndNotDeleted(String projectId,

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -35,6 +35,20 @@ public class ProjectPersistenceAdapter
   }
 
   @Override
+  public Mono<String> lockByIdAndNotDeletedInShareMode(String projectId) {
+    return projectRepository
+        .findWithSharedLockByIdAndDeletedAtIsNull(projectId)
+        .map(Project::getId);
+  }
+
+  @Override
+  public Mono<String> lockByIdAndNotDeletedForUpdate(String projectId) {
+    return projectRepository
+        .findWithExclusiveLockByIdAndDeletedAtIsNull(projectId)
+        .map(Project::getId);
+  }
+
+  @Override
   public Mono<Boolean> existsActiveProjectById(String projectId) {
     return projectRepository.findByIdAndNotDeleted(projectId)
         .hasElement();

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -35,6 +35,12 @@ public class ProjectPersistenceAdapter
   }
 
   @Override
+  public Mono<Long> updateIfActive(String projectId, String name,
+      String description) {
+    return projectRepository.updateIfActive(projectId, name, description);
+  }
+
+  @Override
   public Mono<String> lockByIdAndNotDeletedInShareMode(String projectId) {
     return projectRepository
         .findWithSharedLockByIdAndDeletedAtIsNull(projectId)
@@ -119,6 +125,19 @@ public class ProjectPersistenceAdapter
   @Override
   public Mono<Void> softDeleteByProjectId(String projectId) {
     return projectMemberRepository.softDeleteByProjectId(projectId);
+  }
+
+  @Override
+  public Mono<Long> softDeleteByProjectIdAndUserId(String projectId,
+      String userId) {
+    return projectMemberRepository.softDeleteByProjectIdAndUserId(projectId,
+        userId);
+  }
+
+  @Override
+  public Mono<Long> updateRoleIfActive(String projectId, String userId,
+      String role) {
+    return projectMemberRepository.updateRoleIfActive(projectId, userId, role);
   }
 
   @Override

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
+import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.relational.core.sql.LockMode;
 import org.springframework.data.relational.repository.Lock;
@@ -20,6 +21,17 @@ public interface ProjectRepository extends ReactiveCrudRepository<Project, Strin
 
   @Query("SELECT * FROM projects WHERE id = :id AND deleted_at IS NULL")
   Mono<Project> findByIdAndNotDeleted(String id);
+
+  @Modifying
+  @Query("""
+      UPDATE projects
+      SET name = :name,
+          description = :description,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = :id
+        AND deleted_at IS NULL
+      """)
+  Mono<Long> updateIfActive(String id, String name, String description);
 
   @Query("SELECT * FROM projects WHERE workspace_id = :workspaceId AND deleted_at IS NULL")
   Flux<Project> findByWorkspaceIdAndNotDeleted(String workspaceId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
@@ -1,6 +1,8 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.relational.core.sql.LockMode;
+import org.springframework.data.relational.repository.Lock;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import com.schemafy.core.project.domain.Project;
@@ -9,6 +11,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ProjectRepository extends ReactiveCrudRepository<Project, String> {
+
+  @Lock(LockMode.PESSIMISTIC_READ)
+  Mono<Project> findWithSharedLockByIdAndDeletedAtIsNull(String id);
+
+  @Lock(LockMode.PESSIMISTIC_WRITE)
+  Mono<Project> findWithExclusiveLockByIdAndDeletedAtIsNull(String id);
 
   @Query("SELECT * FROM projects WHERE id = :id AND deleted_at IS NULL")
   Mono<Project> findByIdAndNotDeleted(String id);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkPersistenceAdapter.java
@@ -30,6 +30,19 @@ public class ShareLinkPersistenceAdapter implements ShareLinkPort {
   }
 
   @Override
+  public Mono<Long> softDeleteByIdAndProjectId(String shareLinkId,
+      String projectId) {
+    return shareLinkRepository.softDeleteByIdAndProjectId(shareLinkId,
+        projectId);
+  }
+
+  @Override
+  public Mono<Long> revokeByIdAndProjectId(String shareLinkId,
+      String projectId) {
+    return shareLinkRepository.revokeByIdAndProjectId(shareLinkId, projectId);
+  }
+
+  @Override
   public Flux<ShareLink> findByProjectIdAndNotDeleted(String projectId,
       int limit, int offset) {
     return shareLinkRepository.findByProjectIdAndNotDeleted(projectId, limit,

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
+import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
@@ -14,8 +15,40 @@ public interface ShareLinkRepository
   @Query("SELECT * FROM share_links WHERE code = :code AND deleted_at IS NULL")
   Mono<ShareLink> findByCodeAndNotDeleted(String code);
 
-  @Query("UPDATE share_links SET last_accessed_at = CURRENT_TIMESTAMP, access_count = access_count + 1 WHERE id = :id")
+  @Modifying
+  @Query("""
+      UPDATE share_links
+      SET last_accessed_at = CURRENT_TIMESTAMP,
+          access_count = access_count + 1
+      WHERE id = :id
+        AND deleted_at IS NULL
+        AND is_revoked = FALSE
+        AND expires_at > CURRENT_TIMESTAMP
+      """)
   Mono<Void> incrementAccessCount(String id);
+
+  @Modifying
+  @Query("""
+      UPDATE share_links
+      SET deleted_at = CURRENT_TIMESTAMP,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = :shareLinkId
+        AND project_id = :projectId
+        AND deleted_at IS NULL
+      """)
+  Mono<Long> softDeleteByIdAndProjectId(String shareLinkId, String projectId);
+
+  @Modifying
+  @Query("""
+      UPDATE share_links
+      SET is_revoked = TRUE,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = :shareLinkId
+        AND project_id = :projectId
+        AND deleted_at IS NULL
+        AND is_revoked = FALSE
+      """)
+  Mono<Long> revokeByIdAndProjectId(String shareLinkId, String projectId);
 
   @Query("SELECT * FROM share_links WHERE project_id = :projectId AND deleted_at IS NULL ORDER BY created_at DESC LIMIT :limit OFFSET :offset")
   Flux<ShareLink> findByProjectIdAndNotDeleted(String projectId, int limit,

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ShareLinkRepository.java
@@ -23,7 +23,10 @@ public interface ShareLinkRepository
       WHERE id = :id
         AND deleted_at IS NULL
         AND is_revoked = FALSE
-        AND expires_at > CURRENT_TIMESTAMP
+        AND (
+          expires_at IS NULL
+          OR expires_at > CURRENT_TIMESTAMP
+        )
       """)
   Mono<Void> incrementAccessCount(String id);
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
@@ -29,6 +29,12 @@ public class WorkspacePersistenceAdapter
   }
 
   @Override
+  public Mono<Workspace> findByIdAndNotDeletedInShareMode(String workspaceId) {
+    return workspaceRepository
+        .findWithSharedLockByIdAndDeletedAtIsNull(workspaceId);
+  }
+
+  @Override
   public Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId) {
     return workspaceRepository
         .findWithExclusiveLockByIdAndDeletedAtIsNull(workspaceId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
@@ -29,6 +29,12 @@ public class WorkspacePersistenceAdapter
   }
 
   @Override
+  public Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId) {
+    return workspaceRepository
+        .findWithExclusiveLockByIdAndDeletedAtIsNull(workspaceId);
+  }
+
+  @Override
   public Flux<Workspace> findByUserIdWithPaging(String userId, int limit,
       int offset) {
     return workspaceRepository.findByUserIdWithPaging(userId, limit, offset);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
@@ -19,6 +19,9 @@ public interface WorkspaceRepository
       """)
   Mono<Workspace> findByIdAndNotDeleted(String id);
 
+  @Lock(LockMode.PESSIMISTIC_READ)
+  Mono<Workspace> findWithSharedLockByIdAndDeletedAtIsNull(String id);
+
   @Lock(LockMode.PESSIMISTIC_WRITE)
   Mono<Workspace> findWithExclusiveLockByIdAndDeletedAtIsNull(String id);
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
@@ -1,6 +1,8 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
 import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.relational.core.sql.LockMode;
+import org.springframework.data.relational.repository.Lock;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 import com.schemafy.core.project.domain.Workspace;
@@ -16,6 +18,9 @@ public interface WorkspaceRepository
       WHERE id = :id AND deleted_at IS NULL
       """)
   Mono<Workspace> findByIdAndNotDeleted(String id);
+
+  @Lock(LockMode.PESSIMISTIC_WRITE)
+  Mono<Workspace> findWithExclusiveLockByIdAndDeletedAtIsNull(String id);
 
   @Query("""
       SELECT w.* FROM workspaces w

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectMemberPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectMemberPort.java
@@ -26,6 +26,10 @@ public interface ProjectMemberPort {
 
   Mono<Void> softDeleteByProjectId(String projectId);
 
+  Mono<Long> softDeleteByProjectIdAndUserId(String projectId, String userId);
+
+  Mono<Long> updateRoleIfActive(String projectId, String userId, String role);
+
   Mono<Long> countByProjectIdAndRoleAndNotDeleted(
       String projectId,
       String role);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
@@ -13,6 +13,10 @@ public interface ProjectPort {
 
   Mono<Project> findByIdAndNotDeleted(String projectId);
 
+  Mono<String> lockByIdAndNotDeletedInShareMode(String projectId);
+
+  Mono<String> lockByIdAndNotDeletedForUpdate(String projectId);
+
   Flux<Project> findByWorkspaceIdAndNotDeleted(String workspaceId);
 
   Flux<Project> findByWorkspaceId(String workspaceId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectPort.java
@@ -13,6 +13,8 @@ public interface ProjectPort {
 
   Mono<Project> findByIdAndNotDeleted(String projectId);
 
+  Mono<Long> updateIfActive(String projectId, String name, String description);
+
   Mono<String> lockByIdAndNotDeletedInShareMode(String projectId);
 
   Mono<String> lockByIdAndNotDeletedForUpdate(String projectId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ShareLinkPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ShareLinkPort.java
@@ -13,6 +13,10 @@ public interface ShareLinkPort {
 
   Mono<Void> incrementAccessCount(String shareLinkId);
 
+  Mono<Long> softDeleteByIdAndProjectId(String shareLinkId, String projectId);
+
+  Mono<Long> revokeByIdAndProjectId(String shareLinkId, String projectId);
+
   Flux<ShareLink> findByProjectIdAndNotDeleted(
       String projectId,
       int limit,

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
@@ -11,6 +11,8 @@ public interface WorkspacePort {
 
   Mono<Workspace> findByIdAndNotDeleted(String workspaceId);
 
+  Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId);
+
   Flux<Workspace> findByUserIdWithPaging(String userId, int limit, int offset);
 
   Mono<Long> countByUserId(String userId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
@@ -11,6 +11,8 @@ public interface WorkspacePort {
 
   Mono<Workspace> findByIdAndNotDeleted(String workspaceId);
 
+  Mono<Workspace> findByIdAndNotDeletedInShareMode(String workspaceId);
+
   Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId);
 
   Flux<Workspace> findByUserIdWithPaging(String userId, int limit, int offset);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateShareLinkService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateShareLinkService.java
@@ -3,7 +3,6 @@ package com.schemafy.core.project.application.service;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.CreateShareLinkCommand;
@@ -20,22 +19,22 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class CreateShareLinkService implements CreateShareLinkUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final UlidGeneratorPort ulidGeneratorPort;
   private final ShareLinkPort shareLinkPort;
   private final ShareLinkHelper shareLinkHelper;
+  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ShareLink> createShareLink(CreateShareLinkCommand command) {
-    return shareLinkHelper.findProjectById(command.projectId())
-        .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
-            .flatMap(id -> {
-              String code = UUID.randomUUID().toString().replace("-", "");
-              return shareLinkPort.save(
-                  ShareLink.create(id, command.projectId(), code));
-            }))
-        .as(transactionalOperator::transactional);
+    return projectMutationGuard.protectChildCreation(command.projectId(),
+        () -> shareLinkHelper.findProjectById(command.projectId())
+            .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
+                .flatMap(id -> {
+                  String code = UUID.randomUUID().toString().replace("-", "");
+                  return shareLinkPort.save(
+                      ShareLink.create(id, command.projectId(), code));
+                })));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
@@ -21,7 +21,7 @@ class DeleteProjectService implements DeleteProjectUseCase {
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<Void> deleteProject(DeleteProjectCommand command) {
-    return projectMutationGuard.protectWorkspaceAndProjectMutation(command.projectId(),
+    return projectMutationGuard.protectProjectDeletion(command.projectId(),
         () -> projectAccessHelper.findProjectById(command.projectId())
             .flatMap(projectCascadeHelper::softDeleteLockedProjectCascade));
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteProjectService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
@@ -15,16 +14,16 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class DeleteProjectService implements DeleteProjectUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final ProjectAccessHelper projectAccessHelper;
   private final ProjectCascadeHelper projectCascadeHelper;
+  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<Void> deleteProject(DeleteProjectCommand command) {
-    return projectAccessHelper.findProjectById(command.projectId())
-        .flatMap(projectCascadeHelper::softDeleteProjectCascade)
-        .as(transactionalOperator::transactional);
+    return projectMutationGuard.protectWorkspaceAndProjectMutation(command.projectId(),
+        () -> projectAccessHelper.findProjectById(command.projectId())
+            .flatMap(projectCascadeHelper::softDeleteLockedProjectCascade));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteShareLinkService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteShareLinkService.java
@@ -3,11 +3,13 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkUseCase;
 import com.schemafy.core.project.application.port.out.ShareLinkPort;
 import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ShareLinkErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -25,10 +27,12 @@ class DeleteShareLinkService implements DeleteShareLinkUseCase {
   public Mono<Void> deleteShareLink(DeleteShareLinkCommand command) {
     return shareLinkHelper.findShareLinkById(command.shareLinkId(),
         command.projectId())
-        .flatMap(link -> {
-          link.delete();
-          return shareLinkPort.save(link).then();
-        })
+        .then(shareLinkPort.softDeleteByIdAndProjectId(
+            command.shareLinkId(), command.projectId()))
+        .flatMap(updated -> updated > 0
+            ? Mono.<Void>empty()
+            : Mono.<Void>error(new DomainException(
+                ShareLinkErrorCode.NOT_FOUND)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteShareLinkService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteShareLinkService.java
@@ -20,15 +20,12 @@ class DeleteShareLinkService implements DeleteShareLinkUseCase {
 
   private final TransactionalOperator transactionalOperator;
   private final ShareLinkPort shareLinkPort;
-  private final ShareLinkHelper shareLinkHelper;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<Void> deleteShareLink(DeleteShareLinkCommand command) {
-    return shareLinkHelper.findShareLinkById(command.shareLinkId(),
+    return shareLinkPort.softDeleteByIdAndProjectId(command.shareLinkId(),
         command.projectId())
-        .then(shareLinkPort.softDeleteByIdAndProjectId(
-            command.shareLinkId(), command.projectId()))
         .flatMap(updated -> updated > 0
             ? Mono.<Void>empty()
             : Mono.<Void>error(new DomainException(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveProjectService.java
@@ -1,14 +1,10 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
 import com.schemafy.core.project.application.port.in.LeaveProjectUseCase;
-import com.schemafy.core.project.application.port.out.ProjectMemberPort;
-import com.schemafy.core.project.application.port.out.ProjectPort;
-import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectRole;
 
 import lombok.RequiredArgsConstructor;
@@ -18,32 +14,21 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class LeaveProjectService implements LeaveProjectUseCase {
 
-  private final TransactionalOperator transactionalOperator;
-  private final ProjectPort projectPort;
-  private final ProjectMemberPort projectMemberPort;
   private final ProjectAccessHelper projectAccessHelper;
-  private final ProjectCascadeHelper projectCascadeHelper;
+  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.VIEWER)
   public Mono<Void> leaveProject(LeaveProjectCommand command) {
-    return projectAccessHelper.findProjectMember(command.requesterId(),
-        command.projectId())
+    return projectMutationGuard.protectWorkspaceAndProjectMutation(command.projectId(),
+        () -> applyLeave(command));
+  }
+
+  private Mono<Void> applyLeave(LeaveProjectCommand command) {
+    return projectAccessHelper.findProjectMember(command.requesterId(), command.projectId())
         .flatMap(member -> projectAccessHelper.validateWorkspaceAdminGuard(command.projectId(), member)
             .thenReturn(member))
-        .flatMap(member -> projectMemberPort.countByProjectIdAndNotDeleted(command.projectId())
-            .flatMap(memberCount -> {
-              if (memberCount <= 1) {
-                return projectPort.findById(command.projectId())
-                    .flatMap(project -> projectCascadeHelper.softDeleteProjectCascade(project)
-                        .thenReturn(project))
-                    .switchIfEmpty(Mono.defer(() -> projectAccessHelper.softDeleteMember(member)
-                        .then(Mono.<Project>empty())))
-                    .then();
-              }
-              return projectAccessHelper.softDeleteMember(member);
-            }))
-        .as(transactionalOperator::transactional);
+        .flatMap(projectAccessHelper::softDeleteMember);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveProjectService.java
@@ -15,13 +15,11 @@ import reactor.core.publisher.Mono;
 class LeaveProjectService implements LeaveProjectUseCase {
 
   private final ProjectAccessHelper projectAccessHelper;
-  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.VIEWER)
   public Mono<Void> leaveProject(LeaveProjectCommand command) {
-    return projectMutationGuard.protectWorkspaceAndProjectMutation(command.projectId(),
-        () -> applyLeave(command));
+    return applyLeave(command);
   }
 
   private Mono<Void> applyLeave(LeaveProjectCommand command) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
@@ -46,8 +46,8 @@ class ProjectAccessHelper {
   }
 
   Mono<Void> softDeleteMember(ProjectMember member) {
-    member.delete();
-    return projectMemberPort.save(member).then();
+    return projectMemberPort.softDeleteByProjectIdAndUserId(member.getProjectId(),
+        member.getUserId()).then();
   }
 
   Mono<Void> validateWorkspaceAdminGuard(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectCascadeHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectCascadeHelper.java
@@ -27,6 +27,13 @@ class ProjectCascadeHelper {
   private final ShareLinkPort shareLinkPort;
 
   Mono<Void> softDeleteProjectCascade(Project project) {
+    return projectPort.lockByIdAndNotDeletedForUpdate(project.getId())
+        .then(projectPort.findById(project.getId()))
+        .defaultIfEmpty(project)
+        .flatMap(this::softDeleteLockedProjectCascade);
+  }
+
+  Mono<Void> softDeleteLockedProjectCascade(Project project) {
     String projectId = project.getId();
     Mono<Void> deleteSchemas = getSchemasByProjectIdPort.findSchemasByProjectId(projectId)
         .concatMap(schema -> deleteSchemaUseCase.deleteSchema(new DeleteSchemaCommand(schema.id()))

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMutationGuard.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMutationGuard.java
@@ -1,0 +1,100 @@
+package com.schemafy.core.project.application.service;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+/**
+ * 주의: 재시도 시 {@code action}이 다시 실행될 수 있으므로 롤백되지 않는 외부 부수효과를 포함하지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ProjectMutationGuard {
+
+  private static final Logger log = LoggerFactory.getLogger(
+      ProjectMutationGuard.class);
+
+  private final ProjectPort projectPort;
+  private final WorkspacePort workspacePort;
+  private final TransactionalOperator transactionalOperator;
+
+  public <T> Mono<T> protectChildCreation(
+      String projectId,
+      Supplier<Mono<T>> action) {
+    return Mono.defer(() -> lockProjectInShareMode(projectId)
+        .then(Mono.defer(action)))
+        .as(transactionalOperator::transactional)
+        .retryWhen(lockRetry(projectId));
+  }
+
+  public <T> Mono<T> protectProjectMutation(
+      String projectId,
+      Supplier<Mono<T>> action) {
+    return Mono.defer(() -> lockProjectForUpdate(projectId)
+        .then(Mono.defer(action)))
+        .as(transactionalOperator::transactional)
+        .retryWhen(lockRetry(projectId));
+  }
+
+  public <T> Mono<T> protectWorkspaceAndProjectMutation(
+      String projectId,
+      Supplier<Mono<T>> action) {
+    return projectPort.findByIdAndNotDeleted(projectId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ProjectErrorCode.NOT_FOUND)))
+        .flatMap(project -> Mono.defer(() -> lockWorkspace(project.getWorkspaceId())
+            .then(lockProjectForUpdate(projectId))
+            .then(Mono.defer(action)))
+            .as(transactionalOperator::transactional)
+            .retryWhen(lockRetry(projectId)));
+  }
+
+  private Mono<Void> lockProjectInShareMode(String projectId) {
+    return projectPort.lockByIdAndNotDeletedInShareMode(projectId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ProjectErrorCode.NOT_FOUND)))
+        .then();
+  }
+
+  private Mono<Void> lockProjectForUpdate(String projectId) {
+    return projectPort.lockByIdAndNotDeletedForUpdate(projectId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ProjectErrorCode.NOT_FOUND)))
+        .then();
+  }
+
+  private Mono<Void> lockWorkspace(String workspaceId) {
+    return workspacePort.findByIdAndNotDeletedForUpdate(workspaceId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            WorkspaceErrorCode.NOT_FOUND)))
+        .then();
+  }
+
+  private Retry lockRetry(String projectId) {
+    return Retry.backoff(3, Duration.ofMillis(25))
+        .maxBackoff(Duration.ofMillis(250))
+        .jitter(0.5)
+        .filter(PessimisticLockingFailureException.class::isInstance)
+        .onRetryExhaustedThrow((spec, signal) -> signal.failure())
+        .doBeforeRetry(signal -> log.warn(
+            "Retrying project mutation transaction: projectId={}, retry={}",
+            projectId, signal.totalRetries() + 1));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMutationGuard.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectMutationGuard.java
@@ -20,9 +20,7 @@ import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
-/**
- * 주의: 재시도 시 {@code action}이 다시 실행될 수 있으므로 롤백되지 않는 외부 부수효과를 포함하지 않는다.
- */
+/** 주의: 재시도 시 {@code action}이 다시 실행될 수 있으므로 롤백되지 않는 외부 부수효과를 포함하지 않는다. */
 @Component
 @RequiredArgsConstructor
 public class ProjectMutationGuard {
@@ -43,22 +41,13 @@ public class ProjectMutationGuard {
         .retryWhen(lockRetry(projectId));
   }
 
-  public <T> Mono<T> protectProjectMutation(
-      String projectId,
-      Supplier<Mono<T>> action) {
-    return Mono.defer(() -> lockProjectForUpdate(projectId)
-        .then(Mono.defer(action)))
-        .as(transactionalOperator::transactional)
-        .retryWhen(lockRetry(projectId));
-  }
-
-  public <T> Mono<T> protectWorkspaceAndProjectMutation(
+  public <T> Mono<T> protectProjectDeletion(
       String projectId,
       Supplier<Mono<T>> action) {
     return projectPort.findByIdAndNotDeleted(projectId)
         .switchIfEmpty(Mono.error(new DomainException(
             ProjectErrorCode.NOT_FOUND)))
-        .flatMap(project -> Mono.defer(() -> lockWorkspace(project.getWorkspaceId())
+        .flatMap(project -> Mono.defer(() -> lockWorkspaceInShareMode(project.getWorkspaceId())
             .then(lockProjectForUpdate(projectId))
             .then(Mono.defer(action)))
             .as(transactionalOperator::transactional)
@@ -79,8 +68,8 @@ public class ProjectMutationGuard {
         .then();
   }
 
-  private Mono<Void> lockWorkspace(String workspaceId) {
-    return workspacePort.findByIdAndNotDeletedForUpdate(workspaceId)
+  private Mono<Void> lockWorkspaceInShareMode(String workspaceId) {
+    return workspacePort.findByIdAndNotDeletedInShareMode(workspaceId)
         .switchIfEmpty(Mono.error(new DomainException(
             WorkspaceErrorCode.NOT_FOUND)))
         .then();

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RevokeShareLinkService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RevokeShareLinkService.java
@@ -28,14 +28,15 @@ class RevokeShareLinkService implements RevokeShareLinkUseCase {
   public Mono<ShareLink> revokeShareLink(RevokeShareLinkCommand command) {
     return shareLinkHelper.findShareLinkById(command.shareLinkId(),
         command.projectId())
-        .flatMap(shareLink -> {
-          if (Boolean.TRUE.equals(shareLink.getIsRevoked())) {
-            return Mono.error(
-                new DomainException(ShareLinkErrorCode.NOT_FOUND));
-          }
-          shareLink.revoke();
-          return shareLinkPort.save(shareLink);
-        })
+        .then(shareLinkPort.revokeByIdAndProjectId(
+            command.shareLinkId(), command.projectId()))
+        .flatMap(updated -> updated > 0
+            ? shareLinkPort.findByIdAndProjectIdAndNotDeleted(
+                command.shareLinkId(), command.projectId())
+                .switchIfEmpty(Mono.error(new DomainException(
+                    ShareLinkErrorCode.NOT_FOUND)))
+            : Mono.error(new DomainException(
+                ShareLinkErrorCode.NOT_FOUND)))
         .as(transactionalOperator::transactional);
   }
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RevokeShareLinkService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RevokeShareLinkService.java
@@ -21,15 +21,12 @@ class RevokeShareLinkService implements RevokeShareLinkUseCase {
 
   private final TransactionalOperator transactionalOperator;
   private final ShareLinkPort shareLinkPort;
-  private final ShareLinkHelper shareLinkHelper;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ShareLink> revokeShareLink(RevokeShareLinkCommand command) {
-    return shareLinkHelper.findShareLinkById(command.shareLinkId(),
+    return shareLinkPort.revokeByIdAndProjectId(command.shareLinkId(),
         command.projectId())
-        .then(shareLinkPort.revokeByIdAndProjectId(
-            command.shareLinkId(), command.projectId()))
         .flatMap(updated -> updated > 0
             ? shareLinkPort.findByIdAndProjectIdAndNotDeleted(
                 command.shareLinkId(), command.projectId())

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleService.java
@@ -3,12 +3,14 @@ package com.schemafy.core.project.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleUseCase;
 import com.schemafy.core.project.application.port.out.ProjectMemberPort;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -40,11 +42,15 @@ class UpdateProjectMemberRoleService implements UpdateProjectMemberRoleUseCase {
               : Mono.empty();
 
           return workspaceAdminGuard
+              .then(projectMemberPort.updateRoleIfActive(target.getProjectId(),
+                  target.getUserId(), command.role().name()))
+              .filter(updatedRows -> updatedRows > 0)
+              .switchIfEmpty(Mono.error(new DomainException(
+                  ProjectErrorCode.MEMBER_NOT_FOUND)))
               .then(Mono.fromSupplier(() -> {
                 target.updateRole(command.role());
                 return target;
-              }))
-              .flatMap(projectMemberPort::save);
+              }));
         })
         .as(transactionalOperator::transactional);
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
@@ -2,12 +2,14 @@ package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
 
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
 import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
 import com.schemafy.core.project.application.port.out.ProjectPort;
 import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -18,19 +20,19 @@ class UpdateProjectService implements UpdateProjectUseCase {
 
   private final ProjectPort projectPort;
   private final ProjectAccessHelper projectAccessHelper;
-  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ProjectDetail> updateProject(UpdateProjectCommand command) {
-    return projectMutationGuard.protectProjectMutation(command.projectId(),
-        () -> projectAccessHelper.findProjectById(command.projectId())
-            .flatMap(project -> {
-              project.update(command.name(), command.description());
-              return projectPort.save(project);
-            })
-            .flatMap(savedProject -> projectAccessHelper.buildProjectDetail(
-                savedProject, command.requesterId())));
+    return projectPort.updateIfActive(command.projectId(), command.name(),
+        command.description())
+        .filter(updatedRows -> updatedRows > 0)
+        .switchIfEmpty(Mono.error(new DomainException(ProjectErrorCode.NOT_FOUND)))
+        .then(projectAccessHelper.findProjectById(command.projectId()))
+        .flatMap(updatedProject -> projectAccessHelper.buildProjectDetail(
+            updatedProject, command.requesterId()))
+        .onErrorMap(DomainException.hasErrorCode(ProjectErrorCode.MEMBER_NOT_FOUND),
+            error -> new DomainException(ProjectErrorCode.NOT_FOUND));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
@@ -17,21 +16,21 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class UpdateProjectService implements UpdateProjectUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final ProjectPort projectPort;
   private final ProjectAccessHelper projectAccessHelper;
+  private final ProjectMutationGuard projectMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ProjectDetail> updateProject(UpdateProjectCommand command) {
-    return projectAccessHelper.findProjectById(command.projectId())
-        .flatMap(project -> {
-          project.update(command.name(), command.description());
-          return projectPort.save(project);
-        })
-        .flatMap(savedProject -> projectAccessHelper.buildProjectDetail(
-            savedProject, command.requesterId()))
-        .as(transactionalOperator::transactional);
+    return projectMutationGuard.protectProjectMutation(command.projectId(),
+        () -> projectAccessHelper.findProjectById(command.projectId())
+            .flatMap(project -> {
+              project.update(command.name(), command.description());
+              return projectPort.save(project);
+            })
+            .flatMap(savedProject -> projectAccessHelper.buildProjectDetail(
+                savedProject, command.requesterId())));
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import com.schemafy.core.config.R2dbcTestConfiguration;
 import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.Workspace;
 import com.schemafy.core.ulid.application.service.UlidGenerator;
 
@@ -118,6 +120,29 @@ class ProjectPersistenceAdapterTest {
         .verifyComplete();
     StepVerifier.create(sut.lockByIdAndNotDeletedForUpdate(project.getId()))
         .expectNext(project.getId())
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("삭제된 프로젝트 멤버십의 역할은 조건부 수정으로 변경하지 않는다")
+  void updateRoleIfActiveDoesNotRestoreDeletedMembership() {
+    Workspace workspace = saveWorkspace("Member Update Workspace");
+    Project project = sut.save(Project.create(UlidGenerator.generate(),
+        workspace.getId(), "Member Update Project", "Description")).block();
+    ProjectMember member = projectMemberRepository.save(ProjectMember.create(
+        UlidGenerator.generate(), project.getId(), "user-id", ProjectRole.VIEWER)).block();
+    sut.softDeleteByProjectIdAndUserId(project.getId(), member.getUserId()).block();
+
+    StepVerifier.create(sut.updateRoleIfActive(project.getId(), member.getUserId(),
+        ProjectRole.EDITOR.name()))
+        .expectNext(0L)
+        .verifyComplete();
+
+    StepVerifier.create(projectMemberRepository.findById(member.getId()))
+        .assertNext(persisted -> {
+          assertThat(persisted.isDeleted()).isTrue();
+          assertThat(persisted.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
+        })
         .verifyComplete();
   }
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapterTest.java
@@ -106,6 +106,21 @@ class ProjectPersistenceAdapterTest {
         .verifyComplete();
   }
 
+  @Test
+  @DisplayName("프로젝트 변경 동기화를 위해 활성 프로젝트를 공유 잠금과 쓰기 잠금으로 조회한다")
+  void findActiveProjectWithMutationLocks() {
+    Workspace workspace = saveWorkspace("Mutation Lock Workspace");
+    Project project = sut.save(Project.create(UlidGenerator.generate(),
+        workspace.getId(), "Mutation Lock Project", "Description")).block();
+
+    StepVerifier.create(sut.lockByIdAndNotDeletedInShareMode(project.getId()))
+        .expectNext(project.getId())
+        .verifyComplete();
+    StepVerifier.create(sut.lockByIdAndNotDeletedForUpdate(project.getId()))
+        .expectNext(project.getId())
+        .verifyComplete();
+  }
+
   private Workspace saveWorkspace(String name) {
     return workspaceRepository.save(Workspace.create(UlidGenerator.generate(), name,
         "Description")).block();

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/RepositoryLockMetadataTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/RepositoryLockMetadataTest.java
@@ -26,8 +26,11 @@ class RepositoryLockMetadataTest {
   }
 
   @Test
-  @DisplayName("워크스페이스 잠금 조회에 배타 잠금을 선언한다")
-  void workspaceHierarchyQueryDeclaresExclusiveLock() {
+  @DisplayName("워크스페이스 저장소는 공유 잠금과 배타 잠금을 구분한다")
+  void workspaceRepositoryDistinguishesSharedAndExclusiveLocks() {
+    assertLockMode(WorkspaceRepository.class,
+        "findWithSharedLockByIdAndDeletedAtIsNull",
+        LockMode.PESSIMISTIC_READ);
     assertLockMode(WorkspaceRepository.class,
         "findWithExclusiveLockByIdAndDeletedAtIsNull",
         LockMode.PESSIMISTIC_WRITE);

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/RepositoryLockMetadataTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/RepositoryLockMetadataTest.java
@@ -1,0 +1,51 @@
+package com.schemafy.core.project.adapter.out.persistence;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.springframework.data.relational.core.sql.LockMode;
+import org.springframework.data.relational.repository.Lock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("프로젝트 변경 저장소 잠금 메타데이터 테스트")
+class RepositoryLockMetadataTest {
+
+  @Test
+  @DisplayName("프로젝트 저장소는 공유 잠금과 배타 잠금을 구분한다")
+  void projectRepositoryDistinguishesSharedAndExclusiveLocks() {
+    assertLockMode(ProjectRepository.class,
+        "findWithSharedLockByIdAndDeletedAtIsNull",
+        LockMode.PESSIMISTIC_READ);
+    assertLockMode(ProjectRepository.class,
+        "findWithExclusiveLockByIdAndDeletedAtIsNull",
+        LockMode.PESSIMISTIC_WRITE);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 잠금 조회에 배타 잠금을 선언한다")
+  void workspaceHierarchyQueryDeclaresExclusiveLock() {
+    assertLockMode(WorkspaceRepository.class,
+        "findWithExclusiveLockByIdAndDeletedAtIsNull",
+        LockMode.PESSIMISTIC_WRITE);
+  }
+
+  private void assertLockMode(Class<?> repositoryType, String methodName,
+      LockMode expected) {
+    Method method = Arrays.stream(repositoryType.getDeclaredMethods())
+        .filter(candidate -> candidate.getName().equals(methodName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError(
+            "잠금 저장소 메서드가 없습니다: " + methodName));
+
+    Lock lock = method.getAnnotation(Lock.class);
+    assertThat(lock)
+        .as("%s의 @Lock", methodName)
+        .isNotNull();
+    assertThat(lock.value()).isEqualTo(expected);
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveProjectServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveProjectServiceTest.java
@@ -1,7 +1,8 @@
 package com.schemafy.core.project.application.service;
 
-import org.springframework.transaction.reactive.TransactionalOperator;
+import java.util.function.Supplier;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,9 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
-import com.schemafy.core.project.application.port.out.ProjectMemberPort;
-import com.schemafy.core.project.application.port.out.ProjectPort;
-import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.ProjectRole;
 
@@ -22,66 +20,34 @@ import reactor.test.StepVerifier;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("LeaveProjectService")
+@DisplayName("프로젝트 탈퇴 서비스 테스트")
 class LeaveProjectServiceTest {
 
   private static final String PROJECT_ID = "project-id";
-  private static final String WORKSPACE_ID = "workspace-id";
   private static final String USER_ID = "user-id";
-
-  @Mock
-  TransactionalOperator transactionalOperator;
-
-  @Mock
-  ProjectPort projectPort;
-
-  @Mock
-  ProjectMemberPort projectMemberPort;
 
   @Mock
   ProjectAccessHelper projectAccessHelper;
 
   @Mock
-  ProjectCascadeHelper projectCascadeHelper;
+  ProjectMutationGuard projectMutationGuard;
 
   @InjectMocks
   LeaveProjectService sut;
 
-  @Test
-  @DisplayName("마지막 멤버이고 프로젝트가 존재하면 cascade만 수행하고 fallback 멤버 삭제는 호출하지 않는다")
-  void leaveProject_lastMemberSkipsFallbackWhenProjectExists() {
-    LeaveProjectCommand command = new LeaveProjectCommand(PROJECT_ID, USER_ID);
-    ProjectMember member = ProjectMember.create("member-id", PROJECT_ID, USER_ID, ProjectRole.VIEWER);
-    Project project = Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description");
-
-    given(projectAccessHelper.findProjectMember(USER_ID, PROJECT_ID))
-        .willReturn(Mono.just(member));
-    given(projectAccessHelper.validateWorkspaceAdminGuard(PROJECT_ID, member))
-        .willReturn(Mono.empty());
-    given(projectMemberPort.countByProjectIdAndNotDeleted(PROJECT_ID))
-        .willReturn(Mono.just(1L));
-    given(projectPort.findById(PROJECT_ID))
-        .willReturn(Mono.just(project));
-    given(projectCascadeHelper.softDeleteProjectCascade(project))
-        .willReturn(Mono.empty());
-    given(transactionalOperator.transactional(any(Mono.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
-
-    StepVerifier.create(sut.leaveProject(command))
-        .verifyComplete();
-
-    then(projectCascadeHelper).should()
-        .softDeleteProjectCascade(project);
-    then(projectAccessHelper).should(never())
-        .softDeleteMember(member);
+  @BeforeEach
+  void setUp() {
+    given(projectMutationGuard.<Void>protectWorkspaceAndProjectMutation(
+        any(String.class), any()))
+        .willAnswer(invocation -> invocation
+            .<Supplier<Mono<Void>>>getArgument(1).get());
   }
 
   @Test
-  @DisplayName("마지막 멤버이지만 프로젝트가 없으면 fallback 멤버 삭제를 수행한다")
-  void leaveProject_lastMemberFallsBackWhenProjectMissing() {
+  @DisplayName("프로젝트 멤버가 탈퇴하면 멤버십만 삭제한다")
+  void leaveProject_softDeletesMembershipOnly() {
     LeaveProjectCommand command = new LeaveProjectCommand(PROJECT_ID, USER_ID);
     ProjectMember member = ProjectMember.create("member-id", PROJECT_ID, USER_ID, ProjectRole.VIEWER);
 
@@ -89,21 +55,13 @@ class LeaveProjectServiceTest {
         .willReturn(Mono.just(member));
     given(projectAccessHelper.validateWorkspaceAdminGuard(PROJECT_ID, member))
         .willReturn(Mono.empty());
-    given(projectMemberPort.countByProjectIdAndNotDeleted(PROJECT_ID))
-        .willReturn(Mono.just(1L));
-    given(projectPort.findById(PROJECT_ID))
-        .willReturn(Mono.empty());
     given(projectAccessHelper.softDeleteMember(member))
         .willReturn(Mono.empty());
-    given(transactionalOperator.transactional(any(Mono.class)))
-        .willAnswer(invocation -> invocation.getArgument(0));
-
     StepVerifier.create(sut.leaveProject(command))
         .verifyComplete();
 
     then(projectAccessHelper).should()
         .softDeleteMember(member);
-    then(projectCascadeHelper).shouldHaveNoInteractions();
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveProjectServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveProjectServiceTest.java
@@ -1,8 +1,5 @@
 package com.schemafy.core.project.application.service;
 
-import java.util.function.Supplier;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +14,6 @@ import com.schemafy.core.project.domain.ProjectRole;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -31,19 +27,8 @@ class LeaveProjectServiceTest {
   @Mock
   ProjectAccessHelper projectAccessHelper;
 
-  @Mock
-  ProjectMutationGuard projectMutationGuard;
-
   @InjectMocks
   LeaveProjectService sut;
-
-  @BeforeEach
-  void setUp() {
-    given(projectMutationGuard.<Void>protectWorkspaceAndProjectMutation(
-        any(String.class), any()))
-        .willAnswer(invocation -> invocation
-            .<Supplier<Mono<Void>>>getArgument(1).get());
-  }
 
   @Test
   @DisplayName("프로젝트 멤버가 탈퇴하면 멤버십만 삭제한다")

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
@@ -1,0 +1,150 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.Workspace;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 변경 보호 테스트")
+class ProjectMutationGuardTest {
+
+  @Mock
+  private ProjectPort projectPort;
+
+  @Mock
+  private WorkspacePort workspacePort;
+
+  @Mock
+  private TransactionalOperator transactionalOperator;
+
+  private ProjectMutationGuard sut;
+
+  @BeforeEach
+  void setUp() {
+    sut = new ProjectMutationGuard(projectPort, workspacePort,
+        transactionalOperator);
+    when(transactionalOperator.<Object>transactional(
+        ArgumentMatchers.<Mono<Object>>any()))
+        .thenAnswer(invocation -> invocation.<Mono<Object>>getArgument(0));
+  }
+
+  @Test
+  @DisplayName("공유 잠금 획득 실패 시 잠금부터 전체 작업을 재시도한다")
+  void protectChildCreation_retriesFromLockWhenLockCannotBeAcquired() {
+    when(projectPort.lockByIdAndNotDeletedInShareMode("project-id"))
+        .thenReturn(Mono.error(new CannotAcquireLockException("lock timeout")))
+        .thenReturn(Mono.just("project-id"));
+
+    StepVerifier.create(sut.protectChildCreation(
+        "project-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(projectPort, times(2))
+        .lockByIdAndNotDeletedInShareMode("project-id");
+  }
+
+  @Test
+  @DisplayName("작업 중 잠금 실패 시 잠금부터 전체 작업을 재시도한다")
+  void protectChildCreation_retriesActionFromLock() {
+    AtomicInteger actionAttempts = new AtomicInteger();
+    when(projectPort.lockByIdAndNotDeletedInShareMode("project-id"))
+        .thenReturn(Mono.just("project-id"));
+
+    StepVerifier.create(sut.protectChildCreation("project-id", () -> Mono.defer(
+        () -> actionAttempts.incrementAndGet() == 1
+            ? Mono.error(new CannotAcquireLockException("lock timeout"))
+            : Mono.just("done"))))
+        .expectNext("done")
+        .verifyComplete();
+
+    assertThat(actionAttempts).hasValue(2);
+    verify(projectPort, times(2))
+        .lockByIdAndNotDeletedInShareMode("project-id");
+  }
+
+  @Test
+  @DisplayName("잠금 재시도 소진 시 마지막 잠금 예외를 그대로 전달한다")
+  void protectChildCreation_propagatesLastLockFailureWhenRetriesExhausted() {
+    CannotAcquireLockException failure = new CannotAcquireLockException(
+        "lock timeout");
+    when(projectPort.lockByIdAndNotDeletedInShareMode("project-id"))
+        .thenReturn(Mono.error(failure));
+
+    StepVerifier.create(sut.protectChildCreation(
+        "project-id", () -> Mono.just("done")))
+        .expectErrorSatisfies(error -> assertThat(error).isSameAs(failure))
+        .verify();
+
+    verify(projectPort, times(4))
+        .lockByIdAndNotDeletedInShareMode("project-id");
+  }
+
+  @Test
+  @DisplayName("프로젝트 변경은 프로젝트만 배타 잠금한다")
+  void protectProjectMutation_locksOnlyProject() {
+    when(projectPort.lockByIdAndNotDeletedForUpdate("project-id"))
+        .thenReturn(Mono.just("project-id"));
+
+    StepVerifier.create(sut.protectProjectMutation(
+        "project-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(projectPort).lockByIdAndNotDeletedForUpdate("project-id");
+    verifyNoInteractions(workspacePort);
+  }
+
+  @Test
+  @DisplayName("워크스페이스와 프로젝트를 함께 잠글 때 워크스페이스를 먼저 잠근다")
+  void protectWorkspaceAndProjectMutation_locksWorkspaceBeforeProject() {
+    Project project = Project.create("project-id", "workspace-id", "Project",
+        "Description");
+    Workspace workspace = Workspace.create("workspace-id", "Workspace",
+        "Description");
+    when(projectPort.findByIdAndNotDeleted("project-id"))
+        .thenReturn(Mono.just(project));
+    when(workspacePort.findByIdAndNotDeletedForUpdate("workspace-id"))
+        .thenReturn(Mono.just(workspace));
+    when(projectPort.lockByIdAndNotDeletedForUpdate("project-id"))
+        .thenReturn(Mono.just("project-id"));
+
+    StepVerifier.create(sut.protectWorkspaceAndProjectMutation(
+        "project-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    InOrder lockOrder = inOrder(workspacePort, projectPort);
+    lockOrder.verify(workspacePort)
+        .findByIdAndNotDeletedForUpdate("workspace-id");
+    lockOrder.verify(projectPort)
+        .lockByIdAndNotDeletedForUpdate("project-id");
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
@@ -23,8 +23,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -49,7 +49,7 @@ class ProjectMutationGuardTest {
   void setUp() {
     sut = new ProjectMutationGuard(projectPort, workspacePort,
         transactionalOperator);
-    when(transactionalOperator.<Object>transactional(
+    lenient().when(transactionalOperator.<Object>transactional(
         ArgumentMatchers.<Mono<Object>>any()))
         .thenAnswer(invocation -> invocation.<Mono<Object>>getArgument(0));
   }
@@ -107,44 +107,60 @@ class ProjectMutationGuardTest {
   }
 
   @Test
-  @DisplayName("프로젝트 변경은 프로젝트만 배타 잠금한다")
-  void protectProjectMutation_locksOnlyProject() {
-    when(projectPort.lockByIdAndNotDeletedForUpdate("project-id"))
-        .thenReturn(Mono.just("project-id"));
-
-    StepVerifier.create(sut.protectProjectMutation(
-        "project-id", () -> Mono.just("done")))
-        .expectNext("done")
-        .verifyComplete();
-
-    verify(projectPort).lockByIdAndNotDeletedForUpdate("project-id");
-    verifyNoInteractions(workspacePort);
-  }
-
-  @Test
-  @DisplayName("워크스페이스와 프로젝트를 함께 잠글 때 워크스페이스를 먼저 잠근다")
-  void protectWorkspaceAndProjectMutation_locksWorkspaceBeforeProject() {
+  @DisplayName("프로젝트 삭제는 워크스페이스 공유 잠금 후 프로젝트 배타 잠금을 획득한다")
+  void protectProjectDeletion_locksWorkspaceSharedThenProjectExclusive() {
     Project project = Project.create("project-id", "workspace-id", "Project",
         "Description");
     Workspace workspace = Workspace.create("workspace-id", "Workspace",
         "Description");
+
     when(projectPort.findByIdAndNotDeleted("project-id"))
         .thenReturn(Mono.just(project));
-    when(workspacePort.findByIdAndNotDeletedForUpdate("workspace-id"))
+    when(workspacePort.findByIdAndNotDeletedInShareMode("workspace-id"))
         .thenReturn(Mono.just(workspace));
     when(projectPort.lockByIdAndNotDeletedForUpdate("project-id"))
         .thenReturn(Mono.just("project-id"));
 
-    StepVerifier.create(sut.protectWorkspaceAndProjectMutation(
+    StepVerifier.create(sut.protectProjectDeletion(
         "project-id", () -> Mono.just("done")))
         .expectNext("done")
         .verifyComplete();
 
+    verify(workspacePort).findByIdAndNotDeletedInShareMode("workspace-id");
+    verify(projectPort).lockByIdAndNotDeletedForUpdate("project-id");
     InOrder lockOrder = inOrder(workspacePort, projectPort);
     lockOrder.verify(workspacePort)
-        .findByIdAndNotDeletedForUpdate("workspace-id");
-    lockOrder.verify(projectPort)
-        .lockByIdAndNotDeletedForUpdate("project-id");
+        .findByIdAndNotDeletedInShareMode("workspace-id");
+    lockOrder.verify(projectPort).lockByIdAndNotDeletedForUpdate("project-id");
+  }
+
+  @Test
+  @DisplayName("프로젝트 삭제 대상이 없으면 작업을 실행하지 않는다")
+  void protectProjectDeletion_rejectsMissingProject() {
+    when(projectPort.findByIdAndNotDeleted("project-id"))
+        .thenReturn(Mono.empty());
+
+    StepVerifier.create(sut.protectProjectDeletion(
+        "project-id", () -> Mono.just("done")))
+        .expectError()
+        .verify();
+
+    verifyNoInteractions(workspacePort);
+  }
+
+  @Test
+  @DisplayName("하위 생성은 프로젝트 공유 잠금만 획득한다")
+  void protectChildCreation_locksOnlyProject() {
+    when(projectPort.lockByIdAndNotDeletedInShareMode("project-id"))
+        .thenReturn(Mono.just("project-id"));
+
+    StepVerifier.create(sut.protectChildCreation(
+        "project-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(projectPort).lockByIdAndNotDeletedInShareMode("project-id");
+    verifyNoInteractions(workspacePort);
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ShareLinkMutationServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ShareLinkMutationServiceTest.java
@@ -1,0 +1,92 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
+import com.schemafy.core.project.application.port.in.RevokeShareLinkCommand;
+import com.schemafy.core.project.application.port.out.ShareLinkPort;
+import com.schemafy.core.project.domain.ShareLink;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("공유 링크 변경 서비스 테스트")
+class ShareLinkMutationServiceTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String SHARE_LINK_ID = "share-link-id";
+
+  @Mock
+  TransactionalOperator transactionalOperator;
+
+  @Mock
+  ShareLinkPort shareLinkPort;
+
+  @InjectMocks
+  DeleteShareLinkService deleteSut;
+
+  @InjectMocks
+  RevokeShareLinkService revokeSut;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(transactionalOperator.<Void>transactional(
+        org.mockito.ArgumentMatchers.<Mono<Void>>any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient().when(transactionalOperator.<ShareLink>transactional(
+        org.mockito.ArgumentMatchers.<Mono<ShareLink>>any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  @DisplayName("삭제 결과 행 수만으로 활성 공유 링크를 삭제한다")
+  void deleteShareLinkUsesConditionalUpdateWithoutPreRead() {
+    DeleteShareLinkCommand command = new DeleteShareLinkCommand(PROJECT_ID,
+        SHARE_LINK_ID, "requester-id");
+    given(shareLinkPort.softDeleteByIdAndProjectId(SHARE_LINK_ID, PROJECT_ID))
+        .willReturn(Mono.just(1L));
+
+    StepVerifier.create(deleteSut.deleteShareLink(command))
+        .verifyComplete();
+
+    then(shareLinkPort).should().softDeleteByIdAndProjectId(SHARE_LINK_ID,
+        PROJECT_ID);
+    then(shareLinkPort).should(never()).findByIdAndProjectIdAndNotDeleted(
+        SHARE_LINK_ID, PROJECT_ID);
+  }
+
+  @Test
+  @DisplayName("폐기 결과 행 수로 판정한 뒤 변경된 공유 링크를 조회한다")
+  void revokeShareLinkUsesConditionalUpdateWithoutPreRead() {
+    RevokeShareLinkCommand command = new RevokeShareLinkCommand(PROJECT_ID,
+        SHARE_LINK_ID, "requester-id");
+    ShareLink revokedLink = ShareLink.create(SHARE_LINK_ID, PROJECT_ID, "code");
+    revokedLink.revoke();
+    given(shareLinkPort.revokeByIdAndProjectId(SHARE_LINK_ID, PROJECT_ID))
+        .willReturn(Mono.just(1L));
+    given(shareLinkPort.findByIdAndProjectIdAndNotDeleted(SHARE_LINK_ID,
+        PROJECT_ID)).willReturn(Mono.just(revokedLink));
+
+    StepVerifier.create(revokeSut.revokeShareLink(command))
+        .expectNext(revokedLink)
+        .verifyComplete();
+
+    then(shareLinkPort).should().revokeByIdAndProjectId(SHARE_LINK_ID,
+        PROJECT_ID);
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleServiceTest.java
@@ -1,0 +1,110 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleCommand;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 멤버 역할 변경 서비스 테스트")
+class UpdateProjectMemberRoleServiceTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String REQUESTER_ID = "requester-id";
+  private static final String TARGET_ID = "target-id";
+
+  @Mock
+  TransactionalOperator transactionalOperator;
+
+  @Mock
+  ProjectMemberPort projectMemberPort;
+
+  @Mock
+  ProjectAccessHelper projectAccessHelper;
+
+  @InjectMocks
+  UpdateProjectMemberRoleService sut;
+
+  @Test
+  @DisplayName("활성 멤버십만 조건부로 역할을 변경한다")
+  void updateProjectMemberRoleUpdatesOnlyActiveMembership() {
+    ProjectMember requester = ProjectMember.create("requester-member", PROJECT_ID,
+        REQUESTER_ID, ProjectRole.ADMIN);
+    ProjectMember target = ProjectMember.create("target-member", PROJECT_ID,
+        TARGET_ID, ProjectRole.VIEWER);
+    UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
+    stubTransactionPassThrough();
+    given(projectAccessHelper.findProjectMember(REQUESTER_ID, PROJECT_ID))
+        .willReturn(Mono.just(requester));
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
+        .willReturn(Mono.just(target));
+    given(projectMemberPort.updateRoleIfActive(PROJECT_ID, TARGET_ID,
+        ProjectRole.EDITOR.name())).willReturn(Mono.just(1L));
+
+    StepVerifier.create(sut.updateProjectMemberRole(command))
+        .expectNext(target)
+        .verifyComplete();
+
+    assertThat(target.getRoleAsEnum()).isEqualTo(ProjectRole.EDITOR);
+    then(projectMemberPort).should().updateRoleIfActive(PROJECT_ID, TARGET_ID,
+        ProjectRole.EDITOR.name());
+    then(projectMemberPort).should(never()).save(target);
+  }
+
+  @Test
+  @DisplayName("대상 멤버십이 이미 삭제되었으면 역할을 변경하지 않는다")
+  void updateProjectMemberRoleRejectsAlreadyDeletedMembership() {
+    ProjectMember requester = ProjectMember.create("requester-member", PROJECT_ID,
+        REQUESTER_ID, ProjectRole.ADMIN);
+    ProjectMember target = ProjectMember.create("target-member", PROJECT_ID,
+        TARGET_ID, ProjectRole.VIEWER);
+    UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
+    stubTransactionPassThrough();
+    given(projectAccessHelper.findProjectMember(REQUESTER_ID, PROJECT_ID))
+        .willReturn(Mono.just(requester));
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
+        .willReturn(Mono.just(target));
+    given(projectMemberPort.updateRoleIfActive(PROJECT_ID, TARGET_ID,
+        ProjectRole.EDITOR.name())).willReturn(Mono.just(0L));
+
+    StepVerifier.create(sut.updateProjectMemberRole(command))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.MEMBER_NOT_FOUND);
+        })
+        .verify();
+
+    assertThat(target.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
+    then(projectMemberPort).should(never()).save(target);
+  }
+
+  private void stubTransactionPassThrough() {
+    lenient().when(transactionalOperator.<ProjectMember>transactional(
+        org.mockito.ArgumentMatchers.<Mono<ProjectMember>>any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectServiceTest.java
@@ -1,0 +1,77 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.ProjectDetail;
+import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.domain.Project;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 수정 서비스 테스트")
+class UpdateProjectServiceTest {
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  ProjectAccessHelper projectAccessHelper;
+
+  @Mock
+  ProjectMutationGuard projectMutationGuard;
+
+  @InjectMocks
+  UpdateProjectService sut;
+
+  @BeforeEach
+  void setUp() {
+    given(projectMutationGuard.<ProjectDetail>protectProjectMutation(
+        any(String.class), any()))
+        .willAnswer(invocation -> invocation
+            .<Supplier<Mono<ProjectDetail>>>getArgument(1).get());
+  }
+
+  @Test
+  @DisplayName("프로젝트 행을 수정할 때 배타 변경 보호를 사용한다")
+  void updateProjectUsesExclusiveMutationProtection() {
+    Project project = Project.create("project-id", "workspace-id", "기존 이름",
+        "기존 설명");
+    ProjectDetail detail = new ProjectDetail(project, "ADMIN");
+    UpdateProjectCommand command = new UpdateProjectCommand(
+        project.getId(), "변경 이름", "변경 설명", "requester-id");
+    given(projectAccessHelper.findProjectById(project.getId()))
+        .willReturn(Mono.just(project));
+    given(projectPort.save(project)).willReturn(Mono.just(project));
+    given(projectAccessHelper.buildProjectDetail(project, "requester-id"))
+        .willReturn(Mono.just(detail));
+
+    StepVerifier.create(sut.updateProject(command))
+        .expectNext(detail)
+        .verifyComplete();
+
+    then(projectMutationGuard).should()
+        .protectProjectMutation(eq(project.getId()), any());
+    then(projectMutationGuard).should(never())
+        .protectChildCreation(any(), any());
+    then(projectMutationGuard).should(never())
+        .protectWorkspaceAndProjectMutation(any(), any());
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectServiceTest.java
@@ -1,8 +1,5 @@
 package com.schemafy.core.project.application.service;
 
-import java.util.function.Supplier;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +7,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.port.in.ProjectDetail;
 import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.out.ProjectPort;
 import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -34,31 +32,21 @@ class UpdateProjectServiceTest {
   @Mock
   ProjectAccessHelper projectAccessHelper;
 
-  @Mock
-  ProjectMutationGuard projectMutationGuard;
-
   @InjectMocks
   UpdateProjectService sut;
 
-  @BeforeEach
-  void setUp() {
-    given(projectMutationGuard.<ProjectDetail>protectProjectMutation(
-        any(String.class), any()))
-        .willAnswer(invocation -> invocation
-            .<Supplier<Mono<ProjectDetail>>>getArgument(1).get());
-  }
-
   @Test
-  @DisplayName("프로젝트 행을 수정할 때 배타 변경 보호를 사용한다")
-  void updateProjectUsesExclusiveMutationProtection() {
+  @DisplayName("활성 프로젝트 행만 수정한다")
+  void updateProjectUpdatesOnlyActiveProject() {
     Project project = Project.create("project-id", "workspace-id", "기존 이름",
         "기존 설명");
     ProjectDetail detail = new ProjectDetail(project, "ADMIN");
     UpdateProjectCommand command = new UpdateProjectCommand(
         project.getId(), "변경 이름", "변경 설명", "requester-id");
+    given(projectPort.updateIfActive(project.getId(), "변경 이름", "변경 설명"))
+        .willReturn(Mono.just(1L));
     given(projectAccessHelper.findProjectById(project.getId()))
         .willReturn(Mono.just(project));
-    given(projectPort.save(project)).willReturn(Mono.just(project));
     given(projectAccessHelper.buildProjectDetail(project, "requester-id"))
         .willReturn(Mono.just(detail));
 
@@ -66,12 +54,32 @@ class UpdateProjectServiceTest {
         .expectNext(detail)
         .verifyComplete();
 
-    then(projectMutationGuard).should()
-        .protectProjectMutation(eq(project.getId()), any());
-    then(projectMutationGuard).should(never())
-        .protectChildCreation(any(), any());
-    then(projectMutationGuard).should(never())
-        .protectWorkspaceAndProjectMutation(any(), any());
+    then(projectPort).should()
+        .updateIfActive(project.getId(), "변경 이름", "변경 설명");
+    then(projectPort).should(never()).save(project);
+  }
+
+  @Test
+  @DisplayName("수정 후 삭제 경합으로 멤버십이 사라지면 프로젝트 없음으로 응답한다")
+  void updateProjectMapsDeletedMembershipToProjectNotFound() {
+    Project project = Project.create("project-id", "workspace-id", "기존 이름",
+        "기존 설명");
+    UpdateProjectCommand command = new UpdateProjectCommand(
+        project.getId(), "변경 이름", "변경 설명", "requester-id");
+    given(projectPort.updateIfActive(project.getId(), "변경 이름", "변경 설명"))
+        .willReturn(Mono.just(1L));
+    given(projectAccessHelper.findProjectById(project.getId()))
+        .willReturn(Mono.just(project));
+    given(projectAccessHelper.buildProjectDetail(project, "requester-id"))
+        .willReturn(Mono.error(new DomainException(ProjectErrorCode.MEMBER_NOT_FOUND)));
+
+    StepVerifier.create(sut.updateProject(command))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.NOT_FOUND);
+        })
+        .verify();
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
@@ -21,8 +21,6 @@ import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkUseCase;
-import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
-import com.schemafy.core.project.application.port.in.LeaveProjectUseCase;
 import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
 import com.schemafy.core.project.application.service.ProjectMutationGuard;
@@ -47,9 +45,6 @@ class ProjectMutationConcurrencyIntegrationTest
 
   @Autowired
   private ProjectMutationGuard projectMutationGuard;
-
-  @Autowired
-  private LeaveProjectUseCase leaveProjectUseCase;
 
   @Autowired
   private DeleteProjectUseCase deleteProjectUseCase;
@@ -82,7 +77,7 @@ class ProjectMutationConcurrencyIntegrationTest
       assertThat(mutationLocked.await(3, TimeUnit.SECONDS)).isTrue();
 
       Future<?> exclusive = executor.submit(() -> projectMutationGuard
-          .protectWorkspaceAndProjectMutation(project.getId(), () -> Mono.fromRunnable(
+          .protectProjectDeletion(project.getId(), () -> Mono.fromRunnable(
               exclusiveStarted::countDown))
           .block());
 
@@ -176,7 +171,8 @@ class ProjectMutationConcurrencyIntegrationTest
           project.getId(), "Updated", "Updated", admin.id())).block();
     } catch (DomainException error) {
       if (error.getErrorCode() != ProjectErrorCode.NOT_FOUND
-          && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED) {
+          && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED
+          && error.getErrorCode() != ProjectErrorCode.MEMBER_NOT_FOUND) {
         throw error;
       }
     }
@@ -189,7 +185,8 @@ class ProjectMutationConcurrencyIntegrationTest
     CountDownLatch done = new CountDownLatch(tasks.size());
     ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
 
-    try (ExecutorService executor = Executors.newFixedThreadPool(tasks.size())) {
+    ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+    try {
       for (CheckedTask task : tasks) {
         executor.submit(() -> {
           ready.countDown();
@@ -203,9 +200,13 @@ class ProjectMutationConcurrencyIntegrationTest
           }
         });
       }
-      ready.await();
+      assertThat(ready.await(3, TimeUnit.SECONDS)).isTrue();
       start.countDown();
-      done.await();
+      assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
     }
     return errors;
   }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.schemafy.core.project.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.AccessShareLinkQuery;
+import com.schemafy.core.project.application.port.in.AccessShareLinkUseCase;
+import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
+import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
+import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
+import com.schemafy.core.project.application.port.in.DeleteShareLinkUseCase;
+import com.schemafy.core.project.application.port.in.LeaveProjectCommand;
+import com.schemafy.core.project.application.port.in.LeaveProjectUseCase;
+import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
+import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
+import com.schemafy.core.project.application.service.ProjectMutationGuard;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.ShareLink;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.ShareLinkErrorCode;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("프로젝트 변경 동시성 통합 테스트")
+class ProjectMutationConcurrencyIntegrationTest
+    extends ProjectDomainIntegrationSupport {
+
+  private static final int CONCURRENT_CHANGE_COUNT = 8;
+
+  @Autowired
+  private ProjectMutationGuard projectMutationGuard;
+
+  @Autowired
+  private LeaveProjectUseCase leaveProjectUseCase;
+
+  @Autowired
+  private DeleteProjectUseCase deleteProjectUseCase;
+
+  @Autowired
+  private AccessShareLinkUseCase accessShareLinkUseCase;
+
+  @Autowired
+  private DeleteShareLinkUseCase deleteShareLinkUseCase;
+
+  @Autowired
+  private UpdateProjectUseCase updateProjectUseCase;
+
+  @Test
+  @DisplayName("프로젝트 배타 변경은 진행 중인 하위 변경이 끝날 때까지 대기한다")
+  void exclusiveMutation_waitsForOngoingChildCreation() throws Exception {
+    Workspace workspace = saveWorkspace("Mutation Lock", "Description");
+    Project project = saveProject(workspace, "Mutation Lock Project");
+    CountDownLatch mutationLocked = new CountDownLatch(1);
+    CountDownLatch releaseMutation = new CountDownLatch(1);
+    CountDownLatch exclusiveStarted = new CountDownLatch(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      Future<?> mutation = executor.submit(() -> projectMutationGuard
+          .protectChildCreation(project.getId(), () -> Mono.fromRunnable(() -> {
+            mutationLocked.countDown();
+            await(releaseMutation);
+          }))
+          .block());
+      assertThat(mutationLocked.await(3, TimeUnit.SECONDS)).isTrue();
+
+      Future<?> exclusive = executor.submit(() -> projectMutationGuard
+          .protectWorkspaceAndProjectMutation(project.getId(), () -> Mono.fromRunnable(
+              exclusiveStarted::countDown))
+          .block());
+
+      assertThat(exclusiveStarted.await(200, TimeUnit.MILLISECONDS)).isFalse();
+      releaseMutation.countDown();
+      mutation.get(3, TimeUnit.SECONDS);
+      exclusive.get(3, TimeUnit.SECONDS);
+      assertThat(exclusiveStarted.getCount()).isZero();
+    } finally {
+      releaseMutation.countDown();
+    }
+  }
+
+  @Test
+  @DisplayName("공유 링크 접근과 삭제가 동시에 실행되어도 삭제 뒤 접근 정보가 변경되지 않는다")
+  void concurrentShareLinkAccessAndDelete_stopsMetadataUpdatesAfterDelete()
+      throws InterruptedException {
+    User admin = signUpUser("admin-share-link-race@test.com", "Admin");
+    Workspace workspace = saveWorkspace("Share Link Race", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    Project project = saveProject(workspace, "Share Link Race Project");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+    List<ShareLink> links = new ArrayList<>();
+    List<CheckedTask> tasks = new ArrayList<>();
+
+    for (int i = 0; i < CONCURRENT_CHANGE_COUNT; i++) {
+      ShareLink link = saveShareLink(project);
+      links.add(link);
+      tasks.add(() -> accessShareLinkIgnoringDeletion(link));
+      tasks.add(() -> deleteShareLinkUseCase.deleteShareLink(
+          new DeleteShareLinkCommand(project.getId(), link.getId(), admin.id()))
+          .block());
+    }
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(tasks);
+
+    assertThat(errors).isEmpty();
+    for (ShareLink link : links) {
+      ShareLink deleted = shareLinkRepository.findById(link.getId()).block();
+      assertThat(deleted.isDeleted()).isTrue();
+      long accessCountAfterDelete = deleted.getAccessCount();
+      shareLinkRepository.incrementAccessCount(link.getId()).block();
+      assertThat(shareLinkRepository.findById(link.getId()).block()
+          .getAccessCount()).isEqualTo(accessCountAfterDelete);
+    }
+  }
+
+  @Test
+  @DisplayName("프로젝트 수정과 삭제가 동시에 실행되어도 삭제된 프로젝트가 복원되지 않는다")
+  void concurrentProjectUpdateAndDelete_doesNotRestoreProject()
+      throws InterruptedException {
+    User admin = signUpUser("admin-project-update-delete@test.com", "Admin");
+    Workspace workspace = saveWorkspace("Update Delete Race", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    List<Project> projects = new ArrayList<>();
+    List<CheckedTask> tasks = new ArrayList<>();
+
+    for (int i = 0; i < CONCURRENT_CHANGE_COUNT; i++) {
+      Project project = saveProject(workspace, "Update Delete Race " + i);
+      saveProjectMember(project, admin, ProjectRole.ADMIN);
+      projects.add(project);
+      tasks.add(() -> updateProjectIgnoringDeletion(project, admin));
+      tasks.add(() -> deleteProjectUseCase.deleteProject(
+          new DeleteProjectCommand(project.getId(), admin.id())).block());
+    }
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(tasks);
+
+    assertThat(errors).isEmpty();
+    for (Project project : projects) {
+      assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block())
+          .isNull();
+    }
+  }
+
+  private void accessShareLinkIgnoringDeletion(ShareLink link) {
+    try {
+      accessShareLinkUseCase.accessShareLink(new AccessShareLinkQuery(
+          link.getCode(), null, "127.0.0.1", "동시성 테스트")).block();
+    } catch (DomainException error) {
+      if (error.getErrorCode() != ShareLinkErrorCode.NOT_FOUND
+          && error.getErrorCode() != ShareLinkErrorCode.INVALID_LINK) {
+        throw error;
+      }
+    }
+  }
+
+  private void updateProjectIgnoringDeletion(Project project, User admin) {
+    try {
+      updateProjectUseCase.updateProject(new UpdateProjectCommand(
+          project.getId(), "Updated", "Updated", admin.id())).block();
+    } catch (DomainException error) {
+      if (error.getErrorCode() != ProjectErrorCode.NOT_FOUND
+          && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED) {
+        throw error;
+      }
+    }
+  }
+
+  private ConcurrentLinkedQueue<Throwable> runConcurrently(
+      List<CheckedTask> tasks) throws InterruptedException {
+    CountDownLatch ready = new CountDownLatch(tasks.size());
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(tasks.size());
+    ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(tasks.size())) {
+      for (CheckedTask task : tasks) {
+        executor.submit(() -> {
+          ready.countDown();
+          await(start);
+          try {
+            task.run();
+          } catch (Throwable error) {
+            errors.add(error);
+          } finally {
+            done.countDown();
+          }
+        });
+      }
+      ready.await();
+      start.countDown();
+      done.await();
+    }
+    return errors;
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException error) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(error);
+    }
+  }
+
+  @FunctionalInterface
+  private interface CheckedTask {
+
+    void run();
+
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -506,21 +506,6 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
-  @DisplayName("마지막 멤버가 프로젝트를 나가면 프로젝트도 삭제된다")
-  void leaveProject_lastMemberDeletesProject() {
-    User member = signUpUser("member-last@test.com", "Member");
-    Workspace workspace = saveWorkspace("Last Project WS", "Description");
-    saveWorkspaceMember(workspace, member, WorkspaceRole.MEMBER);
-    var project = saveProject(workspace, "Last Project");
-    saveProjectMember(project, member, ProjectRole.ADMIN);
-    createSchema(project, "last_member_schema");
-
-    leaveProjectUseCase.leaveProject(new LeaveProjectCommand(project.getId(), member.id())).block();
-
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
-  }
-
-  @Test
   @DisplayName("프로젝트 탈퇴는 비회원이면 거부된다")
   void leaveProject_deniesNonMember() {
     User requester = signUpUser("non-member-project-leave@test.com", "Requester");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ShareLinkUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ShareLinkUseCaseIntegrationTest.java
@@ -157,6 +157,44 @@ class ShareLinkUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
+  @DisplayName("삭제된 공유 링크의 접근 횟수와 마지막 접근 시각은 변경되지 않는다")
+  void incrementAccessCount_doesNotUpdateDeletedShareLink() {
+    User admin = signUpUser("admin-share-deleted-access@test.com", "Admin");
+    var workspace = saveWorkspace("Deleted Access WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    var project = saveProject(workspace, "Deleted Access Project");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+    ShareLink link = saveShareLink(project);
+    deleteShareLinkUseCase.deleteShareLink(new DeleteShareLinkCommand(
+        project.getId(), link.getId(), admin.id())).block();
+
+    shareLinkRepository.incrementAccessCount(link.getId()).block();
+
+    ShareLink deletedLink = shareLinkRepository.findById(link.getId()).block();
+    assertThat(deletedLink.getAccessCount()).isZero();
+    assertThat(deletedLink.getLastAccessedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("폐기된 공유 링크의 접근 횟수와 마지막 접근 시각은 변경되지 않는다")
+  void incrementAccessCount_doesNotUpdateRevokedShareLink() {
+    User admin = signUpUser("admin-share-revoked-access@test.com", "Admin");
+    var workspace = saveWorkspace("Revoked Access WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    var project = saveProject(workspace, "Revoked Access Project");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+    ShareLink link = saveShareLink(project);
+    revokeShareLinkUseCase.revokeShareLink(new RevokeShareLinkCommand(
+        project.getId(), link.getId(), admin.id())).block();
+
+    shareLinkRepository.incrementAccessCount(link.getId()).block();
+
+    ShareLink revokedLink = shareLinkRepository.findById(link.getId()).block();
+    assertThat(revokedLink.getAccessCount()).isZero();
+    assertThat(revokedLink.getLastAccessedAt()).isNull();
+  }
+
+  @Test
   @DisplayName("공유 링크 접근은 익명 공개 접근을 허용한다")
   void accessShareLink_allowsAnonymousPublicAccess() {
     User admin = signUpUser("admin-share-public@test.com", "Admin");

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ShareLinkUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ShareLinkUseCaseIntegrationTest.java
@@ -157,6 +157,30 @@ class ShareLinkUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
   }
 
   @Test
+  @DisplayName("만료 시각이 없는 공유 링크도 접근 횟수를 증가시킨다")
+  void accessShareLink_withoutExpirationIncrementsAccessMetadata() {
+    User admin = signUpUser("admin-share-no-expiry@test.com", "Admin");
+    var workspace = saveWorkspace("No Expiry Access WS", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    var project = saveProject(workspace, "No Expiry Access Project");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+    ShareLink link = saveShareLink(project, null);
+
+    Project accessedProject = accessShareLinkUseCase.accessShareLink(new AccessShareLinkQuery(
+        link.getCode(),
+        admin.id(),
+        "127.0.0.1",
+        "JUnit"))
+        .block();
+
+    ShareLink updatedLink = shareLinkRepository.findById(link.getId()).block();
+
+    assertThat(accessedProject.getId()).isEqualTo(project.getId());
+    assertThat(updatedLink.getAccessCount()).isEqualTo(1L);
+    assertThat(updatedLink.getLastAccessedAt()).isNotNull();
+  }
+
+  @Test
   @DisplayName("삭제된 공유 링크의 접근 횟수와 마지막 접근 시각은 변경되지 않는다")
   void incrementAccessCount_doesNotUpdateDeletedShareLink() {
     User admin = signUpUser("admin-share-deleted-access@test.com", "Admin");


### PR DESCRIPTION
## 개요
공유 링크 생성과 프로젝트 lifecycle 변경의 잠금 범위 분리

- Spring Data Relational `@Lock` 기반 프로젝트·워크스페이스 잠금 메타데이터 추가
- 프로젝트 하위 생성, 수정, 삭제, 탈퇴의 잠금 범위 분리
- `Workspace → Project` 잠금 순서 고정
- 잠금 획득과 action을 동일 reactive transaction에서 실행
- 잠금 실패 시 전체 transaction 재시도
- 공유 링크 삭제·폐기를 조건부 원자 UPDATE로 변경
- 마지막 멤버 탈퇴 시 프로젝트를 삭제하던 비정상 경로와 stale 테스트 제거

## Design

### Project mutation

- 공유 링크 생성: 프로젝트 shared lock
- 프로젝트 수정: 프로젝트 exclusive lock
- 프로젝트 삭제·탈퇴: workspace exclusive lock 후 project exclusive lock
- 이미 guard가 획득한 프로젝트 잠금은 cascade helper에서 재사용

### Project leave policy

워크스페이스 ADMIN은 프로젝트 ADMIN 멤버십을 유지하는 정책이므로 정상 플로우에서 마지막 프로젝트 멤버 탈퇴로 프로젝트를 삭제하는 경로는 발생하지 않습니다. 따라서 기존에 있던 마지막 프로젝트 멤버 탈퇴로 프로젝트를 삭제 관련 코드 및 테스트는 정리했습니다.

+) 참고로 여기서 사용하는 `@Lock`은 Spring Data JPA/Hibernate의 어노테이션이 아니라, Spring Data Relational(R2DBC)이 제공하는 `org.springframework.data.relational.repository.Lock`이며 연결된 DB dialect에 맞춰 잠금 구문을 생성합니다.

## 이슈
