### PR TITLE
fix(#478): enforce WebSocket project access

### DIFF
--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
@@ -104,6 +104,8 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
     String userId = authInfo.getUserId();
 
     return projectAccessValidator.canAccess(projectId, userId)
+        .onErrorResume(error -> handleAccessValidationError(session,
+            projectId, error).then(Mono.empty()))
         .flatMap(hasAccess -> {
           if (hasAccess) {
             return handleAuthenticated(session, authInfo,
@@ -227,6 +229,15 @@ public class CollaborationWebSocketHandler implements WebSocketHandler {
         session.getId(), projectId);
     return session.close(CloseStatus.POLICY_VIOLATION
         .withReason("Access denied to project"));
+  }
+
+  private Mono<Void> handleAccessValidationError(WebSocketSession session,
+      String projectId, Throwable error) {
+    log.error(
+        "[CollaborationWebSocketHandler] Project access validation failed: sessionId={}, projectId={}",
+        session.getId(), projectId, error);
+    return session.close(CloseStatus.SERVER_ERROR
+        .withReason("Project access validation failed"));
   }
 
   private Mono<Void> handleInvalidProjectId(WebSocketSession session) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/security/ProjectAccessValidator.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/security/ProjectAccessValidator.java
@@ -3,21 +3,31 @@ package com.schemafy.api.collaboration.security;
 import org.springframework.stereotype.Component;
 
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.access.AccessVerifier;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @Component
+@RequiredArgsConstructor
 @ConditionalOnRedisEnabled
 public class ProjectAccessValidator {
 
+  private final ProjectPort projectPort;
+  private final AccessVerifier accessVerifier;
+
   public Mono<Boolean> canAccess(String projectId, String userId) {
-    // TODO: 프로젝트 멤버십 테이블 구현 시 아래 로직으로 변경
-    // 현재: 해당 projectId에 스키마가 하나라도 존재하면 접근 허용
-    // return schemaRepository.findByProjectIdAndDeletedAtIsNull(projectId)
-    // .hasElements();
-    return Mono.just(true);
+    return accessVerifier.requireProjectAccess(projectId, userId,
+        ProjectRole.VIEWER)
+        .then(Mono.defer(() -> projectPort.findByIdAndNotDeleted(projectId)
+            .hasElement()))
+        .onErrorResume(
+            DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED),
+            error -> Mono.just(false));
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandlerTest.java
@@ -8,6 +8,7 @@ import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.reactive.socket.CloseStatus;
 import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
@@ -15,6 +16,7 @@ import org.springframework.web.reactive.socket.WebSocketSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CollaborationWebSocketHandler 단위 테스트")
@@ -226,6 +229,77 @@ class CollaborationWebSocketHandlerTest {
         .verify(Duration.ofSeconds(1));
 
     subscription.dispose();
+  }
+
+  @Test
+  @DisplayName("접근 검증 전에는 세션과 presence 처리를 시작하지 않고 거부 시 1008로 종료한다")
+  void handle_deniesAccessWithoutSessionSideEffects() {
+    CollaborationWebSocketHandler handler = new CollaborationWebSocketHandler(
+        directMessageSender, collaborationService, sessionRegistry,
+        projectAccessValidator, new CollaborationPresenceProperties());
+    Authentication authentication = new UsernamePasswordAuthenticationToken(
+        AuthenticatedUser.of("user-1", "tester"), null);
+    HandshakeInfo handshakeInfo = new HandshakeInfo(
+        URI.create("ws://localhost/ws/collaboration?projectId=project-1"),
+        HttpHeaders.EMPTY, Mono.just(authentication), null);
+    Sinks.One<Boolean> accessDecision = Sinks.one();
+
+    given(session.getHandshakeInfo()).willReturn(handshakeInfo);
+    given(session.getId()).willReturn("session-1");
+    given(projectAccessValidator.canAccess("project-1", "user-1"))
+        .willReturn(accessDecision.asMono());
+    given(session.close(any())).willReturn(Mono.empty());
+
+    Disposable subscription = handler.handle(session).subscribe();
+
+    verifyNoInteractions(sessionRegistry, collaborationService,
+        directMessageSender);
+    verify(session, never()).receive();
+    verify(session, never()).send(any());
+
+    accessDecision.tryEmitValue(false);
+
+    ArgumentCaptor<CloseStatus> closeStatus = ArgumentCaptor.forClass(
+        CloseStatus.class);
+    verify(session, timeout(1000)).close(closeStatus.capture());
+    assertThat(closeStatus.getValue().getCode()).isEqualTo(1008);
+    verifyNoInteractions(sessionRegistry, collaborationService,
+        directMessageSender);
+    verify(session, never()).receive();
+    verify(session, never()).send(any());
+
+    subscription.dispose();
+  }
+
+  @Test
+  @DisplayName("접근 검증 오류는 세션 부수 효과 없이 1011로 종료한다")
+  void handle_closesOnAccessValidationErrorWithoutSessionSideEffects() {
+    CollaborationWebSocketHandler handler = new CollaborationWebSocketHandler(
+        directMessageSender, collaborationService, sessionRegistry,
+        projectAccessValidator, new CollaborationPresenceProperties());
+    Authentication authentication = new UsernamePasswordAuthenticationToken(
+        AuthenticatedUser.of("user-1", "tester"), null);
+    HandshakeInfo handshakeInfo = new HandshakeInfo(
+        URI.create("ws://localhost/ws/collaboration?projectId=project-1"),
+        HttpHeaders.EMPTY, Mono.just(authentication), null);
+
+    given(session.getHandshakeInfo()).willReturn(handshakeInfo);
+    given(session.getId()).willReturn("session-1");
+    given(projectAccessValidator.canAccess("project-1", "user-1"))
+        .willReturn(Mono.error(new IllegalStateException("database unavailable")));
+    given(session.close(any())).willReturn(Mono.empty());
+
+    StepVerifier.create(handler.handle(session))
+        .verifyComplete();
+
+    ArgumentCaptor<CloseStatus> closeStatus = ArgumentCaptor.forClass(
+        CloseStatus.class);
+    verify(session).close(closeStatus.capture());
+    assertThat(closeStatus.getValue().getCode()).isEqualTo(1011);
+    verifyNoInteractions(sessionRegistry, collaborationService,
+        directMessageSender);
+    verify(session, never()).receive();
+    verify(session, never()).send(any());
   }
 
   private WebSocketMessage message(WebSocketMessage.Type type) {

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/security/ProjectAccessValidatorTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/security/ProjectAccessValidatorTest.java
@@ -1,0 +1,145 @@
+package com.schemafy.api.collaboration.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.access.AccessVerifier;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProjectAccessValidator 단위 테스트")
+class ProjectAccessValidatorTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  private WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  private ProjectMemberPort projectMemberPort;
+
+  @Mock
+  private ProjectPort projectPort;
+
+  @ParameterizedTest
+  @EnumSource(ProjectRole.class)
+  @DisplayName("활성 VIEWER 이상 멤버는 접근을 허용한다")
+  void canAccess_allowsActiveMember(ProjectRole role) {
+    ProjectAccessValidator validator = validator();
+    givenActiveMember(role);
+    givenActiveProject();
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("비멤버는 접근을 거부한다")
+  void canAccess_deniesNonMember() {
+    ProjectAccessValidator validator = validator();
+    given(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(
+        PROJECT_ID, USER_ID))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectNext(false)
+        .verifyComplete();
+
+    verifyNoInteractions(projectPort);
+  }
+
+  @Test
+  @DisplayName("삭제된 멤버는 활성 멤버 조회에서 제외되어 접근을 거부한다")
+  void canAccess_deniesDeletedMember() {
+    ProjectAccessValidator validator = validator();
+    given(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(
+        PROJECT_ID, USER_ID))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectNext(false)
+        .verifyComplete();
+
+    verifyNoInteractions(projectPort);
+  }
+
+  @Test
+  @DisplayName("활성 멤버십이 남아 있어도 존재하지 않는 프로젝트는 접근을 거부한다")
+  void canAccess_deniesMissingProject() {
+    ProjectAccessValidator validator = validator();
+    givenActiveMember(ProjectRole.VIEWER);
+    given(projectPort.findByIdAndNotDeleted(PROJECT_ID))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectNext(false)
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("프로젝트 조회 오류는 접근 허용으로 바꾸지 않는다")
+  void canAccess_propagatesProjectLookupError() {
+    ProjectAccessValidator validator = validator();
+    IllegalStateException error = new IllegalStateException("database unavailable");
+    givenActiveMember(ProjectRole.VIEWER);
+    given(projectPort.findByIdAndNotDeleted(PROJECT_ID))
+        .willReturn(Mono.error(error));
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+  }
+
+  @Test
+  @DisplayName("멤버십 조회 오류는 접근 허용으로 바꾸지 않는다")
+  void canAccess_propagatesMemberLookupError() {
+    ProjectAccessValidator validator = validator();
+    IllegalStateException error = new IllegalStateException("database unavailable");
+    given(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(
+        PROJECT_ID, USER_ID))
+        .willReturn(Mono.error(error));
+
+    StepVerifier.create(validator.canAccess(PROJECT_ID, USER_ID))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+
+    verifyNoInteractions(projectPort);
+  }
+
+  private ProjectAccessValidator validator() {
+    return new ProjectAccessValidator(projectPort,
+        new AccessVerifier(workspaceMemberPort, projectMemberPort));
+  }
+
+  private void givenActiveProject() {
+    given(projectPort.findByIdAndNotDeleted(PROJECT_ID))
+        .willReturn(Mono.just(Project.create(PROJECT_ID, "workspace-id", 1,
+            "Project", "Description")));
+  }
+
+  private void givenActiveMember(ProjectRole role) {
+    given(projectMemberPort.findByProjectIdAndUserIdAndNotDeleted(
+        PROJECT_ID, USER_ID))
+        .willReturn(Mono.just(ProjectMember.create("member-id", PROJECT_ID,
+            USER_ID, role)));
+  }
+
+}


### PR DESCRIPTION
## 개요

- 협업 WebSocket 연결 시 기존 `AccessVerifier`로 활성 `VIEWER` 이상 프로젝트 멤버십 검증
- 비멤버, 삭제된 멤버, 존재하지 않는 프로젝트 연결을 `POLICY_VIOLATION(1008)`으로 종료
- 접근 검증 오류를 `SERVER_ERROR(1011)`로 종료하고 검증 전 session/presence 등록 및 협업 이벤트 처리 차단

## 이슈

- close #478
