### PR TITLE
feat(#471): add project and member search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,4 @@ out/
 
 ### AI Agent ###
 CLAUDE.local.md
-agent-log
 .omo/

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/SearchController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/SearchController.java
@@ -1,0 +1,108 @@
+package com.schemafy.api.project.controller;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.schemafy.api.common.constant.ApiPath;
+import com.schemafy.api.common.type.PageResponse;
+import com.schemafy.api.project.controller.dto.request.MemberSearchCategory;
+import com.schemafy.api.project.controller.dto.request.MemberSearchRequest;
+import com.schemafy.api.project.controller.dto.request.ProjectSearchCategory;
+import com.schemafy.api.project.controller.dto.request.ProjectSearchRequest;
+import com.schemafy.api.project.controller.dto.response.MemberSearchResponse;
+import com.schemafy.api.project.controller.dto.response.ProjectSummaryResponse;
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersUseCase;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsUseCase;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersUseCase;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsUseCase;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RestController
+@Validated
+@RequestMapping(ApiPath.API)
+@RequiredArgsConstructor
+public class SearchController {
+
+  private final SearchWorkspaceProjectsUseCase searchWorkspaceProjectsUseCase;
+  private final SearchSharedProjectsUseCase searchSharedProjectsUseCase;
+  private final SearchWorkspaceMembersUseCase searchWorkspaceMembersUseCase;
+  private final SearchProjectMembersUseCase searchProjectMembersUseCase;
+
+  @GetMapping("/search/projects")
+  public Mono<PageResponse<ProjectSummaryResponse>> searchProjects(
+      @RequestParam ProjectSearchCategory category,
+      @RequestParam(required = false) String workspaceId,
+      @RequestParam(required = false) String search,
+      @RequestParam(defaultValue = "0") @PositiveOrZero @Max(10000) int page,
+      @RequestParam(defaultValue = "5") @Positive @Max(100) int size,
+      Authentication authentication) {
+    ProjectSearchRequest request = new ProjectSearchRequest(
+        category, workspaceId, search, page, size);
+    String requesterId = authentication.getName();
+    Mono<PageResult<ProjectSearchResult>> result = switch (request.category()) {
+    case WORKSPACE -> searchWorkspaceProjectsUseCase.searchWorkspaceProjects(
+        new SearchWorkspaceProjectsQuery(
+            request.workspaceId(), requesterId, request.search(),
+            request.page(), request.size()));
+    case SHARED -> searchSharedProjectsUseCase.searchSharedProjects(
+        new SearchSharedProjectsQuery(
+            requesterId, request.search(), request.page(), request.size()));
+    };
+    return result.map(pageResult -> PageResponse.of(
+        pageResult.content().stream()
+            .map(ProjectSummaryResponse::from)
+            .toList(),
+        pageResult.page(),
+        pageResult.size(),
+        pageResult.totalElements()));
+  }
+
+  @GetMapping("/search/members")
+  public Mono<PageResponse<MemberSearchResponse>> searchMembers(
+      @RequestParam MemberSearchCategory category,
+      @RequestParam(required = false) String workspaceId,
+      @RequestParam(required = false) String projectId,
+      @RequestParam(required = false) String search,
+      @RequestParam(defaultValue = "0") @PositiveOrZero @Max(10000) int page,
+      @RequestParam(defaultValue = "5") @Positive @Max(100) int size,
+      Authentication authentication) {
+    MemberSearchRequest request = new MemberSearchRequest(
+        category, workspaceId, projectId, search, page, size);
+    String requesterId = authentication.getName();
+    Mono<PageResult<MemberSearchResult>> result = switch (request.category()) {
+    case WORKSPACE -> searchWorkspaceMembersUseCase.searchWorkspaceMembers(
+        new SearchWorkspaceMembersQuery(
+            request.workspaceId(), requesterId, request.search(),
+            request.page(), request.size()));
+    case PROJECT -> searchProjectMembersUseCase.searchProjectMembers(
+        new SearchProjectMembersQuery(
+            request.projectId(), requesterId, request.search(),
+            request.page(), request.size()));
+    };
+    return result.map(pageResult -> PageResponse.of(
+        pageResult.content().stream()
+            .map(MemberSearchResponse::from)
+            .toList(),
+        pageResult.page(),
+        pageResult.size(),
+        pageResult.totalElements()));
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/MemberSearchCategory.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/MemberSearchCategory.java
@@ -1,0 +1,6 @@
+package com.schemafy.api.project.controller.dto.request;
+
+public enum MemberSearchCategory {
+  WORKSPACE,
+  PROJECT
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/MemberSearchRequest.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/MemberSearchRequest.java
@@ -1,0 +1,40 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import org.springframework.util.StringUtils;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+public record MemberSearchRequest(
+    MemberSearchCategory category,
+    String workspaceId,
+    String projectId,
+    String search,
+    int page,
+    int size) {
+
+  public MemberSearchRequest {
+    switch (category) {
+    case WORKSPACE -> {
+      if (!StringUtils.hasText(workspaceId)) {
+        throw new DomainException(CommonErrorCode.INVALID_PARAMETER, "workspaceId is required");
+      }
+      if (projectId != null) {
+        throw new DomainException(
+            CommonErrorCode.INVALID_PARAMETER, "projectId is not allowed for WORKSPACE");
+      }
+    }
+    case PROJECT -> {
+      if (!StringUtils.hasText(projectId)) {
+        throw new DomainException(CommonErrorCode.INVALID_PARAMETER, "projectId is required");
+      }
+      if (workspaceId != null) {
+        throw new DomainException(
+            CommonErrorCode.INVALID_PARAMETER, "workspaceId is not allowed for PROJECT");
+      }
+    }
+    }
+    search = ProjectSearchPolicy.normalize(search);
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchCategory.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchCategory.java
@@ -1,0 +1,6 @@
+package com.schemafy.api.project.controller.dto.request;
+
+public enum ProjectSearchCategory {
+  WORKSPACE,
+  SHARED
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchPolicy.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchPolicy.java
@@ -1,0 +1,24 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+public final class ProjectSearchPolicy {
+
+  public static final int MAX_SEARCH_LENGTH = 100;
+  private static final String INVALID_SEARCH_MESSAGE = "search must contain 1 to 100 characters without control characters";
+
+  private ProjectSearchPolicy() {}
+
+  public static String normalize(String search) {
+    String normalizedSearch = search == null ? null : search.strip();
+    if (search == null
+        || search.codePoints().anyMatch(Character::isISOControl)
+        || normalizedSearch.isEmpty()
+        || normalizedSearch.codePointCount(0, normalizedSearch.length()) > MAX_SEARCH_LENGTH) {
+      throw new DomainException(CommonErrorCode.INVALID_PARAMETER, INVALID_SEARCH_MESSAGE);
+    }
+    return normalizedSearch;
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchRequest.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/request/ProjectSearchRequest.java
@@ -1,0 +1,32 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import org.springframework.util.StringUtils;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+public record ProjectSearchRequest(
+    ProjectSearchCategory category,
+    String workspaceId,
+    String search,
+    int page,
+    int size) {
+
+  public ProjectSearchRequest {
+    switch (category) {
+    case WORKSPACE -> {
+      if (!StringUtils.hasText(workspaceId)) {
+        throw new DomainException(CommonErrorCode.INVALID_PARAMETER, "workspaceId is required");
+      }
+    }
+    case SHARED -> {
+      if (workspaceId != null) {
+        throw new DomainException(
+            CommonErrorCode.INVALID_PARAMETER, "workspaceId is not allowed for SHARED");
+      }
+    }
+    }
+    search = ProjectSearchPolicy.normalize(search);
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/MemberSearchResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/MemberSearchResponse.java
@@ -1,0 +1,23 @@
+package com.schemafy.api.project.controller.dto.response;
+
+import java.time.Instant;
+
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+
+public record MemberSearchResponse(
+    String userId,
+    String userName,
+    String userEmail,
+    String role,
+    Instant joinedAt) {
+
+  public static MemberSearchResponse from(MemberSearchResult result) {
+    return new MemberSearchResponse(
+        result.userId(),
+        result.userName(),
+        result.userEmail(),
+        result.role(),
+        result.joinedAt());
+  }
+
+}

--- a/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/ProjectSummaryResponse.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/project/controller/dto/response/ProjectSummaryResponse.java
@@ -2,6 +2,7 @@ package com.schemafy.api.project.controller.dto.response;
 
 import java.time.Instant;
 
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
 import com.schemafy.core.project.application.port.in.ProjectSummary;
 import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectRole;
@@ -24,6 +25,18 @@ public record ProjectSummaryResponse(String id, String workspaceId, Integer dbVe
 
   public static ProjectSummaryResponse from(ProjectSummary detail) {
     return of(detail.project(), detail.role());
+  }
+
+  public static ProjectSummaryResponse from(ProjectSearchResult result) {
+    return new ProjectSummaryResponse(
+        result.id(),
+        result.workspaceId(),
+        result.dbVendorId(),
+        result.name(),
+        result.description(),
+        result.requesterRole(),
+        result.createdAt(),
+        result.updatedAt());
   }
 
 }

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectControllerTest.java
@@ -146,8 +146,8 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
   @Test
   @DisplayName("워크스페이스 멤버가 아닌 사용자는 프로젝트를 생성할 수 없다")
   void createProjectFailWhenNotWorkspaceMember() {
-    // Remove user2 from workspace
-    workspaceMemberRepository.findByWorkspaceIdAndUserIdAndNotDeleted(testWorkspaceId, testUser2Id)
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(testWorkspaceId, testUser2Id)
         .flatMap(workspaceMemberRepository::delete).block();
 
     CreateProjectRequest request = new CreateProjectRequest("My Project",
@@ -206,7 +206,8 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
 
     ProjectMember member = addProjectMember(project.getId(), testUser2Id, ProjectRole.VIEWER);
 
-    workspaceMemberRepository.findByWorkspaceIdAndUserIdAndNotDeleted(testWorkspaceId, testUser2Id)
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(testWorkspaceId, testUser2Id)
         .flatMap(workspaceMemberRepository::delete)
         .block();
 
@@ -664,7 +665,7 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
     addProjectMember(project.getId(), testUser2Id, ProjectRole.ADMIN);
 
     WorkspaceMember targetWorkspaceMember = workspaceMemberRepository
-        .findByWorkspaceIdAndUserIdAndNotDeleted(testWorkspaceId, testUser2Id)
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(testWorkspaceId, testUser2Id)
         .block();
     targetWorkspaceMember.updateRole(WorkspaceRole.ADMIN);
     workspaceMemberRepository.save(targetWorkspaceMember).block();
@@ -686,7 +687,7 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
     addProjectMember(project.getId(), testUser2Id, ProjectRole.ADMIN);
 
     WorkspaceMember targetWorkspaceMember = workspaceMemberRepository
-        .findByWorkspaceIdAndUserIdAndNotDeleted(testWorkspaceId, testUser2Id)
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(testWorkspaceId, testUser2Id)
         .block();
     targetWorkspaceMember.updateRole(WorkspaceRole.ADMIN);
     workspaceMemberRepository.save(targetWorkspaceMember).block();
@@ -755,7 +756,7 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
             ProjectApiSnippets.leaveProjectRequestHeaders()));
 
     ProjectMember deletedMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(),
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(),
             testUser2Id)
         .block();
     assertThat(deletedMember).isNull();
@@ -777,7 +778,7 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
         .expectStatus().isNoContent();
 
     Project deletedProject = projectRepository
-        .findByIdAndNotDeleted(project.getId()).block();
+        .findByIdAndDeletedAtIsNull(project.getId()).block();
     assertThat(deletedProject).isNull();
   }
 
@@ -805,11 +806,11 @@ class ProjectControllerTest extends ProjectHttpTestSupport {
     assertThat(deletedProjectAdmin.isDeleted()).isTrue();
 
     ProjectMember remainedProjectViewer = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(), testUserId)
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(), testUserId)
         .block();
     assertThat(remainedProjectViewer).isNotNull();
 
-    Project remainedProject = projectRepository.findByIdAndNotDeleted(project.getId()).block();
+    Project remainedProject = projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block();
     assertThat(remainedProject).isNotNull();
   }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/ProjectInvitationControllerTest.java
@@ -451,7 +451,7 @@ class ProjectInvitationControllerTest extends ProjectHttpTestSupport {
       assertThat(updated.getStatusAsEnum()).isEqualTo(InvitationStatus.ACCEPTED);
 
       boolean memberExists = projectMemberRepository
-          .existsByProjectIdAndUserIdAndNotDeleted(testProject.getId(), workspaceMemberId)
+          .existsByProjectIdAndUserIdAndDeletedAtIsNull(testProject.getId(), workspaceMemberId)
           .block();
       assertThat(memberExists).isTrue();
     }

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/SearchControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/SearchControllerTest.java
@@ -1,0 +1,342 @@
+package com.schemafy.api.project.controller;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.schemafy.api.common.constant.ApiPath;
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.api.project.docs.SearchApiSnippets;
+import com.schemafy.api.testsupport.project.ProjectHttpTestSupport;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.user.domain.User;
+
+import static com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper.document;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureWebTestClient
+@AutoConfigureRestDocs
+@DisplayName("SearchController 통합 테스트")
+class SearchControllerTest extends ProjectHttpTestSupport {
+
+  private static final String API_PREFIX = ApiPath.API.replace("{version}", "v1.0");
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  private String aliceId;
+  private String bobId;
+  private String outsiderId;
+  private String aliceToken;
+  private String bobToken;
+  private String outsiderToken;
+  private String workspaceId;
+  private String workspaceProjectId;
+  private String bobSharedProjectId;
+  private String aliceSharedProjectId;
+
+  @BeforeEach
+  void setUp() {
+    cleanupProjectFixtures().block();
+
+    User alice = createUser("alice@example.com", "Alice Lee");
+    User bob = createUser("bob@example.com", "Bob Lee");
+    User outsider = createUser("mallory@example.com", "Mallory");
+    aliceId = alice.id();
+    bobId = bob.id();
+    outsiderId = outsider.id();
+    aliceToken = generateAccessToken(aliceId);
+    bobToken = generateAccessToken(bobId);
+    outsiderToken = generateAccessToken(outsiderId);
+
+    Workspace workspace = saveWorkspace("Search Workspace", "Description");
+    workspaceId = workspace.getId();
+    addWorkspaceMember(workspaceId, aliceId, WorkspaceRole.ADMIN);
+    addWorkspaceMember(workspaceId, bobId, WorkspaceRole.MEMBER);
+
+    Project workspaceProject = saveProject(
+        workspaceId, "Schema Workspace", "Workspace project");
+    workspaceProjectId = workspaceProject.getId();
+    addProjectMember(workspaceProjectId, aliceId, ProjectRole.ADMIN);
+    addProjectMember(workspaceProjectId, bobId, ProjectRole.VIEWER);
+    Project unrelatedProject = saveProject(
+        workspaceId, "Unrelated", "Not a search match");
+    addProjectMember(unrelatedProject.getId(), aliceId, ProjectRole.ADMIN);
+
+    Workspace bobSharedWorkspace = saveWorkspace(
+        "Bob Shared Workspace", "Description");
+    addWorkspaceMember(
+        bobSharedWorkspace.getId(), aliceId, WorkspaceRole.ADMIN);
+    Project bobSharedProject = saveProject(
+        bobSharedWorkspace.getId(), "Schema Shared Bob", "Direct share");
+    bobSharedProjectId = bobSharedProject.getId();
+    addProjectMember(bobSharedProjectId, aliceId, ProjectRole.ADMIN);
+    addProjectMember(bobSharedProjectId, bobId, ProjectRole.EDITOR);
+
+    Workspace aliceSharedWorkspace = saveWorkspace(
+        "Alice Shared Workspace", "Description");
+    addWorkspaceMember(
+        aliceSharedWorkspace.getId(), outsiderId, WorkspaceRole.ADMIN);
+    Project aliceSharedProject = saveProject(
+        aliceSharedWorkspace.getId(), "Schema Shared Alice", "Direct share");
+    aliceSharedProjectId = aliceSharedProject.getId();
+    addProjectMember(aliceSharedProjectId, outsiderId, ProjectRole.ADMIN);
+    addProjectMember(aliceSharedProjectId, aliceId, ProjectRole.VIEWER);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 프로젝트를 검색한다")
+  void searchWorkspaceProjects() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/projects?category=WORKSPACE&workspaceId="
+            + workspaceId + "&search=schema&page=0&size=5")
+        .header("Authorization", "Bearer " + bobToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(document("search-projects-workspace",
+            SearchApiSnippets.searchRequestHeaders(),
+            SearchApiSnippets.projectQueryParameters(),
+            SearchApiSnippets.searchResponseHeaders(),
+            SearchApiSnippets.projectResponse()))
+        .jsonPath("$.content[0].id").isEqualTo(workspaceProjectId)
+        .jsonPath("$.content[0].workspaceId").isEqualTo(workspaceId)
+        .jsonPath("$.content[0].dbVendorId").isEqualTo(DB_VENDOR_ID)
+        .jsonPath("$.content[0].name").isEqualTo("Schema Workspace")
+        .jsonPath("$.content[0].description")
+        .isEqualTo("Workspace project")
+        .jsonPath("$.content[0].myRole")
+        .isEqualTo(ProjectRole.VIEWER.name())
+        .jsonPath("$.content[0].createdAt").isNotEmpty()
+        .jsonPath("$.content[0].updatedAt").isNotEmpty()
+        .jsonPath("$.page").isEqualTo(0)
+        .jsonPath("$.size").isEqualTo(5)
+        .jsonPath("$.totalElements").isEqualTo(1)
+        .jsonPath("$.totalPages").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("직접 공유된 프로젝트를 검색한다")
+  void searchSharedProjects() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/projects?category=SHARED&search=schema&page=0&size=5")
+        .header("Authorization", "Bearer " + bobToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(document("search-projects-shared",
+            SearchApiSnippets.searchRequestHeaders(),
+            SearchApiSnippets.projectQueryParameters(),
+            SearchApiSnippets.searchResponseHeaders(),
+            SearchApiSnippets.projectResponse()))
+        .jsonPath("$.content[0].id").isEqualTo(bobSharedProjectId)
+        .jsonPath("$.content[0].myRole")
+        .isEqualTo(ProjectRole.EDITOR.name())
+        .jsonPath("$.totalElements").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버를 검색한다")
+  void searchWorkspaceMembers() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/members?category=WORKSPACE&workspaceId="
+            + workspaceId + "&search=lee&page=0&size=5")
+        .header("Authorization", "Bearer " + aliceToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(document("search-members-workspace",
+            SearchApiSnippets.searchRequestHeaders(),
+            SearchApiSnippets.memberQueryParameters(),
+            SearchApiSnippets.searchResponseHeaders(),
+            SearchApiSnippets.memberResponse()))
+        .jsonPath("$.content[?(@.userId == '" + aliceId + "')].userId")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of(aliceId)))
+        .jsonPath("$.content[?(@.userId == '" + aliceId + "')].userName")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of("Alice Lee")))
+        .jsonPath("$.content[?(@.userId == '" + aliceId + "')].userEmail")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of("alice@example.com")))
+        .jsonPath("$.content[?(@.userId == '" + aliceId + "')].role")
+        .value(value -> assertThat(value).isEqualTo(
+            java.util.List.of(WorkspaceRole.ADMIN.name())))
+        .jsonPath("$.content[?(@.userId == '" + bobId + "')].userId")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of(bobId)))
+        .jsonPath("$.content[0].joinedAt").isNotEmpty()
+        .jsonPath("$.content[0].workspaceId").doesNotExist()
+        .jsonPath("$.content[0].projectId").doesNotExist()
+        .jsonPath("$.totalElements").isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버를 검색한다")
+  void searchProjectMembers() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/members?category=PROJECT&projectId="
+            + workspaceProjectId + "&search=lee&page=0&size=5")
+        .header("Authorization", "Bearer " + bobToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .consumeWith(document("search-members-project",
+            SearchApiSnippets.searchRequestHeaders(),
+            SearchApiSnippets.memberQueryParameters(),
+            SearchApiSnippets.searchResponseHeaders(),
+            SearchApiSnippets.memberResponse()))
+        .jsonPath("$.content[?(@.userId == '" + aliceId + "')].userId")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of(aliceId)))
+        .jsonPath("$.content[?(@.userId == '" + bobId + "')].userId")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of(bobId)))
+        .jsonPath("$.content[?(@.userId == '" + bobId + "')].userName")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of("Bob Lee")))
+        .jsonPath("$.content[?(@.userId == '" + bobId + "')].userEmail")
+        .value(value -> assertThat(value).isEqualTo(java.util.List.of("bob@example.com")))
+        .jsonPath("$.content[?(@.userId == '" + bobId + "')].role")
+        .value(value -> assertThat(value).isEqualTo(
+            java.util.List.of(ProjectRole.VIEWER.name())))
+        .jsonPath("$.content[0].joinedAt").isNotEmpty()
+        .jsonPath("$.content[0].workspaceId").doesNotExist()
+        .jsonPath("$.content[0].projectId").doesNotExist()
+        .jsonPath("$.totalElements").isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("공유 프로젝트 검색의 requesterId는 인증 주체에서만 가져온다")
+  void sharedSearchUsesOnlyAuthenticatedPrincipal() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/projects?category=SHARED&search=schema"
+            + "&requesterId=" + aliceId)
+        .header("Authorization", "Bearer " + bobToken)
+        .exchange()
+        .expectStatus().isOk()
+        .expectBody()
+        .jsonPath("$.content.length()").isEqualTo(1)
+        .jsonPath("$.content[0].id").isEqualTo(bobSharedProjectId)
+        .jsonPath("$.content[?(@.id == '" + aliceSharedProjectId + "')]")
+        .isEmpty()
+        .jsonPath("$.page").isEqualTo(0)
+        .jsonPath("$.size").isEqualTo(5);
+  }
+
+  @DisplayName("잘못된 검색 요청은 400 Bad Request를 반환한다")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidSearchRequests")
+  void rejectInvalidSearchRequests(String description, String uri) {
+    webTestClient.get()
+        .uri(URI.create(uri))
+        .header("Authorization", "Bearer " + aliceToken)
+        .exchange()
+        .expectStatus().isBadRequest()
+        .expectBody()
+        .jsonPath("$.reason")
+        .isEqualTo(CommonErrorCode.INVALID_PARAMETER.code());
+  }
+
+  @Test
+  @DisplayName("워크스페이스 외부 요청자는 워크스페이스 검색을 할 수 없다")
+  void rejectRequesterOutsideWorkspace() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/projects?category=WORKSPACE&workspaceId="
+            + workspaceId + "&search=schema")
+        .header("Authorization", "Bearer " + outsiderToken)
+        .exchange()
+        .expectStatus().isForbidden();
+  }
+
+  @Test
+  @DisplayName("프로젝트 외부 요청자는 프로젝트 멤버 검색을 할 수 없다")
+  void rejectRequesterOutsideProject() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/members?category=PROJECT&projectId="
+            + workspaceProjectId + "&search=lee")
+        .header("Authorization", "Bearer " + outsiderToken)
+        .exchange()
+        .expectStatus().isForbidden();
+  }
+
+  @Test
+  @DisplayName("인증하지 않은 요청은 거부한다")
+  void rejectUnauthenticatedRequest() {
+    webTestClient.get()
+        .uri(API_PREFIX
+            + "/search/projects?category=SHARED&search=schema")
+        .exchange()
+        .expectStatus().isUnauthorized();
+  }
+
+  private static Stream<Arguments> invalidSearchRequests() {
+    String projects = API_PREFIX + "/search/projects";
+    String members = API_PREFIX + "/search/members";
+    return Stream.of(
+        Arguments.of("missing search",
+            projects + "?category=SHARED"),
+        Arguments.of("empty search",
+            projects + "?category=SHARED&search="),
+        Arguments.of("blank search",
+            projects + "?category=SHARED&search=%20%20"),
+        Arguments.of("over 100 Unicode code points",
+            projects + "?category=SHARED&search=" + "a".repeat(101)),
+        Arguments.of("NUL search",
+            projects + "?category=SHARED&search=%00"),
+        Arguments.of("control-character search",
+            projects + "?category=SHARED&search=%0A"),
+        Arguments.of("negative page",
+            projects + "?category=SHARED&search=schema&page=-1"),
+        Arguments.of("page over 10000",
+            projects + "?category=SHARED&search=schema&page=10001"),
+        Arguments.of("zero size",
+            projects + "?category=SHARED&search=schema&size=0"),
+        Arguments.of("size over 100",
+            projects + "?category=SHARED&search=schema&size=101"),
+        Arguments.of("unknown project category",
+            projects + "?category=UNKNOWN&search=schema"),
+        Arguments.of("workspace project search without workspaceId",
+            projects + "?category=WORKSPACE&search=schema"),
+        Arguments.of("workspace project search with blank workspaceId",
+            projects
+                + "?category=WORKSPACE&workspaceId=%20&search=schema"),
+        Arguments.of("shared search with workspaceId",
+            projects
+                + "?category=SHARED&workspaceId=" + "0".repeat(26)
+                + "&search=schema"),
+        Arguments.of("unknown member category",
+            members + "?category=UNKNOWN&search=lee"),
+        Arguments.of("workspace member search without workspaceId",
+            members + "?category=WORKSPACE&search=lee"),
+        Arguments.of("workspace member search with projectId",
+            members
+                + "?category=WORKSPACE&workspaceId=" + "0".repeat(26)
+                + "&projectId=" + "1".repeat(26) + "&search=lee"),
+        Arguments.of("project member search without projectId",
+            members + "?category=PROJECT&search=lee"),
+        Arguments.of("project member search with workspaceId",
+            members
+                + "?category=PROJECT&projectId=" + "1".repeat(26)
+                + "&workspaceId=" + "0".repeat(26) + "&search=lee"));
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java
@@ -473,11 +473,11 @@ class WorkspaceControllerTest extends ProjectHttpTestSupport {
     assertThat(deletedWorkspace).isNull();
 
     Project deletedProject = projectRepository
-        .findByIdAndNotDeleted(project.getId()).block();
+        .findByIdAndDeletedAtIsNull(project.getId()).block();
     assertThat(deletedProject).isNull();
 
     ProjectMember activeProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(), testUser2Id).block();
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(), testUser2Id).block();
     assertThat(activeProjectMember).isNull();
   }
 

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceInvitationControllerTest.java
@@ -451,7 +451,7 @@ class WorkspaceInvitationControllerTest extends ProjectHttpTestSupport {
       assertThat(updated.getStatusAsEnum()).isEqualTo(InvitationStatus.ACCEPTED);
 
       boolean memberExists = workspaceMemberRepository
-          .existsByWorkspaceIdAndUserIdAndNotDeleted(testWorkspace.getId(), invitedUserId)
+          .existsByWorkspaceIdAndUserIdAndDeletedAtIsNull(testWorkspace.getId(), invitedUserId)
           .block();
       assertThat(memberExists).isTrue();
     }

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/MemberSearchRequestTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/MemberSearchRequestTest.java
@@ -1,0 +1,94 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("MemberSearchRequest")
+class MemberSearchRequestTest {
+
+  @Test
+  @DisplayName("워크스페이스 멤버 검색어를 정규화한다")
+  void normalizesWorkspaceMemberSearchText() {
+    MemberSearchRequest request = new MemberSearchRequest(
+        MemberSearchCategory.WORKSPACE, "workspace-id", null, "  schema  ", 0,
+        5);
+
+    assertThat(request.workspaceId()).isEqualTo("workspace-id");
+    assertThat(request.search()).isEqualTo("schema");
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 검색은 projectId만 허용한다")
+  void acceptsProjectMemberSearchWithOnlyProjectId() {
+    MemberSearchRequest request = new MemberSearchRequest(
+        MemberSearchCategory.PROJECT, null, "project-id", "schema", 0, 5);
+
+    assertThat(request.projectId()).isEqualTo("project-id");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = { " ", "\t" })
+  @DisplayName("워크스페이스 멤버 검색에 workspaceId가 없으면 예외가 발생한다")
+  void rejectsMissingWorkspaceIdForWorkspaceMemberSearch(String workspaceId) {
+    assertInvalidParameter(
+        () -> new MemberSearchRequest(
+            MemberSearchCategory.WORKSPACE, workspaceId, null, "schema", 0,
+            5),
+        "workspaceId is required");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "", " ", "project-id" })
+  @DisplayName("워크스페이스 멤버 검색에 projectId가 있으면 예외가 발생한다")
+  void rejectsProjectIdForWorkspaceMemberSearch(String projectId) {
+    assertInvalidParameter(
+        () -> new MemberSearchRequest(
+            MemberSearchCategory.WORKSPACE, "workspace-id", projectId,
+            "schema", 0, 5),
+        "projectId is not allowed for WORKSPACE");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = { " ", "\t" })
+  @DisplayName("프로젝트 멤버 검색에 projectId가 없으면 예외가 발생한다")
+  void rejectsMissingProjectIdForProjectMemberSearch(String projectId) {
+    assertInvalidParameter(
+        () -> new MemberSearchRequest(
+            MemberSearchCategory.PROJECT, null, projectId, "schema", 0, 5),
+        "projectId is required");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "", " ", "workspace-id" })
+  @DisplayName("프로젝트 멤버 검색에 workspaceId가 있으면 예외가 발생한다")
+  void rejectsWorkspaceIdForProjectMemberSearch(String workspaceId) {
+    assertInvalidParameter(
+        () -> new MemberSearchRequest(
+            MemberSearchCategory.PROJECT, workspaceId, "project-id",
+            "schema", 0, 5),
+        "workspaceId is not allowed for PROJECT");
+  }
+
+  private void assertInvalidParameter(
+      org.assertj.core.api.ThrowableAssert.ThrowingCallable action,
+      String message) {
+    assertThatThrownBy(action)
+        .isInstanceOf(DomainException.class)
+        .hasMessage(message)
+        .satisfies(error -> assertThat(
+            ((DomainException) error).getErrorCode())
+            .isEqualTo(CommonErrorCode.INVALID_PARAMETER));
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/ProjectSearchPolicyTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/ProjectSearchPolicyTest.java
@@ -1,0 +1,48 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectSearchPolicyTest {
+
+  @Test
+  void normalizesSearchText() {
+    assertThat(ProjectSearchPolicy.normalize("  schema  ")).isEqualTo("schema");
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = { "", " ", "\t", "schema\ntext" })
+  void rejectsNullBlankAndControlCharacterSearchText(String search) {
+    assertInvalidSearch(search);
+  }
+
+  @Test
+  void acceptsOneHundredSupplementaryUnicodeCodePoints() {
+    String search = "😀".repeat(100);
+
+    assertThat(ProjectSearchPolicy.normalize(search)).isEqualTo(search);
+  }
+
+  @Test
+  void rejectsSearchTextOverOneHundredUnicodeCodePoints() {
+    assertInvalidSearch("😀".repeat(101));
+  }
+
+  private void assertInvalidSearch(String search) {
+    assertThatThrownBy(() -> ProjectSearchPolicy.normalize(search))
+        .isInstanceOf(DomainException.class)
+        .hasMessage("search must contain 1 to 100 characters without control characters")
+        .satisfies(error -> assertThat(((DomainException) error).getErrorCode())
+            .isEqualTo(CommonErrorCode.INVALID_PARAMETER));
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/ProjectSearchRequestTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/dto/request/ProjectSearchRequestTest.java
@@ -1,0 +1,70 @@
+package com.schemafy.api.project.controller.dto.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.schemafy.api.common.exception.CommonErrorCode;
+import com.schemafy.core.common.exception.DomainException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ProjectSearchRequest")
+class ProjectSearchRequestTest {
+
+  @Test
+  @DisplayName("워크스페이스 프로젝트 검색어를 정규화한다")
+  void normalizesWorkspaceSearchText() {
+    ProjectSearchRequest request = new ProjectSearchRequest(
+        ProjectSearchCategory.WORKSPACE, "workspace-id", "  schema  ",
+        0, 5);
+
+    assertThat(request.workspaceId()).isEqualTo("workspace-id");
+    assertThat(request.search()).isEqualTo("schema");
+  }
+
+  @Test
+  @DisplayName("공유 프로젝트 검색은 workspaceId 없이 허용한다")
+  void acceptsSharedProjectSearchWithoutWorkspaceId() {
+    ProjectSearchRequest request = new ProjectSearchRequest(
+        ProjectSearchCategory.SHARED, null, "schema", 0, 5);
+
+    assertThat(request.workspaceId()).isNull();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = { " ", "\t" })
+  @DisplayName("워크스페이스 프로젝트 검색은 workspaceId를 필수로 요구한다")
+  void rejectsMissingWorkspaceIdForWorkspaceSearch(String workspaceId) {
+    assertInvalidParameter(
+        () -> new ProjectSearchRequest(
+            ProjectSearchCategory.WORKSPACE, workspaceId, "schema", 0, 5),
+        "workspaceId is required");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "", " ", "workspace-id" })
+  @DisplayName("공유 프로젝트 검색은 workspaceId를 허용하지 않는다")
+  void rejectsWorkspaceIdForSharedSearch(String workspaceId) {
+    assertInvalidParameter(
+        () -> new ProjectSearchRequest(
+            ProjectSearchCategory.SHARED, workspaceId, "schema", 0, 5),
+        "workspaceId is not allowed for SHARED");
+  }
+
+  private void assertInvalidParameter(
+      org.assertj.core.api.ThrowableAssert.ThrowingCallable action,
+      String message) {
+    assertThatThrownBy(action)
+        .isInstanceOf(DomainException.class)
+        .hasMessage(message)
+        .satisfies(error -> assertThat(
+            ((DomainException) error).getErrorCode())
+            .isEqualTo(CommonErrorCode.INVALID_PARAMETER));
+  }
+
+}

--- a/apps/backend/api/src/test/java/com/schemafy/api/project/docs/SearchApiSnippets.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/docs/SearchApiSnippets.java
@@ -1,0 +1,114 @@
+package com.schemafy.api.project.docs;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import com.schemafy.api.common.docs.RestDocsSnippets;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+/** Search API 문서화를 위한 스니펫 제공 클래스 */
+public class SearchApiSnippets extends RestDocsSnippets {
+
+  public static Snippet searchRequestHeaders() {
+    return createRequestHeadersSnippet(authorizationHeader());
+  }
+
+  public static Snippet searchResponseHeaders() {
+    return createResponseHeadersSnippet(commonResponseHeaders());
+  }
+
+  public static Snippet projectQueryParameters() {
+    return queryParameters(
+        parameterWithName("category")
+            .description("프로젝트 검색 범위 (WORKSPACE, SHARED)"),
+        parameterWithName("workspaceId")
+            .description("WORKSPACE 검색 대상 워크스페이스 ID")
+            .optional(),
+        parameterWithName("search")
+            .description("프로젝트 이름 검색어 (1-100자)"),
+        parameterWithName("page")
+            .description("페이지 번호 (0부터 시작, 기본값: 0, 최대: 10000)")
+            .optional(),
+        parameterWithName("size")
+            .description("페이지 크기 (기본값: 5, 범위: 1-100)")
+            .optional());
+  }
+
+  public static Snippet memberQueryParameters() {
+    return queryParameters(
+        parameterWithName("category")
+            .description("멤버 검색 범위 (WORKSPACE, PROJECT)"),
+        parameterWithName("workspaceId")
+            .description("WORKSPACE 검색 대상 워크스페이스 ID")
+            .optional(),
+        parameterWithName("projectId")
+            .description("PROJECT 검색 대상 프로젝트 ID")
+            .optional(),
+        parameterWithName("search")
+            .description("사용자 이름 또는 이메일 검색어 (1-100자)"),
+        parameterWithName("page")
+            .description("페이지 번호 (0부터 시작, 기본값: 0, 최대: 10000)")
+            .optional(),
+        parameterWithName("size")
+            .description("페이지 크기 (기본값: 5, 범위: 1-100)")
+            .optional());
+  }
+
+  public static Snippet projectResponse() {
+    return createResponseFieldsSnippet(
+        fieldWithPath("content[]").type(JsonFieldType.ARRAY)
+            .description("검색된 프로젝트 목록"),
+        fieldWithPath("content[].id").type(JsonFieldType.STRING)
+            .description("프로젝트 ID"),
+        fieldWithPath("content[].workspaceId").type(JsonFieldType.STRING)
+            .description("워크스페이스 ID"),
+        fieldWithPath("content[].dbVendorId").type(JsonFieldType.NUMBER)
+            .description("데이터베이스 벤더 ID"),
+        fieldWithPath("content[].name").type(JsonFieldType.STRING)
+            .description("프로젝트 이름"),
+        fieldWithPath("content[].description").type(JsonFieldType.STRING)
+            .description("프로젝트 설명").optional(),
+        fieldWithPath("content[].myRole").type(JsonFieldType.STRING)
+            .description("요청자의 프로젝트 역할"),
+        fieldWithPath("content[].createdAt").type(JsonFieldType.STRING)
+            .description("프로젝트 생성 시각"),
+        fieldWithPath("content[].updatedAt").type(JsonFieldType.STRING)
+            .description("프로젝트 수정 시각"),
+        fieldWithPath("page").type(JsonFieldType.NUMBER)
+            .description("현재 페이지 번호"),
+        fieldWithPath("size").type(JsonFieldType.NUMBER)
+            .description("페이지 크기"),
+        fieldWithPath("totalElements").type(JsonFieldType.NUMBER)
+            .description("전체 검색 결과 수"),
+        fieldWithPath("totalPages").type(JsonFieldType.NUMBER)
+            .description("전체 페이지 수"));
+  }
+
+  public static Snippet memberResponse() {
+    return createResponseFieldsSnippet(
+        fieldWithPath("content[]").type(JsonFieldType.ARRAY)
+            .description("검색된 멤버 목록"),
+        fieldWithPath("content[].userId").type(JsonFieldType.STRING)
+            .description("사용자 ID"),
+        fieldWithPath("content[].userName").type(JsonFieldType.STRING)
+            .description("사용자 이름"),
+        fieldWithPath("content[].userEmail").type(JsonFieldType.STRING)
+            .description("사용자 이메일"),
+        fieldWithPath("content[].role").type(JsonFieldType.STRING)
+            .description("검색 범위 내 사용자 역할"),
+        fieldWithPath("content[].joinedAt").type(JsonFieldType.STRING)
+            .description("멤버 가입 시각"),
+        fieldWithPath("page").type(JsonFieldType.NUMBER)
+            .description("현재 페이지 번호"),
+        fieldWithPath("size").type(JsonFieldType.NUMBER)
+            .description("페이지 크기"),
+        fieldWithPath("totalElements").type(JsonFieldType.NUMBER)
+            .description("전체 검색 결과 수"),
+        fieldWithPath("totalPages").type(JsonFieldType.NUMBER)
+            .description("전체 페이지 수"));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/persistence/SqlLikePattern.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/persistence/SqlLikePattern.java
@@ -1,0 +1,17 @@
+package com.schemafy.core.common.persistence;
+
+import java.util.Locale;
+
+public final class SqlLikePattern {
+
+  private SqlLikePattern() {}
+
+  public static String contains(String value) {
+    String escaped = value.toLowerCase(Locale.ROOT)
+        .replace("!", "!!")
+        .replace("%", "!%")
+        .replace("_", "!_");
+    return "%" + escaped + "%";
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
@@ -34,7 +34,7 @@ public interface ProjectMemberRepository
           LOWER(u.name) LIKE :pattern ESCAPE '!'
           OR LOWER(u.email) LIKE :pattern ESCAPE '!'
         )
-      ORDER BY pm.joined_at ASC
+      ORDER BY pm.joined_at ASC, pm.id ASC
       LIMIT :limit OFFSET :offset
       """)
   Flux<MemberSearchResult> searchMemberResultsByProjectIdAndUser(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectMemberRepository.java
@@ -3,6 +3,7 @@ package com.schemafy.core.project.adapter.out.persistence;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
 import com.schemafy.core.project.domain.ProjectMember;
 
 import reactor.core.publisher.Flux;
@@ -11,31 +12,59 @@ import reactor.core.publisher.Mono;
 public interface ProjectMemberRepository
     extends ReactiveCrudRepository<ProjectMember, String> {
 
-  @Query("SELECT * FROM project_members WHERE project_id = :projectId AND user_id = :userId AND deleted_at IS NULL")
-  Mono<ProjectMember> findByProjectIdAndUserIdAndNotDeleted(String projectId,
+  Mono<ProjectMember> findByProjectIdAndUserIdAndDeletedAtIsNull(String projectId,
       String userId);
 
   @Query("SELECT * FROM project_members WHERE project_id = :projectId AND deleted_at IS NULL ORDER BY joined_at LIMIT :limit OFFSET :offset")
   Flux<ProjectMember> findByProjectIdAndNotDeleted(String projectId,
       int limit, int offset);
 
-  @Query("SELECT COUNT(*) FROM project_members WHERE project_id = :projectId AND deleted_at IS NULL")
-  Mono<Long> countByProjectIdAndNotDeleted(String projectId);
+  @Query("""
+      SELECT
+        pm.user_id AS user_id,
+        u.name AS user_name,
+        u.email AS user_email,
+        pm.role AS role,
+        pm.joined_at AS joined_at
+      FROM project_members pm
+      INNER JOIN users u ON u.id = pm.user_id
+      WHERE pm.project_id = :projectId
+        AND pm.deleted_at IS NULL
+        AND (
+          LOWER(u.name) LIKE :pattern ESCAPE '!'
+          OR LOWER(u.email) LIKE :pattern ESCAPE '!'
+        )
+      ORDER BY pm.joined_at ASC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<MemberSearchResult> searchMemberResultsByProjectIdAndUser(
+      String projectId, String pattern, int limit, int offset);
 
-  @Query("SELECT EXISTS(SELECT 1 FROM project_members WHERE project_id = :projectId AND user_id = :userId AND deleted_at IS NULL)")
-  Mono<Boolean> existsByProjectIdAndUserIdAndNotDeleted(String projectId,
+  Mono<Long> countByProjectIdAndDeletedAtIsNull(String projectId);
+
+  @Query("""
+      SELECT COUNT(*) FROM project_members pm
+      INNER JOIN users u ON u.id = pm.user_id
+      WHERE pm.project_id = :projectId
+        AND pm.deleted_at IS NULL
+        AND (
+          LOWER(u.name) LIKE :pattern ESCAPE '!'
+          OR LOWER(u.email) LIKE :pattern ESCAPE '!'
+        )
+      """)
+  Mono<Long> countByProjectIdAndUser(String projectId, String pattern);
+
+  Mono<Boolean> existsByProjectIdAndUserIdAndDeletedAtIsNull(String projectId,
       String userId);
 
   @Query("UPDATE project_members SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE project_id = :projectId AND deleted_at IS NULL")
   Mono<Void> softDeleteByProjectId(String projectId);
 
-  @Query("SELECT COUNT(*) FROM project_members WHERE project_id = :projectId AND role = :role AND deleted_at IS NULL")
-  Mono<Long> countByProjectIdAndRoleAndNotDeleted(String projectId,
+  Mono<Long> countByProjectIdAndRoleAndDeletedAtIsNull(String projectId,
       String role);
 
-  @Query("SELECT * FROM project_members WHERE project_id = :projectId AND user_id = :userId ORDER BY created_at DESC LIMIT 1")
-  Mono<ProjectMember> findLatestByProjectIdAndUserId(String projectId,
-      String userId);
+  Mono<ProjectMember> findFirstByProjectIdAndUserIdOrderByCreatedAtDesc(
+      String projectId, String userId);
 
   @Query("""
       SELECT pm.role FROM project_members pm

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -36,24 +36,24 @@ public class ProjectPersistenceAdapter
 
   @Override
   public Mono<Project> findByIdAndNotDeleted(String projectId) {
-    return projectRepository.findByIdAndNotDeleted(projectId);
+    return projectRepository.findByIdAndDeletedAtIsNull(projectId);
   }
 
   @Override
   public Mono<Boolean> existsActiveProjectById(String projectId) {
-    return projectRepository.findByIdAndNotDeleted(projectId)
+    return projectRepository.findByIdAndDeletedAtIsNull(projectId)
         .hasElement();
   }
 
   @Override
   public Mono<Integer> findDbVendorIdByProjectId(String projectId) {
-    return projectRepository.findByIdAndNotDeleted(projectId)
+    return projectRepository.findByIdAndDeletedAtIsNull(projectId)
         .map(Project::getDbVendorId);
   }
 
   @Override
   public Flux<Project> findByWorkspaceIdAndNotDeleted(String workspaceId) {
-    return projectRepository.findByWorkspaceIdAndNotDeleted(workspaceId);
+    return projectRepository.findByWorkspaceIdAndDeletedAtIsNull(workspaceId);
   }
 
   @Override
@@ -63,7 +63,7 @@ public class ProjectPersistenceAdapter
 
   @Override
   public Mono<Long> countByWorkspaceIdAndNotDeleted(String workspaceId) {
-    return projectRepository.countByWorkspaceIdAndNotDeleted(workspaceId);
+    return projectRepository.countByWorkspaceIdAndDeletedAtIsNull(workspaceId);
   }
 
   @Override
@@ -89,7 +89,7 @@ public class ProjectPersistenceAdapter
   public Mono<ProjectMember> findByProjectIdAndUserIdAndNotDeleted(
       String projectId,
       String userId) {
-    return projectMemberRepository.findByProjectIdAndUserIdAndNotDeleted(
+    return projectMemberRepository.findByProjectIdAndUserIdAndDeletedAtIsNull(
         projectId, userId);
   }
 
@@ -102,14 +102,14 @@ public class ProjectPersistenceAdapter
 
   @Override
   public Mono<Long> countByProjectIdAndNotDeleted(String projectId) {
-    return projectMemberRepository.countByProjectIdAndNotDeleted(projectId);
+    return projectMemberRepository.countByProjectIdAndDeletedAtIsNull(projectId);
   }
 
   @Override
   public Mono<Boolean> existsByProjectIdAndUserIdAndNotDeleted(
       String projectId,
       String userId) {
-    return projectMemberRepository.existsByProjectIdAndUserIdAndNotDeleted(
+    return projectMemberRepository.existsByProjectIdAndUserIdAndDeletedAtIsNull(
         projectId, userId);
   }
 
@@ -121,15 +121,15 @@ public class ProjectPersistenceAdapter
   @Override
   public Mono<Long> countByProjectIdAndRoleAndNotDeleted(String projectId,
       String role) {
-    return projectMemberRepository.countByProjectIdAndRoleAndNotDeleted(
+    return projectMemberRepository.countByProjectIdAndRoleAndDeletedAtIsNull(
         projectId, role);
   }
 
   @Override
   public Mono<ProjectMember> findLatestByProjectIdAndUserId(String projectId,
       String userId) {
-    return projectMemberRepository.findLatestByProjectIdAndUserId(projectId,
-        userId);
+    return projectMemberRepository
+        .findFirstByProjectIdAndUserIdOrderByCreatedAtDesc(projectId, userId);
   }
 
   @Override

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectRepository.java
@@ -3,6 +3,7 @@ package com.schemafy.core.project.adapter.out.persistence;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
 import com.schemafy.core.project.domain.Project;
 
 import reactor.core.publisher.Flux;
@@ -10,17 +11,13 @@ import reactor.core.publisher.Mono;
 
 public interface ProjectRepository extends ReactiveCrudRepository<Project, String> {
 
-  @Query("SELECT * FROM projects WHERE id = :id AND deleted_at IS NULL")
-  Mono<Project> findByIdAndNotDeleted(String id);
+  Mono<Project> findByIdAndDeletedAtIsNull(String id);
 
-  @Query("SELECT * FROM projects WHERE workspace_id = :workspaceId AND deleted_at IS NULL")
-  Flux<Project> findByWorkspaceIdAndNotDeleted(String workspaceId);
+  Flux<Project> findByWorkspaceIdAndDeletedAtIsNull(String workspaceId);
 
-  @Query("SELECT * FROM projects WHERE workspace_id = :workspaceId")
   Flux<Project> findByWorkspaceId(String workspaceId);
 
-  @Query("SELECT COUNT(*) FROM projects WHERE workspace_id = :workspaceId AND deleted_at IS NULL")
-  Mono<Long> countByWorkspaceIdAndNotDeleted(String workspaceId);
+  Mono<Long> countByWorkspaceIdAndDeletedAtIsNull(String workspaceId);
 
   @Query("""
       SELECT p.* FROM projects p
@@ -53,5 +50,95 @@ public interface ProjectRepository extends ReactiveCrudRepository<Project, Strin
   Flux<Project> findSharedByUserIdWithPaging(String userId,
       int limit,
       int offset);
+
+  @Query("""
+      SELECT
+        p.id AS id,
+        p.workspace_id AS workspace_id,
+        p.db_vendor_id AS db_vendor_id,
+        p.name AS name,
+        p.description AS description,
+        pm.role AS requester_role,
+        p.created_at AS created_at,
+        p.updated_at AS updated_at
+      FROM projects p
+      INNER JOIN project_members pm ON p.id = pm.project_id
+      WHERE p.workspace_id = :workspaceId
+        AND pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND LOWER(p.name) LIKE :pattern ESCAPE '!'
+      ORDER BY p.created_at DESC, p.id DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<ProjectSearchResult> searchByWorkspaceIdAndUserId(
+      String workspaceId,
+      String userId,
+      String pattern,
+      int limit,
+      int offset);
+
+  @Query("""
+      SELECT COUNT(*)
+      FROM projects p
+      INNER JOIN project_members pm ON p.id = pm.project_id
+      WHERE p.workspace_id = :workspaceId
+        AND pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND LOWER(p.name) LIKE :pattern ESCAPE '!'
+      """)
+  Mono<Long> countSearchByWorkspaceIdAndUserId(
+      String workspaceId,
+      String userId,
+      String pattern);
+
+  @Query("""
+      SELECT
+        p.id AS id,
+        p.workspace_id AS workspace_id,
+        p.db_vendor_id AS db_vendor_id,
+        p.name AS name,
+        p.description AS description,
+        pm.role AS requester_role,
+        p.created_at AS created_at,
+        p.updated_at AS updated_at
+      FROM projects p
+      INNER JOIN project_members pm ON p.id = pm.project_id
+      WHERE pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND LOWER(p.name) LIKE :pattern ESCAPE '!'
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_members wm
+          WHERE wm.workspace_id = p.workspace_id
+            AND wm.user_id = :userId
+            AND wm.deleted_at IS NULL
+        )
+      ORDER BY p.created_at DESC, p.id DESC
+      LIMIT :limit OFFSET :offset
+      """)
+  Flux<ProjectSearchResult> searchSharedByUserId(
+      String userId,
+      String pattern,
+      int limit,
+      int offset);
+
+  @Query("""
+      SELECT COUNT(*)
+      FROM projects p
+      INNER JOIN project_members pm ON p.id = pm.project_id
+      WHERE pm.user_id = :userId
+        AND pm.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        AND LOWER(p.name) LIKE :pattern ESCAPE '!'
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_members wm
+          WHERE wm.workspace_id = p.workspace_id
+            AND wm.user_id = :userId
+            AND wm.deleted_at IS NULL
+        )
+      """)
+  Mono<Long> countSearchSharedByUserId(String userId, String pattern);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapter.java
@@ -1,0 +1,89 @@
+package com.schemafy.core.project.adapter.out.persistence;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.common.PersistenceAdapter;
+import com.schemafy.core.common.persistence.SqlLikePattern;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+import com.schemafy.core.project.application.port.out.ProjectSearchPort;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ProjectSearchPersistenceAdapter implements ProjectSearchPort {
+
+  private final ProjectRepository projectRepository;
+  private final ProjectMemberRepository projectMemberRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  @Override
+  public Mono<PageResult<ProjectSearchResult>> searchWorkspaceProjects(
+      String workspaceId,
+      String requesterId,
+      String search,
+      int page,
+      int size) {
+    String pattern = SqlLikePattern.contains(search);
+    return toPageResult(
+        projectRepository.countSearchByWorkspaceIdAndUserId(
+            workspaceId, requesterId, pattern),
+        projectRepository.searchByWorkspaceIdAndUserId(
+            workspaceId, requesterId, pattern, size, page * size),
+        page, size);
+  }
+
+  @Override
+  public Mono<PageResult<ProjectSearchResult>> searchSharedProjects(
+      String requesterId,
+      String search,
+      int page,
+      int size) {
+    String pattern = SqlLikePattern.contains(search);
+    return toPageResult(
+        projectRepository.countSearchSharedByUserId(requesterId, pattern),
+        projectRepository.searchSharedByUserId(
+            requesterId, pattern, size, page * size),
+        page, size);
+  }
+
+  @Override
+  public Mono<PageResult<MemberSearchResult>> searchWorkspaceMembers(
+      String workspaceId,
+      String search,
+      int page,
+      int size) {
+    String pattern = SqlLikePattern.contains(search);
+    return toPageResult(
+        workspaceMemberRepository.countByWorkspaceIdAndUser(workspaceId, pattern),
+        workspaceMemberRepository.searchMemberResultsByWorkspaceIdAndUser(
+            workspaceId, pattern, size, page * size),
+        page, size);
+  }
+
+  @Override
+  public Mono<PageResult<MemberSearchResult>> searchProjectMembers(
+      String projectId,
+      String search,
+      int page,
+      int size) {
+    String pattern = SqlLikePattern.contains(search);
+    return toPageResult(
+        projectMemberRepository.countByProjectIdAndUser(projectId, pattern),
+        projectMemberRepository.searchMemberResultsByProjectIdAndUser(
+            projectId, pattern, size, page * size),
+        page, size);
+  }
+
+  private <T> Mono<PageResult<T>> toPageResult(
+      Mono<Long> totalElements,
+      Flux<T> content,
+      int page,
+      int size) {
+    return totalElements.flatMap(total -> content.collectList()
+        .map(items -> PageResult.of(items, page, size, total)));
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
@@ -40,7 +40,7 @@ public interface WorkspaceMemberRepository
             LOWER(u.name) LIKE :pattern ESCAPE '!'
             OR LOWER(u.email) LIKE :pattern ESCAPE '!'
         )
-      ORDER BY wm.created_at ASC
+      ORDER BY wm.created_at ASC, wm.id ASC
       LIMIT :limit OFFSET :offset
       """)
   Flux<MemberSearchResult> searchMemberResultsByWorkspaceIdAndUser(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceMemberRepository.java
@@ -3,6 +3,7 @@ package com.schemafy.core.project.adapter.out.persistence;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
 import com.schemafy.core.project.domain.WorkspaceMember;
 
 import reactor.core.publisher.Flux;
@@ -11,13 +12,7 @@ import reactor.core.publisher.Mono;
 public interface WorkspaceMemberRepository
     extends ReactiveCrudRepository<WorkspaceMember, String> {
 
-  @Query("""
-      SELECT * FROM workspace_members
-      WHERE workspace_id = :workspaceId
-        AND user_id = :userId
-        AND deleted_at IS NULL
-      """)
-  Mono<WorkspaceMember> findByWorkspaceIdAndUserIdAndNotDeleted(
+  Mono<WorkspaceMember> findByWorkspaceIdAndUserIdAndDeletedAtIsNull(
       String workspaceId, String userId);
 
   @Query("""
@@ -31,19 +26,42 @@ public interface WorkspaceMemberRepository
       int limit, int offset);
 
   @Query("""
-      SELECT * FROM workspace_members
-      WHERE workspace_id = :workspaceId
-        AND deleted_at IS NULL
-      ORDER BY created_at ASC
+      SELECT
+        wm.user_id AS user_id,
+        u.name AS user_name,
+        u.email AS user_email,
+        wm.role AS role,
+        wm.created_at AS joined_at
+      FROM workspace_members wm
+      INNER JOIN users u ON u.id = wm.user_id
+      WHERE wm.workspace_id = :workspaceId
+        AND wm.deleted_at IS NULL
+        AND (
+            LOWER(u.name) LIKE :pattern ESCAPE '!'
+            OR LOWER(u.email) LIKE :pattern ESCAPE '!'
+        )
+      ORDER BY wm.created_at ASC
+      LIMIT :limit OFFSET :offset
       """)
-  Flux<WorkspaceMember> findAllByWorkspaceIdAndNotDeleted(String workspaceId);
+  Flux<MemberSearchResult> searchMemberResultsByWorkspaceIdAndUser(
+      String workspaceId, String pattern, int limit, int offset);
+
+  Flux<WorkspaceMember> findAllByWorkspaceIdAndDeletedAtIsNullOrderByCreatedAtAsc(
+      String workspaceId);
+
+  Mono<Long> countByWorkspaceIdAndDeletedAtIsNull(String workspaceId);
 
   @Query("""
-      SELECT COUNT(*) FROM workspace_members
-      WHERE workspace_id = :workspaceId
-        AND deleted_at IS NULL
+      SELECT COUNT(*) FROM workspace_members wm
+      INNER JOIN users u ON u.id = wm.user_id
+      WHERE wm.workspace_id = :workspaceId
+        AND wm.deleted_at IS NULL
+        AND (
+          LOWER(u.name) LIKE :pattern ESCAPE '!'
+          OR LOWER(u.email) LIKE :pattern ESCAPE '!'
+        )
       """)
-  Mono<Long> countByWorkspaceIdAndNotDeleted(String workspaceId);
+  Mono<Long> countByWorkspaceIdAndUser(String workspaceId, String pattern);
 
   @Query("""
       UPDATE workspace_members
@@ -53,34 +71,14 @@ public interface WorkspaceMemberRepository
       """)
   Mono<Void> softDeleteByWorkspaceId(String workspaceId);
 
-  @Query("""
-      SELECT EXISTS(
-          SELECT 1 FROM workspace_members
-          WHERE workspace_id = :workspaceId
-            AND user_id = :userId
-            AND deleted_at IS NULL
-      )
-      """)
-  Mono<Boolean> existsByWorkspaceIdAndUserIdAndNotDeleted(String workspaceId,
+  Mono<Boolean> existsByWorkspaceIdAndUserIdAndDeletedAtIsNull(String workspaceId,
       String userId);
 
-  @Query("""
-      SELECT COUNT(*) FROM workspace_members
-      WHERE workspace_id = :workspaceId
-        AND role = :role
-        AND deleted_at IS NULL
-      """)
-  Mono<Long> countByWorkspaceIdAndRoleAndNotDeleted(String workspaceId,
+  Mono<Long> countByWorkspaceIdAndRoleAndDeletedAtIsNull(String workspaceId,
       String role);
 
-  @Query("""
-      SELECT * FROM workspace_members
-      WHERE workspace_id = :workspaceId
-        AND user_id = :userId
-      ORDER BY created_at DESC
-      LIMIT 1
-      """)
-  Mono<WorkspaceMember> findLatestByWorkspaceIdAndUserId(String workspaceId,
+  Mono<WorkspaceMember> findFirstByWorkspaceIdAndUserIdOrderByCreatedAtDesc(
+      String workspaceId,
       String userId);
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
@@ -49,7 +49,7 @@ public class WorkspacePersistenceAdapter
       String workspaceId,
       String userId) {
     return workspaceMemberRepository
-        .findByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, userId);
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(workspaceId, userId);
   }
 
   @Override
@@ -64,13 +64,13 @@ public class WorkspacePersistenceAdapter
   @Override
   public Flux<WorkspaceMember> findAllByWorkspaceIdAndNotDeleted(
       String workspaceId) {
-    return workspaceMemberRepository.findAllByWorkspaceIdAndNotDeleted(
-        workspaceId);
+    return workspaceMemberRepository
+        .findAllByWorkspaceIdAndDeletedAtIsNullOrderByCreatedAtAsc(workspaceId);
   }
 
   @Override
   public Mono<Long> countByWorkspaceIdAndNotDeleted(String workspaceId) {
-    return workspaceMemberRepository.countByWorkspaceIdAndNotDeleted(
+    return workspaceMemberRepository.countByWorkspaceIdAndDeletedAtIsNull(
         workspaceId);
   }
 
@@ -83,14 +83,15 @@ public class WorkspacePersistenceAdapter
   public Mono<Boolean> existsByWorkspaceIdAndUserIdAndNotDeleted(
       String workspaceId,
       String userId) {
-    return workspaceMemberRepository.existsByWorkspaceIdAndUserIdAndNotDeleted(
-        workspaceId, userId);
+    return workspaceMemberRepository
+        .existsByWorkspaceIdAndUserIdAndDeletedAtIsNull(
+            workspaceId, userId);
   }
 
   @Override
   public Mono<Long> countByWorkspaceIdAndRoleAndNotDeleted(String workspaceId,
       String role) {
-    return workspaceMemberRepository.countByWorkspaceIdAndRoleAndNotDeleted(
+    return workspaceMemberRepository.countByWorkspaceIdAndRoleAndDeletedAtIsNull(
         workspaceId, role);
   }
 
@@ -98,8 +99,8 @@ public class WorkspacePersistenceAdapter
   public Mono<WorkspaceMember> findLatestByWorkspaceIdAndUserId(
       String workspaceId,
       String userId) {
-    return workspaceMemberRepository.findLatestByWorkspaceIdAndUserId(
-        workspaceId, userId);
+    return workspaceMemberRepository
+        .findFirstByWorkspaceIdAndUserIdOrderByCreatedAtDesc(workspaceId, userId);
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/MemberSearchResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/MemberSearchResult.java
@@ -1,0 +1,11 @@
+package com.schemafy.core.project.application.port.in;
+
+import java.time.Instant;
+
+public record MemberSearchResult(
+    String userId,
+    String userName,
+    String userEmail,
+    String role,
+    Instant joinedAt) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/ProjectSearchResult.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/ProjectSearchResult.java
@@ -1,0 +1,14 @@
+package com.schemafy.core.project.application.port.in;
+
+import java.time.Instant;
+
+public record ProjectSearchResult(
+    String id,
+    String workspaceId,
+    Integer dbVendorId,
+    String name,
+    String description,
+    String requesterRole,
+    Instant createdAt,
+    Instant updatedAt) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchProjectMembersQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchProjectMembersQuery.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.project.application.port.in;
+
+public record SearchProjectMembersQuery(
+    String projectId,
+    String requesterId,
+    String search,
+    int page,
+    int size) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchProjectMembersUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchProjectMembersUseCase.java
@@ -1,0 +1,12 @@
+package com.schemafy.core.project.application.port.in;
+
+import com.schemafy.core.common.PageResult;
+
+import reactor.core.publisher.Mono;
+
+public interface SearchProjectMembersUseCase {
+
+  Mono<PageResult<MemberSearchResult>> searchProjectMembers(
+      SearchProjectMembersQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchSharedProjectsQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchSharedProjectsQuery.java
@@ -1,0 +1,8 @@
+package com.schemafy.core.project.application.port.in;
+
+public record SearchSharedProjectsQuery(
+    String requesterId,
+    String search,
+    int page,
+    int size) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchSharedProjectsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchSharedProjectsUseCase.java
@@ -1,0 +1,12 @@
+package com.schemafy.core.project.application.port.in;
+
+import com.schemafy.core.common.PageResult;
+
+import reactor.core.publisher.Mono;
+
+public interface SearchSharedProjectsUseCase {
+
+  Mono<PageResult<ProjectSearchResult>> searchSharedProjects(
+      SearchSharedProjectsQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceMembersQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceMembersQuery.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.project.application.port.in;
+
+public record SearchWorkspaceMembersQuery(
+    String workspaceId,
+    String requesterId,
+    String search,
+    int page,
+    int size) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceMembersUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceMembersUseCase.java
@@ -1,0 +1,12 @@
+package com.schemafy.core.project.application.port.in;
+
+import com.schemafy.core.common.PageResult;
+
+import reactor.core.publisher.Mono;
+
+public interface SearchWorkspaceMembersUseCase {
+
+  Mono<PageResult<MemberSearchResult>> searchWorkspaceMembers(
+      SearchWorkspaceMembersQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceProjectsQuery.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceProjectsQuery.java
@@ -1,0 +1,9 @@
+package com.schemafy.core.project.application.port.in;
+
+public record SearchWorkspaceProjectsQuery(
+    String workspaceId,
+    String requesterId,
+    String search,
+    int page,
+    int size) {
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceProjectsUseCase.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/in/SearchWorkspaceProjectsUseCase.java
@@ -1,0 +1,12 @@
+package com.schemafy.core.project.application.port.in;
+
+import com.schemafy.core.common.PageResult;
+
+import reactor.core.publisher.Mono;
+
+public interface SearchWorkspaceProjectsUseCase {
+
+  Mono<PageResult<ProjectSearchResult>> searchWorkspaceProjects(
+      SearchWorkspaceProjectsQuery query);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectSearchPort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/ProjectSearchPort.java
@@ -1,0 +1,36 @@
+package com.schemafy.core.project.application.port.out;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+
+import reactor.core.publisher.Mono;
+
+public interface ProjectSearchPort {
+
+  Mono<PageResult<ProjectSearchResult>> searchWorkspaceProjects(
+      String workspaceId,
+      String requesterId,
+      String search,
+      int page,
+      int size);
+
+  Mono<PageResult<ProjectSearchResult>> searchSharedProjects(
+      String requesterId,
+      String search,
+      int page,
+      int size);
+
+  Mono<PageResult<MemberSearchResult>> searchWorkspaceMembers(
+      String workspaceId,
+      String search,
+      int page,
+      int size);
+
+  Mono<PageResult<MemberSearchResult>> searchProjectMembers(
+      String projectId,
+      String search,
+      int page,
+      int size);
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchProjectMembersService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchProjectMembersService.java
@@ -1,0 +1,30 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.access.RequireProjectAccess;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersUseCase;
+import com.schemafy.core.project.application.port.out.ProjectSearchPort;
+import com.schemafy.core.project.domain.ProjectRole;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class SearchProjectMembersService implements SearchProjectMembersUseCase {
+
+  private final ProjectSearchPort projectSearchPort;
+
+  @Override
+  @RequireProjectAccess(role = ProjectRole.VIEWER)
+  public Mono<PageResult<MemberSearchResult>> searchProjectMembers(
+      SearchProjectMembersQuery query) {
+    return projectSearchPort.searchProjectMembers(
+        query.projectId(), query.search(), query.page(), query.size());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchSharedProjectsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchSharedProjectsService.java
@@ -1,0 +1,27 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsUseCase;
+import com.schemafy.core.project.application.port.out.ProjectSearchPort;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class SearchSharedProjectsService implements SearchSharedProjectsUseCase {
+
+  private final ProjectSearchPort projectSearchPort;
+
+  @Override
+  public Mono<PageResult<ProjectSearchResult>> searchSharedProjects(
+      SearchSharedProjectsQuery query) {
+    return projectSearchPort.searchSharedProjects(
+        query.requesterId(), query.search(), query.page(), query.size());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchWorkspaceMembersService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchWorkspaceMembersService.java
@@ -1,0 +1,30 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersUseCase;
+import com.schemafy.core.project.application.port.out.ProjectSearchPort;
+import com.schemafy.core.project.domain.WorkspaceRole;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class SearchWorkspaceMembersService implements SearchWorkspaceMembersUseCase {
+
+  private final ProjectSearchPort projectSearchPort;
+
+  @Override
+  @RequireWorkspaceAccess(role = WorkspaceRole.MEMBER)
+  public Mono<PageResult<MemberSearchResult>> searchWorkspaceMembers(
+      SearchWorkspaceMembersQuery query) {
+    return projectSearchPort.searchWorkspaceMembers(
+        query.workspaceId(), query.search(), query.page(), query.size());
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchWorkspaceProjectsService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/SearchWorkspaceProjectsService.java
@@ -1,0 +1,31 @@
+package com.schemafy.core.project.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsUseCase;
+import com.schemafy.core.project.application.port.out.ProjectSearchPort;
+import com.schemafy.core.project.domain.WorkspaceRole;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+class SearchWorkspaceProjectsService implements SearchWorkspaceProjectsUseCase {
+
+  private final ProjectSearchPort projectSearchPort;
+
+  @Override
+  @RequireWorkspaceAccess(role = WorkspaceRole.MEMBER)
+  public Mono<PageResult<ProjectSearchResult>> searchWorkspaceProjects(
+      SearchWorkspaceProjectsQuery query) {
+    return projectSearchPort.searchWorkspaceProjects(
+        query.workspaceId(), query.requesterId(), query.search(),
+        query.page(), query.size());
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/common/persistence/SqlLikePatternTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/common/persistence/SqlLikePatternTest.java
@@ -1,0 +1,44 @@
+package com.schemafy.core.common.persistence;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SqlLikePattern")
+class SqlLikePatternTest {
+
+  @ParameterizedTest
+  @MethodSource("containsCases")
+  @DisplayName("contains 패턴을 소문자화하고 LIKE 특수문자를 escape한다")
+  void containsEscapesLikeSpecialCharacters(String input, String expected) {
+    assertThat(SqlLikePattern.contains(input)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> containsCases() {
+    return Stream.of(
+        Arguments.of("Schema", "%schema%"),
+        Arguments.of("100%_Real", "%100!%!_real%"),
+        Arguments.of("A!%_\\", "%a!!!%!_\\%"));
+  }
+
+  @Test
+  @DisplayName("기본 locale과 무관하게 ROOT locale으로 소문자화한다")
+  void lowercasesIndependentlyOfDefaultLocale() {
+    Locale previousDefault = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+      assertThat(SqlLikePattern.contains("I")).isEqualTo("%i%");
+    } finally {
+      Locale.setDefault(previousDefault);
+    }
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
@@ -82,6 +82,39 @@ class ProjectSearchPersistenceAdapterTest {
   }
 
   @Test
+  @DisplayName("워크스페이스 멤버 검색은 생성 시각이 같으면 멤버 ID 순으로 페이지를 반환한다")
+  void searchWorkspaceMembers_ordersEqualCreatedAtByMemberId() {
+    Instant createdAt = Instant.parse("2025-01-01T00:00:00Z");
+    Workspace workspace = saveWorkspace("Stable Workspace Member Search");
+    UserFixture firstUser = saveUser(
+        "00000000000000000000000011", "first@example.com", "Stable First");
+    UserFixture secondUser = saveUser(
+        "00000000000000000000000012", "second@example.com", "Stable Second");
+    WorkspaceMember higherIdMember = saveWorkspaceMember(
+        "00000000000000000000000002", workspace, firstUser.id(),
+        WorkspaceRole.MEMBER);
+    WorkspaceMember lowerIdMember = saveWorkspaceMember(
+        "00000000000000000000000001", workspace, secondUser.id(),
+        WorkspaceRole.MEMBER);
+    setWorkspaceMemberCreatedAt(higherIdMember.getId(), createdAt);
+    setWorkspaceMemberCreatedAt(lowerIdMember.getId(), createdAt);
+
+    StepVerifier.create(sut.searchWorkspaceMembers(
+        workspace.getId(), "stable", 0, 1)
+        .zipWith(sut.searchWorkspaceMembers(
+            workspace.getId(), "stable", 1, 1)))
+        .assertNext(pages -> {
+          assertThat(pages.getT1().content())
+              .extracting(MemberSearchResult::userId)
+              .containsExactly(secondUser.id());
+          assertThat(pages.getT2().content())
+              .extracting(MemberSearchResult::userId)
+              .containsExactly(firstUser.id());
+        })
+        .verifyComplete();
+  }
+
+  @Test
   @DisplayName("프로젝트 멤버 검색은 사용자 이메일과 가입 시각을 포함한 read projection을 반환한다")
   void searchProjectMembers_returnsUserProjection() {
     Instant joinedAt = Instant.parse("2025-01-01T00:00:00Z");
@@ -99,6 +132,40 @@ class ProjectSearchPersistenceAdapterTest {
           assertThat(page.content()).containsExactly(new MemberSearchResult(
               user.id(), user.name(), user.email(), member.getRole(),
               joinedAt));
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 검색은 가입 시각이 같으면 멤버 ID 순으로 페이지를 반환한다")
+  void searchProjectMembers_ordersEqualJoinedAtByMemberId() {
+    Instant joinedAt = Instant.parse("2025-01-01T00:00:00Z");
+    Workspace workspace = saveWorkspace("Stable Project Member Workspace");
+    Project project = saveProject(workspace, "Stable Project Member Search");
+    UserFixture firstUser = saveUser(
+        "00000000000000000000000011", "first@example.com", "Stable First");
+    UserFixture secondUser = saveUser(
+        "00000000000000000000000012", "second@example.com", "Stable Second");
+    ProjectMember higherIdMember = saveProjectMember(
+        "00000000000000000000000002", project, firstUser.id(),
+        ProjectRole.VIEWER);
+    ProjectMember lowerIdMember = saveProjectMember(
+        "00000000000000000000000001", project, secondUser.id(),
+        ProjectRole.EDITOR);
+    setProjectMemberJoinedAt(higherIdMember.getId(), joinedAt);
+    setProjectMemberJoinedAt(lowerIdMember.getId(), joinedAt);
+
+    StepVerifier.create(sut.searchProjectMembers(
+        project.getId(), "stable", 0, 1)
+        .zipWith(sut.searchProjectMembers(
+            project.getId(), "stable", 1, 1)))
+        .assertNext(pages -> {
+          assertThat(pages.getT1().content())
+              .extracting(MemberSearchResult::userId)
+              .containsExactly(secondUser.id());
+          assertThat(pages.getT2().content())
+              .extracting(MemberSearchResult::userId)
+              .containsExactly(firstUser.id());
         })
         .verifyComplete();
   }
@@ -161,9 +228,13 @@ class ProjectSearchPersistenceAdapterTest {
 
   private WorkspaceMember saveWorkspaceMember(Workspace workspace,
       String userId, WorkspaceRole role) {
+    return saveWorkspaceMember(UlidGenerator.generate(), workspace, userId, role);
+  }
+
+  private WorkspaceMember saveWorkspaceMember(String id, Workspace workspace,
+      String userId, WorkspaceRole role) {
     return workspaceMemberRepository.save(
-        WorkspaceMember.create(UlidGenerator.generate(), workspace.getId(),
-            userId, role)).block();
+        WorkspaceMember.create(id, workspace.getId(), userId, role)).block();
   }
 
   private Project saveProject(Workspace workspace, String name) {
@@ -173,8 +244,13 @@ class ProjectSearchPersistenceAdapterTest {
 
   private ProjectMember saveProjectMember(Project project, String userId,
       ProjectRole role) {
+    return saveProjectMember(UlidGenerator.generate(), project, userId, role);
+  }
+
+  private ProjectMember saveProjectMember(String id, Project project,
+      String userId, ProjectRole role) {
     return projectMemberRepository.save(ProjectMember.create(
-        UlidGenerator.generate(), project.getId(), userId, role)).block();
+        id, project.getId(), userId, role)).block();
   }
 
   private void setWorkspaceMemberCreatedAt(String memberId, Instant createdAt) {
@@ -196,7 +272,10 @@ class ProjectSearchPersistenceAdapterTest {
   }
 
   private UserFixture saveUser(String email, String name) {
-    String id = UlidGenerator.generate();
+    return saveUser(UlidGenerator.generate(), email, name);
+  }
+
+  private UserFixture saveUser(String id, String email, String name) {
     databaseClient.sql("""
         INSERT INTO users (
           id, email, name, password, status, created_at, updated_at

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
@@ -1,0 +1,196 @@
+package com.schemafy.core.project.adapter.out.persistence;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.r2dbc.core.DatabaseClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.config.R2dbcTestConfiguration;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.ulid.application.service.UlidGenerator;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataR2dbcTest
+@Import({ ProjectSearchPersistenceAdapter.class, R2dbcTestConfiguration.class })
+@DisplayName("ProjectSearchPersistenceAdapter")
+class ProjectSearchPersistenceAdapterTest {
+
+  private static final Integer DB_VENDOR_ID = 1;
+
+  @Autowired
+  private ProjectSearchPersistenceAdapter sut;
+
+  @Autowired
+  private DatabaseClient databaseClient;
+
+  @Autowired
+  private ProjectRepository projectRepository;
+
+  @Autowired
+  private ProjectMemberRepository projectMemberRepository;
+
+  @Autowired
+  private WorkspaceRepository workspaceRepository;
+
+  @Autowired
+  private WorkspaceMemberRepository workspaceMemberRepository;
+
+  @BeforeEach
+  void setUp() {
+    projectMemberRepository.deleteAll()
+        .then(projectRepository.deleteAll())
+        .then(workspaceMemberRepository.deleteAll())
+        .then(workspaceRepository.deleteAll())
+        .then(databaseClient.sql("DELETE FROM users").fetch().rowsUpdated())
+        .block();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버 검색은 사용자 정보를 포함한 read projection을 반환한다")
+  void searchWorkspaceMembers_returnsUserProjection() {
+    Workspace workspace = saveWorkspace("Search Workspace");
+    UserFixture user = saveUser("alice@example.com", "Alice Engineer");
+    WorkspaceMember member = saveWorkspaceMember(workspace, user.id(),
+        WorkspaceRole.ADMIN);
+
+    StepVerifier.create(sut.searchWorkspaceMembers(
+        workspace.getId(), "ALICE", 0, 5))
+        .assertNext(page -> {
+          assertThat(page.totalElements()).isEqualTo(1);
+          assertThat(page.content()).containsExactly(new MemberSearchResult(
+              user.id(), user.name(), user.email(), member.getRole(),
+              member.getCreatedAt()));
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 검색은 사용자 이메일과 가입 시각을 포함한 read projection을 반환한다")
+  void searchProjectMembers_returnsUserProjection() {
+    Workspace workspace = saveWorkspace("Project Search Workspace");
+    Project project = saveProject(workspace, "Project Search");
+    UserFixture user = saveUser("bob@example.com", "Bob Designer");
+    ProjectMember member = saveProjectMember(project, user.id(),
+        ProjectRole.EDITOR);
+
+    StepVerifier.create(sut.searchProjectMembers(
+        project.getId(), "BOB@EXAMPLE.COM", 0, 5))
+        .assertNext(page -> {
+          assertThat(page.totalElements()).isEqualTo(1);
+          assertThat(page.content()).containsExactly(new MemberSearchResult(
+              user.id(), user.name(), user.email(), member.getRole(),
+              member.getJoinedAt()));
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("워크스페이스의 프로젝트 검색은 역할과 전체 개수를 같은 페이지 결과로 반환한다")
+  void searchWorkspaceProjects_returnsProjectsWithRolesAndCount() {
+    Workspace workspace = saveWorkspace("Workspace Project Search");
+    String requesterId = UlidGenerator.generate();
+    Project olderMatch = saveProject(workspace, "Alpha Search Project");
+    saveProjectMember(olderMatch, requesterId, ProjectRole.VIEWER);
+    Project nonMatch = saveProject(workspace, "Unrelated Project");
+    saveProjectMember(nonMatch, requesterId, ProjectRole.ADMIN);
+    Project newerMatch = saveProject(workspace, "SEARCH Omega");
+    saveProjectMember(newerMatch, requesterId, ProjectRole.EDITOR);
+
+    StepVerifier.create(sut.searchWorkspaceProjects(
+        workspace.getId(), requesterId, "sEaRcH", 0, 1))
+        .assertNext(page -> {
+          assertThat(page.totalElements()).isEqualTo(2);
+          assertThat(page.totalPages()).isEqualTo(2);
+          assertThat(page.content()).singleElement().satisfies(result -> {
+            assertThat(result.id()).isEqualTo(newerMatch.getId());
+            assertThat(result.requesterRole()).isEqualTo(ProjectRole.EDITOR.name());
+          });
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("공유 프로젝트 검색은 워크스페이스 멤버십으로 상속된 프로젝트를 제외한다")
+  void searchSharedProjects_excludesWorkspaceInheritedProjects() {
+    String requesterId = UlidGenerator.generate();
+    Workspace sharedWorkspace = saveWorkspace("Shared Workspace");
+    Project sharedProject = saveProject(sharedWorkspace, "Shared Search Project");
+    saveProjectMember(sharedProject, requesterId, ProjectRole.EDITOR);
+
+    Workspace joinedWorkspace = saveWorkspace("Joined Workspace");
+    saveWorkspaceMember(joinedWorkspace, requesterId, WorkspaceRole.MEMBER);
+    Project inheritedProject = saveProject(joinedWorkspace,
+        "Shared Search Inherited");
+    saveProjectMember(inheritedProject, requesterId, ProjectRole.VIEWER);
+
+    StepVerifier.create(sut.searchSharedProjects(
+        requesterId, "shared search", 0, 5))
+        .assertNext(page -> {
+          assertThat(page.totalElements()).isEqualTo(1);
+          assertThat(page.content()).singleElement().satisfies(result -> {
+            assertThat(result.id()).isEqualTo(sharedProject.getId());
+            assertThat(result.requesterRole()).isEqualTo(ProjectRole.EDITOR.name());
+          });
+        })
+        .verifyComplete();
+  }
+
+  private Workspace saveWorkspace(String name) {
+    return workspaceRepository.save(Workspace.create(
+        UlidGenerator.generate(), name, "Description")).block();
+  }
+
+  private WorkspaceMember saveWorkspaceMember(Workspace workspace,
+      String userId, WorkspaceRole role) {
+    return workspaceMemberRepository.save(WorkspaceMember.create(
+        UlidGenerator.generate(), workspace.getId(), userId, role)).block();
+  }
+
+  private Project saveProject(Workspace workspace, String name) {
+    return projectRepository.save(Project.create(UlidGenerator.generate(),
+        workspace.getId(), DB_VENDOR_ID, name, "Description")).block();
+  }
+
+  private ProjectMember saveProjectMember(Project project, String userId,
+      ProjectRole role) {
+    return projectMemberRepository.save(ProjectMember.create(
+        UlidGenerator.generate(), project.getId(), userId, role)).block();
+  }
+
+  private UserFixture saveUser(String email, String name) {
+    String id = UlidGenerator.generate();
+    databaseClient.sql("""
+        INSERT INTO users (
+          id, email, name, password, status, created_at, updated_at
+        )
+        VALUES (
+          :id, :email, :name, NULL, 'ACTIVE',
+          CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        )
+        """)
+        .bind("id", id)
+        .bind("email", email)
+        .bind("name", name)
+        .fetch()
+        .rowsUpdated()
+        .block();
+    return new UserFixture(id, email, name);
+  }
+
+  private record UserFixture(String id, String email, String name) {
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/ProjectSearchPersistenceAdapterTest.java
@@ -1,5 +1,7 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
+import java.time.Instant;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
 import org.springframework.context.annotation.Import;
@@ -61,10 +63,12 @@ class ProjectSearchPersistenceAdapterTest {
   @Test
   @DisplayName("워크스페이스 멤버 검색은 사용자 정보를 포함한 read projection을 반환한다")
   void searchWorkspaceMembers_returnsUserProjection() {
+    Instant createdAt = Instant.parse("2025-01-01T00:00:00Z");
     Workspace workspace = saveWorkspace("Search Workspace");
     UserFixture user = saveUser("alice@example.com", "Alice Engineer");
     WorkspaceMember member = saveWorkspaceMember(workspace, user.id(),
         WorkspaceRole.ADMIN);
+    setWorkspaceMemberCreatedAt(member.getId(), createdAt);
 
     StepVerifier.create(sut.searchWorkspaceMembers(
         workspace.getId(), "ALICE", 0, 5))
@@ -72,7 +76,7 @@ class ProjectSearchPersistenceAdapterTest {
           assertThat(page.totalElements()).isEqualTo(1);
           assertThat(page.content()).containsExactly(new MemberSearchResult(
               user.id(), user.name(), user.email(), member.getRole(),
-              member.getCreatedAt()));
+              createdAt));
         })
         .verifyComplete();
   }
@@ -80,11 +84,13 @@ class ProjectSearchPersistenceAdapterTest {
   @Test
   @DisplayName("프로젝트 멤버 검색은 사용자 이메일과 가입 시각을 포함한 read projection을 반환한다")
   void searchProjectMembers_returnsUserProjection() {
+    Instant joinedAt = Instant.parse("2025-01-01T00:00:00Z");
     Workspace workspace = saveWorkspace("Project Search Workspace");
     Project project = saveProject(workspace, "Project Search");
     UserFixture user = saveUser("bob@example.com", "Bob Designer");
     ProjectMember member = saveProjectMember(project, user.id(),
         ProjectRole.EDITOR);
+    setProjectMemberJoinedAt(member.getId(), joinedAt);
 
     StepVerifier.create(sut.searchProjectMembers(
         project.getId(), "BOB@EXAMPLE.COM", 0, 5))
@@ -92,7 +98,7 @@ class ProjectSearchPersistenceAdapterTest {
           assertThat(page.totalElements()).isEqualTo(1);
           assertThat(page.content()).containsExactly(new MemberSearchResult(
               user.id(), user.name(), user.email(), member.getRole(),
-              member.getJoinedAt()));
+              joinedAt));
         })
         .verifyComplete();
   }
@@ -155,8 +161,9 @@ class ProjectSearchPersistenceAdapterTest {
 
   private WorkspaceMember saveWorkspaceMember(Workspace workspace,
       String userId, WorkspaceRole role) {
-    return workspaceMemberRepository.save(WorkspaceMember.create(
-        UlidGenerator.generate(), workspace.getId(), userId, role)).block();
+    return workspaceMemberRepository.save(
+        WorkspaceMember.create(UlidGenerator.generate(), workspace.getId(),
+            userId, role)).block();
   }
 
   private Project saveProject(Workspace workspace, String name) {
@@ -168,6 +175,24 @@ class ProjectSearchPersistenceAdapterTest {
       ProjectRole role) {
     return projectMemberRepository.save(ProjectMember.create(
         UlidGenerator.generate(), project.getId(), userId, role)).block();
+  }
+
+  private void setWorkspaceMemberCreatedAt(String memberId, Instant createdAt) {
+    databaseClient.sql("UPDATE workspace_members SET created_at = :createdAt WHERE id = :memberId")
+        .bind("createdAt", createdAt)
+        .bind("memberId", memberId)
+        .fetch()
+        .rowsUpdated()
+        .block();
+  }
+
+  private void setProjectMemberJoinedAt(String memberId, Instant joinedAt) {
+    databaseClient.sql("UPDATE project_members SET joined_at = :joinedAt WHERE id = :memberId")
+        .bind("joinedAt", joinedAt)
+        .bind("memberId", memberId)
+        .fetch()
+        .rowsUpdated()
+        .block();
   }
 
   private UserFixture saveUser(String email, String name) {

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectUseCaseIntegrationTest.java
@@ -91,13 +91,13 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .block();
 
     ProjectMember creatorMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(detail.project().getId(), creator.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(detail.project().getId(), creator.id())
         .block();
     ProjectMember memberProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(detail.project().getId(), member.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(detail.project().getId(), member.id())
         .block();
     ProjectMember deletedProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(detail.project().getId(), deletedMember.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(detail.project().getId(), deletedMember.id())
         .block();
 
     assertThat(detail.currentUserRole()).isEqualTo(ProjectRole.ADMIN.name());
@@ -424,7 +424,7 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     deleteProjectUseCase.deleteProject(new DeleteProjectCommand(project.getId(), admin.id()))
         .block();
 
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNull();
     assertThat(findSchemasByProjectId(project.getId())).isEmpty();
   }
 
@@ -564,7 +564,7 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
 
     leaveProjectUseCase.leaveProject(new LeaveProjectCommand(project.getId(), member.id())).block();
 
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNull();
   }
 
   @Test
@@ -581,7 +581,7 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
         .verify();
 
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNotNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNotNull();
   }
 
   @Test
@@ -808,7 +808,7 @@ class ProjectUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .block();
     assertThat(deletedMember).isNotNull();
     assertThat(deletedMember.isDeleted()).isTrue();
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNotNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNotNull();
   }
 
   private void insertDeletedDbVendor() {

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/SearchUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/SearchUseCaseIntegrationTest.java
@@ -1,0 +1,370 @@
+package com.schemafy.core.project.integration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.common.PageResult;
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.MemberSearchResult;
+import com.schemafy.core.project.application.port.in.ProjectSearchResult;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchProjectMembersUseCase;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchSharedProjectsUseCase;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceMembersUseCase;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsQuery;
+import com.schemafy.core.project.application.port.in.SearchWorkspaceProjectsUseCase;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.user.domain.User;
+
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("프로젝트 검색 유스케이스 통합 테스트")
+class SearchUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
+
+  @Autowired
+  private SearchWorkspaceProjectsUseCase searchWorkspaceProjectsUseCase;
+
+  @Autowired
+  private SearchSharedProjectsUseCase searchSharedProjectsUseCase;
+
+  @Autowired
+  private SearchWorkspaceMembersUseCase searchWorkspaceMembersUseCase;
+
+  @Autowired
+  private SearchProjectMembersUseCase searchProjectMembersUseCase;
+
+  @Test
+  @DisplayName("워크스페이스 검색은 요청자의 활성 프로젝트 멤버십에서 이름을 필터링한 뒤 페이지와 역할을 반환한다")
+  void searchWorkspaceProjects_filtersBeforePagingAndReturnsRequesterRoles() {
+    User requester = signUpUser("workspace-search-requester@test.com", "Requester");
+    User otherUser = signUpUser("workspace-search-other@test.com", "Other");
+    Workspace workspace = saveWorkspace("Workspace Search", "Description");
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.MEMBER);
+
+    Project olderMatch = saveProject(workspace, "Alpha Search Project");
+    saveProjectMember(olderMatch, requester, ProjectRole.VIEWER);
+    Project nonMatch = saveProject(workspace, "Unrelated Project");
+    saveProjectMember(nonMatch, requester, ProjectRole.ADMIN);
+    Project hiddenMatch = saveProject(workspace, "Search Hidden Project");
+    saveProjectMember(hiddenMatch, otherUser, ProjectRole.ADMIN);
+    Project newerMatch = saveProject(workspace, "SEARCH Omega");
+    saveProjectMember(newerMatch, requester, ProjectRole.EDITOR);
+
+    PageResult<ProjectSearchResult> firstPage = searchWorkspaceProjectsUseCase
+        .searchWorkspaceProjects(new SearchWorkspaceProjectsQuery(
+            workspace.getId(), requester.id(), "sEaRcH", 0, 1))
+        .block();
+    PageResult<ProjectSearchResult> secondPage = searchWorkspaceProjectsUseCase
+        .searchWorkspaceProjects(new SearchWorkspaceProjectsQuery(
+            workspace.getId(), requester.id(), "sEaRcH", 1, 1))
+        .block();
+
+    assertThat(firstPage).isNotNull();
+    assertThat(firstPage.content()).singleElement().satisfies(result -> {
+      assertThat(result.name()).isEqualTo(newerMatch.getName());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.EDITOR.name());
+    });
+    assertThat(firstPage.totalElements()).isEqualTo(2);
+    assertThat(firstPage.totalPages()).isEqualTo(2);
+
+    assertThat(secondPage).isNotNull();
+    assertThat(secondPage.content()).singleElement().satisfies(result -> {
+      assertThat(result.name()).isEqualTo(olderMatch.getName());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.VIEWER.name());
+    });
+    assertThat(secondPage.totalElements()).isEqualTo(2);
+    assertThat(secondPage.totalPages()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 비회원의 프로젝트 검색은 거부된다")
+  void searchWorkspaceProjects_deniesRequesterWithoutWorkspaceMembership() {
+    User requester = signUpUser("workspace-search-denied@test.com", "Requester");
+    Workspace workspace = saveWorkspace("Workspace Search Denied", "Description");
+    Project project = saveProject(workspace, "Search Project");
+    saveProjectMember(project, requester, ProjectRole.EDITOR);
+
+    StepVerifier.create(searchWorkspaceProjectsUseCase.searchWorkspaceProjects(
+        new SearchWorkspaceProjectsQuery(
+            workspace.getId(), requester.id(), "search", 0, 10)))
+        .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("공유 검색은 워크스페이스 비회원의 직접 프로젝트 멤버십만 필터링한 뒤 페이지와 역할을 반환한다")
+  void searchSharedProjects_filtersDirectMembershipsBeforePaging() {
+    User requester = signUpUser("shared-search-requester@test.com", "Requester");
+    User owner = signUpUser("shared-search-owner@test.com", "Owner");
+
+    Workspace sharedWorkspace = saveWorkspace("Shared Search", "Description");
+    saveWorkspaceMember(sharedWorkspace, owner, WorkspaceRole.ADMIN);
+    Project olderMatch = saveProject(sharedWorkspace, "Alpha Shared Search");
+    saveProjectMember(olderMatch, requester, ProjectRole.VIEWER);
+    Project nonMatch = saveProject(sharedWorkspace, "Unrelated Shared Project");
+    saveProjectMember(nonMatch, requester, ProjectRole.ADMIN);
+    Project newerMatch = saveProject(sharedWorkspace, "SHARED SEARCH Omega");
+    saveProjectMember(newerMatch, requester, ProjectRole.EDITOR);
+
+    Workspace joinedWorkspace = saveWorkspace("Joined Search", "Description");
+    saveWorkspaceMember(joinedWorkspace, requester, WorkspaceRole.MEMBER);
+    Project joinedMatch = saveProject(joinedWorkspace, "Shared Search Excluded");
+    saveProjectMember(joinedMatch, requester, ProjectRole.VIEWER);
+
+    PageResult<ProjectSearchResult> firstPage = searchSharedProjectsUseCase
+        .searchSharedProjects(new SearchSharedProjectsQuery(
+            requester.id(), "sHaReD sEaRcH", 0, 1))
+        .block();
+    PageResult<ProjectSearchResult> secondPage = searchSharedProjectsUseCase
+        .searchSharedProjects(new SearchSharedProjectsQuery(
+            requester.id(), "sHaReD sEaRcH", 1, 1))
+        .block();
+
+    assertThat(firstPage).isNotNull();
+    assertThat(firstPage.content()).singleElement().satisfies(result -> {
+      assertThat(result.name()).isEqualTo(newerMatch.getName());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.EDITOR.name());
+    });
+    assertThat(firstPage.totalElements()).isEqualTo(2);
+    assertThat(firstPage.totalPages()).isEqualTo(2);
+
+    assertThat(secondPage).isNotNull();
+    assertThat(secondPage.content()).singleElement().satisfies(result -> {
+      assertThat(result.name()).isEqualTo(olderMatch.getName());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.VIEWER.name());
+    });
+    assertThat(secondPage.totalElements()).isEqualTo(2);
+    assertThat(secondPage.totalPages()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("삭제된 프로젝트와 요청자의 삭제된 프로젝트 멤버십은 워크스페이스 및 공유 검색 결과와 개수에서 제외된다")
+  void searchProjects_excludesDeletedProjectsAndRequesterMemberships() {
+    User requester = signUpUser("deleted-search-requester@test.com", "Requester");
+
+    Workspace workspace = saveWorkspace("Deleted Workspace Search", "Description");
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.MEMBER);
+    Project activeWorkspaceProject = saveProject(workspace, "Search Active Workspace");
+    saveProjectMember(activeWorkspaceProject, requester, ProjectRole.ADMIN);
+    Project deletedWorkspaceProject = saveProject(workspace, "Search Deleted Workspace Project");
+    saveProjectMember(deletedWorkspaceProject, requester, ProjectRole.EDITOR);
+    softDeleteProject(deletedWorkspaceProject.getId());
+    Project deletedWorkspaceMembershipProject = saveProject(
+        workspace, "Search Deleted Workspace Membership");
+    ProjectMember deletedWorkspaceMembership = saveProjectMember(
+        deletedWorkspaceMembershipProject, requester, ProjectRole.VIEWER);
+    softDeleteProjectMember(deletedWorkspaceMembership.getId());
+
+    Workspace sharedWorkspace = saveWorkspace("Deleted Shared Search", "Description");
+    Project activeSharedProject = saveProject(sharedWorkspace, "Search Active Shared");
+    saveProjectMember(activeSharedProject, requester, ProjectRole.VIEWER);
+    Project deletedSharedProject = saveProject(sharedWorkspace, "Search Deleted Shared Project");
+    saveProjectMember(deletedSharedProject, requester, ProjectRole.EDITOR);
+    softDeleteProject(deletedSharedProject.getId());
+    Project deletedSharedMembershipProject = saveProject(
+        sharedWorkspace, "Search Deleted Shared Membership");
+    ProjectMember deletedSharedMembership = saveProjectMember(
+        deletedSharedMembershipProject, requester, ProjectRole.ADMIN);
+    softDeleteProjectMember(deletedSharedMembership.getId());
+
+    PageResult<ProjectSearchResult> workspaceResult = searchWorkspaceProjectsUseCase
+        .searchWorkspaceProjects(new SearchWorkspaceProjectsQuery(
+            workspace.getId(), requester.id(), "search", 0, 10))
+        .block();
+    PageResult<ProjectSearchResult> sharedResult = searchSharedProjectsUseCase
+        .searchSharedProjects(new SearchSharedProjectsQuery(
+            requester.id(), "search", 0, 10))
+        .block();
+
+    assertThat(workspaceResult).isNotNull();
+    assertThat(workspaceResult.content()).singleElement().satisfies(result -> {
+      assertThat(result.id()).isEqualTo(activeWorkspaceProject.getId());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.ADMIN.name());
+    });
+    assertThat(workspaceResult.totalElements()).isEqualTo(1);
+
+    assertThat(sharedResult).isNotNull();
+    assertThat(sharedResult.content()).singleElement().satisfies(result -> {
+      assertThat(result.id()).isEqualTo(activeSharedProject.getId());
+      assertThat(result.requesterRole()).isEqualTo(ProjectRole.VIEWER.name());
+    });
+    assertThat(sharedResult.totalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버 검색은 이름과 이메일을 필터링한 뒤 페이지와 전체 개수를 반환한다")
+  void searchWorkspaceMembers_matchesNameAndEmailBeforePaging() {
+    User requester = signUpUser(
+        "workspace-member-requester@test.com", "Workspace Requester");
+    User alice = signUpUser(
+        "alice@workspace-member.test", "Alice Engineer");
+    User bob = signUpUser(
+        "bob@workspace-member.test", "Bob Designer");
+    Workspace workspace = saveWorkspace("Workspace Member Search", "Description");
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.MEMBER);
+    saveWorkspaceMember(workspace, alice, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, bob, WorkspaceRole.MEMBER);
+
+    PageResult<MemberSearchResult> byName = searchWorkspaceMembersUseCase
+        .searchWorkspaceMembers(new SearchWorkspaceMembersQuery(
+            workspace.getId(), requester.id(), "aLi", 0, 5))
+        .block();
+    PageResult<MemberSearchResult> byEmail = searchWorkspaceMembersUseCase
+        .searchWorkspaceMembers(new SearchWorkspaceMembersQuery(
+            workspace.getId(), requester.id(), "BOB@WORKSPACE-MEMBER", 0, 5))
+        .block();
+    PageResult<MemberSearchResult> secondPage = searchWorkspaceMembersUseCase
+        .searchWorkspaceMembers(new SearchWorkspaceMembersQuery(
+            workspace.getId(), requester.id(), "@workspace-member.test", 1, 1))
+        .block();
+
+    assertThat(byName).isNotNull();
+    assertThat(byName.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(alice.id());
+    assertThat(byName.totalElements()).isEqualTo(1);
+
+    assertThat(byEmail).isNotNull();
+    assertThat(byEmail.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(bob.id());
+    assertThat(byEmail.totalElements()).isEqualTo(1);
+
+    assertThat(secondPage).isNotNull();
+    assertThat(secondPage.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(bob.id());
+    assertThat(secondPage.totalElements()).isEqualTo(2);
+    assertThat(secondPage.totalPages()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 검색은 이름과 이메일을 필터링한 뒤 페이지와 전체 개수를 반환한다")
+  void searchProjectMembers_matchesNameAndEmailBeforePaging() {
+    User requester = signUpUser(
+        "project-member-requester@test.com", "Project Requester");
+    User alice = signUpUser(
+        "alice@project-member.test", "Alice Engineer");
+    User bob = signUpUser(
+        "bob@project-member.test", "Bob Designer");
+    Workspace workspace = saveWorkspace("Project Member Workspace", "Description");
+    Project project = saveProject(workspace, "Project Member Search");
+    saveProjectMember(project, requester, ProjectRole.VIEWER);
+    saveProjectMember(project, alice, ProjectRole.ADMIN);
+    saveProjectMember(project, bob, ProjectRole.EDITOR);
+
+    PageResult<MemberSearchResult> byName = searchProjectMembersUseCase
+        .searchProjectMembers(new SearchProjectMembersQuery(
+            project.getId(), requester.id(), "aLi", 0, 5))
+        .block();
+    PageResult<MemberSearchResult> byEmail = searchProjectMembersUseCase
+        .searchProjectMembers(new SearchProjectMembersQuery(
+            project.getId(), requester.id(), "BOB@PROJECT-MEMBER", 0, 5))
+        .block();
+    PageResult<MemberSearchResult> secondPage = searchProjectMembersUseCase
+        .searchProjectMembers(new SearchProjectMembersQuery(
+            project.getId(), requester.id(), "@project-member.test", 1, 1))
+        .block();
+
+    assertThat(byName).isNotNull();
+    assertThat(byName.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(alice.id());
+    assertThat(byName.totalElements()).isEqualTo(1);
+
+    assertThat(byEmail).isNotNull();
+    assertThat(byEmail.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(bob.id());
+    assertThat(byEmail.totalElements()).isEqualTo(1);
+
+    assertThat(secondPage).isNotNull();
+    assertThat(secondPage.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(bob.id());
+    assertThat(secondPage.totalElements()).isEqualTo(2);
+    assertThat(secondPage.totalPages()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("삭제된 워크스페이스 및 프로젝트 멤버십은 멤버 검색 결과와 개수에서 제외된다")
+  void searchMembers_excludesSoftDeletedMemberships() {
+    User requester = signUpUser(
+        "deleted-member-requester@test.com", "Deleted Member Requester");
+    User active = signUpUser(
+        "active@deleted-member.test", "Search Active");
+    User deleted = signUpUser(
+        "deleted@deleted-member.test", "Search Deleted");
+    Workspace workspace = saveWorkspace("Deleted Member Workspace", "Description");
+    saveWorkspaceMember(workspace, requester, WorkspaceRole.MEMBER);
+    saveWorkspaceMember(workspace, active, WorkspaceRole.MEMBER);
+    WorkspaceMember deletedWorkspaceMember = saveWorkspaceMember(
+        workspace, deleted, WorkspaceRole.MEMBER);
+    softDeleteWorkspaceMember(deletedWorkspaceMember.getId());
+
+    Project project = saveProject(workspace, "Deleted Member Project");
+    saveProjectMember(project, requester, ProjectRole.VIEWER);
+    saveProjectMember(project, active, ProjectRole.EDITOR);
+    ProjectMember deletedProjectMember = saveProjectMember(
+        project, deleted, ProjectRole.VIEWER);
+    softDeleteProjectMember(deletedProjectMember.getId());
+
+    PageResult<MemberSearchResult> workspaceResult = searchWorkspaceMembersUseCase
+        .searchWorkspaceMembers(new SearchWorkspaceMembersQuery(
+            workspace.getId(), requester.id(), "search", 0, 10))
+        .block();
+    PageResult<MemberSearchResult> projectResult = searchProjectMembersUseCase
+        .searchProjectMembers(new SearchProjectMembersQuery(
+            project.getId(), requester.id(), "search", 0, 10))
+        .block();
+
+    assertThat(workspaceResult).isNotNull();
+    assertThat(workspaceResult.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(active.id());
+    assertThat(workspaceResult.totalElements()).isEqualTo(1);
+
+    assertThat(projectResult).isNotNull();
+    assertThat(projectResult.content())
+        .extracting(MemberSearchResult::userId)
+        .containsExactly(active.id());
+    assertThat(projectResult.totalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("멤버가 아닌 요청자의 워크스페이스 및 프로젝트 멤버 검색은 거부된다")
+  void searchMembers_deniesRequestersWithoutRequiredMemberships() {
+    User requester = signUpUser(
+        "member-search-denied@test.com", "Denied Requester");
+    Workspace workspace = saveWorkspace("Denied Member Search", "Description");
+    Project project = saveProject(workspace, "Denied Member Search");
+
+    StepVerifier.create(searchWorkspaceMembersUseCase.searchWorkspaceMembers(
+        new SearchWorkspaceMembersQuery(
+            workspace.getId(), requester.id(), "search", 0, 10)))
+        .expectErrorMatches(DomainException.hasErrorCode(
+            WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+
+    StepVerifier.create(searchProjectMembersUseCase.searchProjectMembers(
+        new SearchProjectMembersQuery(
+            project.getId(), requester.id(), "search", 0, 10)))
+        .expectErrorMatches(DomainException.hasErrorCode(
+            ProjectErrorCode.ACCESS_DENIED))
+        .verify();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationUseCaseIntegrationTest.java
@@ -206,7 +206,7 @@ class WorkspaceInvitationUseCaseIntegrationTest
         .block();
 
     ProjectMember restoredProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(), invitee.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(), invitee.id())
         .block();
     Invitation cancelledSibling = invitationRepository.findById(siblingInvitation.getId()).block();
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
@@ -89,7 +89,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     assertThat(detail.currentUserRole()).isEqualTo(WorkspaceRole.ADMIN.name());
 
     WorkspaceMember member = workspaceMemberRepository
-        .findByWorkspaceIdAndUserIdAndNotDeleted(detail.workspace().getId(), admin.id())
+        .findByWorkspaceIdAndUserIdAndDeletedAtIsNull(detail.workspace().getId(), admin.id())
         .block();
     assertThat(member).isNotNull();
     assertThat(member.getRoleAsEnum()).isEqualTo(WorkspaceRole.ADMIN);
@@ -121,8 +121,8 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         admin.id())).block();
 
     assertThat(workspaceRepository.findByIdAndNotDeleted(workspace.getId()).block()).isNull();
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
-    assertThat(projectRepository.findByIdAndNotDeleted(secondProject.getId()).block()).isNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(secondProject.getId()).block()).isNull();
     assertThat(findSchemasByProjectId(project.getId())).isEmpty();
     assertThat(findSchemasByProjectId(secondProject.getId())).isEmpty();
 
@@ -253,7 +253,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .block();
 
     ProjectMember restoredProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(), target.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(), target.id())
         .block();
 
     assertThat(restoredMember.getId()).isEqualTo(deletedWorkspaceMember.getId());
@@ -281,10 +281,10 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .block();
 
     ProjectMember upgradedProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(joinedProject.getId(), target.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(joinedProject.getId(), target.id())
         .block();
     ProjectMember createdProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(missingProject.getId(), target.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(missingProject.getId(), target.id())
         .block();
 
     assertThat(addedMember).isNotNull();
@@ -424,7 +424,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
     ProjectMember restoredProjectMember = projectMemberRepository.findById(deletedProjectMember.getId())
         .block();
     ProjectMember createdProjectMember = projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(missingProject.getId(), target.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(missingProject.getId(), target.id())
         .block();
 
     assertThat(updatedMember.getId()).isEqualTo(targetWorkspaceMember.getId());
@@ -563,9 +563,9 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         admin.id())).block();
 
     assertThat(workspaceRepository.findByIdAndNotDeleted(workspace.getId()).block()).isNull();
-    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
+    assertThat(projectRepository.findByIdAndDeletedAtIsNull(project.getId()).block()).isNull();
     assertThat(projectMemberRepository
-        .findByProjectIdAndUserIdAndNotDeleted(project.getId(), outsider.id())
+        .findByProjectIdAndUserIdAndDeletedAtIsNull(project.getId(), outsider.id())
         .block()).isNull();
     assertThat(findSchemasByProjectId(project.getId())).isEmpty();
   }

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -19,9 +19,7 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['tests/*.spec.ts'],
-        },
+        projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -19,7 +19,9 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['tests/*.spec.ts'],
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },


### PR DESCRIPTION
## 개요
프로젝트와 멤버를 이름 기준으로 검색할 수 있는 API를 추가했습니다.(프로젝트 조회, 멤버 조회 api 각각 제공)

  - 워크스페이스 프로젝트 검색 및 공유 프로젝트 검색
  - 워크스페이스 멤버 및 프로젝트 멤버 검색
  - 검색어 정규화·검증과 SQL LIKE 특수문자 escape 처리

프로젝트 조회, 멤버 조회의 리턴 타입이 다르고 사용 화면이 다르기에, 분리해 제공.

- `GET /api/search/projects`
   - `WORKSPACE`, `SHARED` 카테고리 지원
 - `GET /api/search/members`
   - `WORKSPACE`, `PROJECT` 카테고리 지원
 - 검색 결과에 페이지 정보와 요청자의 프로젝트 역할을 포함
 - 검색어는 앞뒤 공백을 제거하고, 제어 문자 및 100 code point 초과 입력을 거부
 - `%`, `_`, `!`를 escape하여 LIKE 검색어가 의도대로 동작하도록 처리
 
 agent-log 는 레거시 사용법으로 판단되어 제거

## 관련 문서
https://app.notion.com/p/cjeongmin/3b8be17b3b9d80a288a7f39f1777fae9?source=copy_link

## 이슈


- close #471