### PR TITLE
refactor(#479): remove legacy resource roles from JWT principal

### DIFF
--- a/apps/backend/api/src/main/java/com/schemafy/api/common/security/SecurityConfig.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/security/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -32,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 @Profile("!test")
 @Configuration
 @EnableWebFluxSecurity
-@EnableReactiveMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/security/jwt/JwtAuthenticationFilter.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/security/jwt/JwtAuthenticationFilter.java
@@ -96,7 +96,7 @@ public class JwtAuthenticationFilter implements WebFilter {
           claims -> claims.get(CLAIM_NAME, String.class));
       AuthenticatedUser principal = createPrincipal(userId, userName);
       UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-          principal, null, principal.asAuthorities());
+          principal, null, principal.getAuthorities());
 
       return AuthenticationResult.success(authentication);
 
@@ -116,7 +116,7 @@ public class JwtAuthenticationFilter implements WebFilter {
   }
 
   private AuthenticatedUser createPrincipal(String userId, String userName) {
-    return AuthenticatedUser.withAllRoles(userId, userName);
+    return AuthenticatedUser.of(userId, userName);
   }
 
   private boolean isPublicPath(ServerHttpRequest request) {

--- a/apps/backend/api/src/main/java/com/schemafy/api/common/security/principal/AuthenticatedUser.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/common/security/principal/AuthenticatedUser.java
@@ -2,27 +2,17 @@ package com.schemafy.api.common.security.principal;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import com.schemafy.core.project.domain.ProjectRole;
 
 /** 인증된 사용자 정보를 담는 UserDetails 구현체.
  * JWT 토큰에서 추출한 사용자 정보를 담으며, Spring Security의 표준 방식을 따른다.
  *
- * JWT 기반 인증에서는 password가 불필요하므로 null을 반환한다.
- * 향후 워크스페이스/프로젝트 롤을 실제 데이터로 매핑할 예정이며,
- * 현재는 모든 프로젝트 롤을 부여해 hasAuthority 기반 체크를 통과시키는 임시 구현이다. */
+ * JWT 기반 인증에서는 password와 authority가 불필요하므로 각각 null과 빈 컬렉션을 반환한다. */
 public record AuthenticatedUser(
     String userId,
-    String userName,
-    Set<ProjectRole> roles // TODO: 사용자 역할을 저장/조회해 채워 넣는다.
-) implements UserDetails {
+    String userName) implements UserDetails {
 
   @Override
   public String getUsername() { return userId; }
@@ -34,13 +24,7 @@ public record AuthenticatedUser(
   }
 
   @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return roles == null ? Collections.emptySet()
-        : roles.stream()
-            .map(ProjectRole::asAuthority)
-            .map(SimpleGrantedAuthority::new)
-            .collect(Collectors.toUnmodifiableSet());
-  }
+  public Collection<? extends GrantedAuthority> getAuthorities() { return Collections.emptySet(); }
 
   @Override
   public boolean isAccountNonExpired() { return true; }
@@ -59,35 +43,7 @@ public record AuthenticatedUser(
   }
 
   public static AuthenticatedUser of(String userId, String userName) {
-    return new AuthenticatedUser(userId, userName, Collections.emptySet());
-  }
-
-  public static AuthenticatedUser withAllRoles(String userId) {
-    return withAllRoles(userId, "unknown");
-  }
-
-  public static AuthenticatedUser withAllRoles(String userId,
-      String userName) {
-    return new AuthenticatedUser(userId, userName,
-        EnumSet.allOf(ProjectRole.class));
-  }
-
-  public static AuthenticatedUser withRoles(String userId,
-      Set<ProjectRole> roles) {
-    return withRoles(userId, "unknown", roles);
-  }
-
-  public static AuthenticatedUser withRoles(String userId, String userName,
-      Set<ProjectRole> roles) {
-    return new AuthenticatedUser(userId, userName, roles);
-  }
-
-  public Collection<? extends GrantedAuthority> asAuthorities() {
-    return roles == null ? Collections.emptyList()
-        : roles.stream()
-            .map(ProjectRole::asAuthority)
-            .map(SimpleGrantedAuthority::new)
-            .collect(Collectors.toUnmodifiableSet());
+    return new AuthenticatedUser(userId, userName);
   }
 
 }

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectController.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.PositiveOrZero;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -78,7 +77,6 @@ public class ProjectController {
   @Value("${app.base-url:http://localhost:8080}")
   private String baseUrl;
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PostMapping("/workspaces/{workspaceId}/projects")
   @ResponseStatus(HttpStatus.CREATED)
   public Mono<ProjectResponse> createProject(
@@ -95,7 +93,6 @@ public class ProjectController {
         .map(ProjectResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
   @GetMapping("/workspaces/{workspaceId}/projects")
   public Mono<PageResponse<ProjectSummaryResponse>> getProjects(
       @PathVariable String workspaceId,
@@ -115,7 +112,6 @@ public class ProjectController {
             result.totalElements()));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
   @GetMapping("/projects/{projectId}")
   public Mono<ProjectResponse> getProject(
       @PathVariable String projectId,
@@ -125,7 +121,6 @@ public class ProjectController {
         .map(ProjectResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
   @GetMapping("/projects/shared/me")
   public Mono<PageResponse<ProjectSummaryResponse>> getMySharedProjects(
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
@@ -142,7 +137,6 @@ public class ProjectController {
             result.totalElements()));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PutMapping("/projects/{projectId}")
   public Mono<ProjectResponse> updateProject(
       @PathVariable String projectId,
@@ -157,7 +151,6 @@ public class ProjectController {
         .map(ProjectResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @DeleteMapping("/projects/{projectId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> deleteProject(@PathVariable String projectId,
@@ -168,7 +161,6 @@ public class ProjectController {
         userId));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
   @GetMapping("/projects/{projectId}/members")
   public Mono<PageResponse<ProjectMemberResponse>> getMembers(
       @PathVariable String projectId,
@@ -184,7 +176,6 @@ public class ProjectController {
         .map(result -> result.map(ProjectMemberResponse::from));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PatchMapping("/projects/{projectId}/members/{userId}/role")
   public Mono<ProjectMemberResponse> updateMemberRole(
       @PathVariable String projectId,
@@ -201,7 +192,6 @@ public class ProjectController {
         .map(ProjectMemberResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @DeleteMapping("/projects/{projectId}/members/{userId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> removeMember(@PathVariable String projectId, @PathVariable String userId,
@@ -211,7 +201,6 @@ public class ProjectController {
         new RemoveProjectMemberCommand(projectId, userId, requester));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','EDITOR','VIEWER')")
   @DeleteMapping("/projects/{projectId}/members/me")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> leaveProject(
@@ -224,7 +213,6 @@ public class ProjectController {
 
   // ========== ShareLink Management ==========
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PostMapping("/projects/{projectId}/share-links")
   @ResponseStatus(HttpStatus.CREATED)
   public Mono<ShareLinkResponse> createShareLink(
@@ -238,7 +226,6 @@ public class ProjectController {
         .map(shareLink -> ShareLinkResponse.of(shareLink, baseUrl, version));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @GetMapping("/projects/{projectId}/share-links")
   public Mono<PageResponse<ShareLinkResponse>> getShareLinks(
       @PathVariable String version,
@@ -261,7 +248,6 @@ public class ProjectController {
             result.totalElements()));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @GetMapping("/projects/{projectId}/share-links/{shareLinkId}")
   public Mono<ShareLinkResponse> getShareLink(
       @PathVariable String version,
@@ -276,7 +262,6 @@ public class ProjectController {
         .map(shareLink -> ShareLinkResponse.of(shareLink, baseUrl, version));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PatchMapping("/projects/{projectId}/share-links/{shareLinkId}/revoke")
   public Mono<ShareLinkResponse> revokeShareLink(
       @PathVariable String version,
@@ -291,7 +276,6 @@ public class ProjectController {
         .map(shareLink -> ShareLinkResponse.of(shareLink, baseUrl, version));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @DeleteMapping("/projects/{projectId}/share-links/{shareLinkId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> deleteShareLink(

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectInvitationController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/ProjectInvitationController.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -43,7 +42,6 @@ public class ProjectInvitationController {
   private final RejectProjectInvitationUseCase rejectProjectInvitationUseCase;
   private final ProjectMemberOrchestrator projectMemberOrchestrator;
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PostMapping("/projects/{projectId}/invitations")
   @ResponseStatus(HttpStatus.CREATED)
   public Mono<ProjectInvitationCreateResponse> createInvitation(
@@ -60,7 +58,6 @@ public class ProjectInvitationController {
         .map(ProjectInvitationCreateResponse::of);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @GetMapping("/projects/{projectId}/invitations")
   public Mono<PageResponse<ProjectInvitationResponse>> listInvitations(
       @PathVariable String projectId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceController.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -70,7 +69,6 @@ public class WorkspaceController {
         .map(WorkspaceResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
   @GetMapping("/workspaces")
   public Mono<PageResponse<WorkspaceSummaryResponse>> getWorkspaces(
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
@@ -88,7 +86,6 @@ public class WorkspaceController {
             result.totalElements()));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
   @GetMapping("/workspaces/{id}")
   public Mono<WorkspaceResponse> getWorkspace(
       @PathVariable String id, Authentication authentication) {
@@ -98,7 +95,6 @@ public class WorkspaceController {
         .map(WorkspaceResponse::from);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PutMapping("/workspaces/{id}")
   public Mono<WorkspaceResponse> updateWorkspace(
       @PathVariable String id,
@@ -113,7 +109,6 @@ public class WorkspaceController {
         .map(WorkspaceResponse::from);
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
   @DeleteMapping("/workspaces/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> deleteWorkspace(@PathVariable String id,
@@ -124,7 +119,6 @@ public class WorkspaceController {
         requesterId));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
   @GetMapping("/workspaces/{id}/members")
   public Mono<PageResponse<WorkspaceMemberResponse>> getMembers(
       @PathVariable String id,
@@ -140,7 +134,6 @@ public class WorkspaceController {
         .map(result -> result.map(WorkspaceMemberResponse::from));
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
   @PostMapping("/workspaces/{workspaceId}/members")
   @ResponseStatus(HttpStatus.CREATED)
   public Mono<WorkspaceMemberResponse> addMember(
@@ -156,7 +149,6 @@ public class WorkspaceController {
         .map(WorkspaceMemberResponse::from);
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
   @DeleteMapping("/workspaces/{workspaceId}/members/{userId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> removeMember(
@@ -171,7 +163,6 @@ public class WorkspaceController {
             requesterId));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
   @DeleteMapping("/workspaces/{workspaceId}/members/me")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public Mono<Void> leaveMember(
@@ -183,7 +174,6 @@ public class WorkspaceController {
         requesterId));
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
   @PatchMapping("/workspaces/{workspaceId}/members/{userId}/role")
   public Mono<WorkspaceMemberResponse> updateMemberRole(
       @PathVariable String workspaceId,

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceInvitationController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/WorkspaceInvitationController.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -43,7 +42,6 @@ public class WorkspaceInvitationController {
   private final RejectWorkspaceInvitationUseCase rejectWorkspaceInvitationUseCase;
   private final WorkspaceMemberOrchestrator workspaceMemberOrchestrator;
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @PostMapping("/workspaces/{workspaceId}/invitations")
   @ResponseStatus(HttpStatus.CREATED)
   public Mono<WorkspaceInvitationCreateResponse> createInvitation(
@@ -60,7 +58,6 @@ public class WorkspaceInvitationController {
         .map(WorkspaceInvitationCreateResponse::of);
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN')")
   @GetMapping("/workspaces/{workspaceId}/invitations")
   public Mono<PageResponse<WorkspaceInvitationResponse>> getInvitations(
       @PathVariable String workspaceId,

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/config/JwtAuthenticationFilterTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/config/JwtAuthenticationFilterTest.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.web.server.WebFilterChain;
 
@@ -23,6 +24,7 @@ import com.schemafy.api.common.exception.ProblemProperties;
 import com.schemafy.api.common.security.jwt.JwtAuthenticationFilter;
 import com.schemafy.api.common.security.jwt.JwtProvider;
 import com.schemafy.api.common.security.jwt.WebExchangeErrorWriter;
+import com.schemafy.api.common.security.principal.AuthenticatedUser;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.ErdOperationMetadata;
@@ -33,6 +35,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -59,32 +62,38 @@ class JwtAuthenticationFilterTest {
   }
 
   @Test
-  @DisplayName("유효한 JWT 토큰으로 인증에 성공한다")
-  void authenticateValidToken() {
+  @DisplayName("유효한 JWT 토큰은 authority 없이 인증에 성공한다")
+  void authenticateValidTokenWithoutAuthorities() {
     String token = "valid-token";
     String userId = "user123";
+    String userName = "tester";
     MockServerHttpRequest request = MockServerHttpRequest
         .get("/api/test")
         .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
         .build();
     MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    AtomicReference<Authentication> authenticationRef = new AtomicReference<>();
 
     when(jwtProvider.extractUserId(token)).thenReturn(userId);
     when(jwtProvider.getTokenType(token))
         .thenReturn(JwtProvider.ACCESS_TOKEN);
     when(jwtProvider.validateToken(token, userId)).thenReturn(true);
-    when(filterChain.filter(any())).thenReturn(Mono.empty());
+    when(jwtProvider.<String>extractClaim(eq(token), any())).thenReturn(userName);
+    when(filterChain.filter(any())).thenReturn(
+        ReactiveSecurityContextHolder.getContext()
+            .doOnNext(context -> authenticationRef.set(
+                context.getAuthentication()))
+            .then());
 
-    StepVerifier
-        .create(jwtAuthenticationFilter.filter(exchange, filterChain)
-            .contextWrite(ctx -> {
-              return ctx;
-            })
-            .then(Mono.deferContextual(Mono::just))
-            .flatMap(ctx -> ReactiveSecurityContextHolder
-                .getContext()))
-        .expectNextCount(0)
+    StepVerifier.create(jwtAuthenticationFilter.filter(exchange, filterChain))
         .verifyComplete();
+
+    assertThat(authenticationRef.get()).isNotNull();
+    assertThat(authenticationRef.get().isAuthenticated()).isTrue();
+    assertThat(authenticationRef.get().getName()).isEqualTo(userId);
+    assertThat(authenticationRef.get().getPrincipal())
+        .isEqualTo(AuthenticatedUser.of(userId, userName));
+    assertThat(authenticationRef.get().getAuthorities()).isEmpty();
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/config/TestSecurityConfig.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/config/TestSecurityConfig.java
@@ -2,7 +2,6 @@ package com.schemafy.api.common.config;
 
 import org.springframework.context.annotation.*;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -19,7 +18,6 @@ import com.schemafy.api.common.security.jwt.JwtAuthenticationFilter;
 @Profile("test")
 @Configuration
 @EnableWebFluxSecurity
-@EnableReactiveMethodSecurity
 @Import({ JwtAuthenticationEntryPoint.class, JwtAccessDeniedHandler.class,
   JwtAuthenticationFilter.class })
 public class TestSecurityConfig {

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/security/WithMockCustomUser.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/security/WithMockCustomUser.java
@@ -11,6 +11,4 @@ public @interface WithMockCustomUser {
 
   String userId() default "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 
-  String[] roles() default { "EDITOR" };
-
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/common/security/WithMockCustomUserSecurityContextFactory.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/common/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,16 +1,11 @@
 package com.schemafy.api.common.security;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
 import com.schemafy.api.common.security.principal.AuthenticatedUser;
-import com.schemafy.core.project.domain.ProjectRole;
 
 public class WithMockCustomUserSecurityContextFactory
     implements WithSecurityContextFactory<WithMockCustomUser> {
@@ -20,12 +15,8 @@ public class WithMockCustomUserSecurityContextFactory
       WithMockCustomUser customUser) {
     SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-    Set<ProjectRole> roles = Arrays.stream(customUser.roles())
-        .map(ProjectRole::valueOf)
-        .collect(Collectors.toSet());
-
     AuthenticatedUser principal = AuthenticatedUser
-        .withRoles(customUser.userId(), roles);
+        .of(customUser.userId());
 
     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
         principal, null, principal.getAuthorities());

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ColumnControllerTest.java
@@ -56,7 +56,7 @@ import static org.mockito.BDDMockito.given;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("ColumnController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class ColumnControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -385,7 +385,6 @@ class ColumnControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("컬럼 삭제 API 문서화")
   void deleteColumn() {
     String columnId = "06D6W3CAHD51T5NJPK29Q6BCRA";

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/ConstraintControllerTest.java
@@ -73,7 +73,7 @@ import static org.mockito.BDDMockito.then;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("ConstraintController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class ConstraintControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -494,7 +494,6 @@ class ConstraintControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("제약조건 삭제 API 문서화")
   void deleteConstraint() {
     String constraintId = "06D6W4CAHD51T5NJPK29Q6BCRC";

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/DbVendorControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/DbVendorControllerTest.java
@@ -43,7 +43,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("DbVendorController 통합 테스트")
-@WithMockCustomUser(roles = "VIEWER")
+@WithMockCustomUser
 class DbVendorControllerTest {
 
   private static final Integer DB_VENDOR_ID = 1;

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/IndexControllerTest.java
@@ -71,7 +71,7 @@ import static org.mockito.BDDMockito.then;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("IndexController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class IndexControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -297,7 +297,6 @@ class IndexControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("인덱스 삭제 API 문서화")
   void deleteIndex() {
     String indexId = "06D6W6CAHD51T5NJPK29Q6BCRG";

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/MemoControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/MemoControllerTest.java
@@ -51,7 +51,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("MemoController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class MemoControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/OperationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/OperationControllerTest.java
@@ -39,7 +39,7 @@ import static org.mockito.BDDMockito.then;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("OperationController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class OperationControllerTest {
 
   private static final String API_BASE_PATH = ApiPath.API

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/RelationshipControllerTest.java
@@ -74,7 +74,7 @@ import static org.mockito.BDDMockito.then;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("RelationshipController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class RelationshipControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -570,7 +570,6 @@ class RelationshipControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("관계 삭제 API 문서화")
   void deleteRelationship() {
     String relationshipId = "06D6W8CAHD51T5NJPK29Q6BCRK";

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/SchemaControllerTest.java
@@ -68,7 +68,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("SchemaController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class SchemaControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -478,7 +478,6 @@ class SchemaControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("스키마 삭제 API 문서화")
   void deleteSchema() throws Exception {
     String schemaId = "06D6W1GAHD51T5NJPK29Q6BCR8";

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/TableControllerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.BDDMockito.then;
 @AutoConfigureWebTestClient
 @AutoConfigureRestDocs
 @DisplayName("TableController 통합 테스트")
-@WithMockCustomUser(roles = "EDITOR")
+@WithMockCustomUser
 class TableControllerTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -633,7 +633,6 @@ class TableControllerTest {
   }
 
   @Test
-  @WithMockCustomUser(roles = "ADMIN")
   @DisplayName("테이블 삭제 API 문서화")
   void deleteTable() {
     String tableId = "06D6W2BAHD51T5NJPK29Q6BCR9";

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/domain/ProjectRole.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/domain/ProjectRole.java
@@ -20,10 +20,6 @@ public enum ProjectRole {
     return this.level >= EDITOR.level;
   }
 
-  public String asAuthority() {
-    return "ROLE_" + this.name();
-  }
-
   public static ProjectRole fromString(String value) {
     for (ProjectRole role : ProjectRole.values()) {
       if (role.name().equalsIgnoreCase(value)) {


### PR DESCRIPTION
## 개요

- 프로젝트·워크스페이스·초대 controller의 레거시 `@PreAuthorize` 제거 및 리소스 권한 판단을 core 접근 검증으로 일원화
- `AuthenticatedUser`를 사용자 식별 정보 중심으로 단순화하고 JWT의 프로젝트 역할 authority 제거
- 역할 기반 mock-user fixture와 사용되지 않는 reactive method security 설정 정리

## 참고

- core의 `@RequireProjectAccess`, `@RequireWorkspaceAccess`, `AccessVerifier` 동작 변경 없음

## 이슈

- close #479
