### PR TITLE
refactor(#482): centralize collaboration event publishing in core

### DIFF
--- a/apps/backend/api/src/main/java/com/schemafy/api/cache/service/RedisCacheService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/cache/service/RedisCacheService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.schemafy.api.cache.config.CacheProperties;
 import com.schemafy.api.cache.service.dto.CacheStatsDto;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/config/WebSocketConfig.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/config/WebSocketConfig.java
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.socket.WebSocketHandler;
 import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
 
 import com.schemafy.api.collaboration.handler.CollaborationWebSocketHandler;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 @Configuration
 @ConditionalOnRedisEnabled

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/constant/CollaborationConstants.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/constant/CollaborationConstants.java
@@ -6,8 +6,6 @@ public final class CollaborationConstants {
     // utility class
   }
 
-  public static final String CHANNEL_PREFIX = "collaboration:";
-  public static final String CHANNEL_PATTERN = "collaboration:*";
   public static final String SESSION_ID_HEADER = "X-Session-Id";
   public static final String CLIENT_OPERATION_ID_HEADER = "X-Client-Op-Id";
   public static final String BASE_SCHEMA_REVISION_HEADER = "X-Base-Schema-Revision";

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/handler/CollaborationWebSocketHandler.java
@@ -20,8 +20,8 @@ import com.schemafy.api.collaboration.service.CollaborationService;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.collaboration.service.presence.CollaborationPresenceProperties;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.api.common.security.principal.AuthenticatedUser;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/security/ProjectAccessValidator.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/security/ProjectAccessValidator.java
@@ -2,7 +2,7 @@ package com.schemafy.api.collaboration.security;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.AccessVerifier;
 import com.schemafy.core.project.application.port.out.ProjectPort;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
@@ -5,10 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.schemafy.api.collaboration.service.model.SessionEntry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSender.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationEventPublisher.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationEventPublisher.java
@@ -4,8 +4,8 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializer.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializer.java
@@ -2,8 +2,8 @@ package com.schemafy.api.collaboration.service;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializer.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializer.java
@@ -2,8 +2,8 @@ package com.schemafy.api.collaboration.service;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
@@ -10,19 +10,19 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.collaboration.dto.BroadcastMessage;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.CursorPosition;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.CursorEvent;
 import com.schemafy.api.collaboration.service.handler.InboundMessageHandler;
 import com.schemafy.api.collaboration.service.handler.MessageContext;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.CursorEvent;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
@@ -15,7 +15,6 @@ import com.schemafy.api.collaboration.service.handler.MessageContext;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.CursorPosition;
 import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
@@ -24,6 +23,7 @@ import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.CursorEvent;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/CollaborationService.java
@@ -23,6 +23,7 @@ import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.CursorEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/RedisSubscriptionService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/RedisSubscriptionService.java
@@ -8,8 +8,8 @@ import jakarta.annotation.PreDestroy;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.CollaborationChannel;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/RedisSubscriptionService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/RedisSubscriptionService.java
@@ -8,8 +8,8 @@ import jakarta.annotation.PreDestroy;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.collaboration.constant.CollaborationConstants;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.CollaborationChannel;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +44,7 @@ public class RedisSubscriptionService {
 
   private void subscribeToChannels() {
     subscription = redisTemplate
-        .listenToPattern(CollaborationConstants.CHANNEL_PATTERN)
+        .listenToPattern(CollaborationChannel.PATTERN)
         .flatMap(message -> {
           String channel = message.getChannel();
           String payload = message.getMessage();
@@ -76,12 +76,7 @@ public class RedisSubscriptionService {
   }
 
   private String extractProjectId(String channel) {
-    if (channel != null
-        && channel.startsWith(CollaborationConstants.CHANNEL_PREFIX)) {
-      return channel
-          .substring(CollaborationConstants.CHANNEL_PREFIX.length());
-    }
-    return channel;
+    return CollaborationChannel.extractProjectId(channel);
   }
 
   public void shutdown() {

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
@@ -4,12 +4,12 @@ import org.springframework.stereotype.Component;
 
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.event.ChatEvent;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.ulid.application.port.in.GenerateUlidUseCase;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
@@ -2,14 +2,14 @@ package com.schemafy.api.collaboration.service.handler;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.event.ChatEvent;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.event.ChatEvent;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.ulid.application.port.in.GenerateUlidUseCase;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/ChatMessageHandler.java
@@ -2,7 +2,6 @@ package com.schemafy.api.collaboration.service.handler;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
@@ -10,6 +9,7 @@ import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.event.ChatEvent;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.ulid.application.port.in.GenerateUlidUseCase;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/CursorMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/CursorMessageHandler.java
@@ -4,11 +4,11 @@ import org.springframework.stereotype.Component;
 
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.CursorPosition;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CursorEvent;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/CursorMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/CursorMessageHandler.java
@@ -2,13 +2,13 @@ package com.schemafy.api.collaboration.service.handler;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.CursorPosition;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CursorEvent;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CursorEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/InboundMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/InboundMessageHandler.java
@@ -1,7 +1,7 @@
 package com.schemafy.api.collaboration.service.handler;
 
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 
 import reactor.core.publisher.Mono;
 

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
@@ -4,13 +4,13 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.schemafy.api.collaboration.service.SessionRegistry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.RelationshipExtraPreviewEvent;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
@@ -3,7 +3,6 @@ package com.schemafy.api.collaboration.service.handler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
@@ -11,6 +10,7 @@ import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.RelationshipExtraPreviewEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandler.java
@@ -3,14 +3,14 @@ package com.schemafy.api.collaboration.service.handler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.RelationshipExtraPreviewEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.RelationshipExtraPreviewEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
@@ -4,12 +4,12 @@ import org.springframework.stereotype.Component;
 
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.SchemaFocusEvent;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
@@ -2,14 +2,14 @@ package com.schemafy.api.collaboration.service.handler;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.SchemaFocusEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.SchemaFocusEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/SchemaFocusMessageHandler.java
@@ -2,7 +2,6 @@ package com.schemafy.api.collaboration.service.handler;
 
 import org.springframework.stereotype.Component;
 
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
@@ -10,6 +9,7 @@ import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.SchemaFocusEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
@@ -4,13 +4,13 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.schemafy.api.collaboration.service.SessionRegistry;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.TablePositionPreviewEvent;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
@@ -3,14 +3,14 @@ package com.schemafy.api.collaboration.service.handler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.event.CollaborationInbound;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.TablePositionPreviewEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.TablePositionPreviewEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandler.java
@@ -3,7 +3,6 @@ package com.schemafy.api.collaboration.service.handler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.CollaborationEventType;
@@ -11,6 +10,7 @@ import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.CollaborationInbound;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.TablePositionPreviewEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/model/SessionEntry.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/model/SessionEntry.java
@@ -5,8 +5,8 @@ import java.time.Duration;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
 
-import com.schemafy.api.collaboration.dto.CursorPosition;
 import com.schemafy.api.collaboration.security.WebSocketAuthInfo;
+import com.schemafy.core.collaboration.dto.CursorPosition;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceCleanupService.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/ProjectPresenceCleanupService.java
@@ -6,7 +6,7 @@ import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.collaboration.service.CollaborationService;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/collaboration/service/presence/RedisProjectPresenceStore.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
@@ -5,9 +5,9 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcaster.java
@@ -5,9 +5,9 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ColumnController.java
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.ChangeColumnMetaRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeColumnNameRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeColumnPositionRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeColumnTypeRequest;
 import com.schemafy.api.erd.controller.dto.request.CreateColumnRequest;
 import com.schemafy.api.erd.controller.dto.response.ColumnResponse;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.column.application.port.in.ChangeColumnMetaCommand;
 import com.schemafy.core.erd.column.application.port.in.ChangeColumnMetaUseCase;
 import com.schemafy.core.erd.column.application.port.in.ChangeColumnNameCommand;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/ConstraintController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.AddConstraintColumnRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeConstraintCheckExprRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeConstraintColumnPositionRequest;
@@ -29,6 +28,7 @@ import com.schemafy.api.erd.controller.dto.response.AddConstraintColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.ConstraintColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.ConstraintResponse;
 import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.constraint.application.port.in.AddConstraintColumnCommand;
 import com.schemafy.core.erd.constraint.application.port.in.AddConstraintColumnUseCase;
 import com.schemafy.core.erd.constraint.application.port.in.ChangeConstraintCheckExprCommand;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/IndexController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.AddIndexColumnRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeIndexColumnPositionRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeIndexColumnSortDirectionRequest;
@@ -28,6 +27,7 @@ import com.schemafy.api.erd.controller.dto.request.CreateIndexRequest;
 import com.schemafy.api.erd.controller.dto.response.AddIndexColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.IndexColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.IndexResponse;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.index.application.port.in.AddIndexColumnCommand;
 import com.schemafy.core.erd.index.application.port.in.AddIndexColumnUseCase;
 import com.schemafy.core.erd.index.application.port.in.ChangeIndexColumnPositionCommand;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/OperationController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/OperationController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.operation.application.inverse.StructuralOperationInverse;
 import com.schemafy.core.erd.operation.application.port.in.RedoErdOperationCommand;
 import com.schemafy.core.erd.operation.application.port.in.RedoErdOperationUseCase;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/RelationshipController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.AddRelationshipColumnRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeRelationshipCardinalityRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeRelationshipColumnPositionRequest;
@@ -29,6 +28,7 @@ import com.schemafy.api.erd.controller.dto.response.AddRelationshipColumnRespons
 import com.schemafy.api.erd.controller.dto.response.RelationshipColumnResponse;
 import com.schemafy.api.erd.controller.dto.response.RelationshipResponse;
 import com.schemafy.api.erd.service.relationship.RelationshipApiResponseMapper;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.relationship.application.port.in.AddRelationshipColumnCommand;
 import com.schemafy.core.erd.relationship.application.port.in.AddRelationshipColumnUseCase;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/SchemaController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.ChangeSchemaNameRequest;
 import com.schemafy.api.erd.controller.dto.request.CreateSchemaRequest;
 import com.schemafy.api.erd.controller.dto.response.SchemaDdlExportResponse;
@@ -27,6 +26,7 @@ import com.schemafy.api.erd.controller.dto.response.SchemaSnapshotsResponse;
 import com.schemafy.api.erd.service.SchemaDdlExportOrchestrator;
 import com.schemafy.api.erd.service.SchemaMermaidExportOrchestrator;
 import com.schemafy.api.erd.service.SchemaSnapshotOrchestrator;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameCommand;
 import com.schemafy.core.erd.schema.application.port.in.ChangeSchemaNameUseCase;

--- a/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/erd/controller/TableController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.schemafy.api.common.constant.ApiPath;
 import com.schemafy.api.common.type.MutationResponse;
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.api.erd.controller.dto.request.ChangeTableExtraRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeTableMetaRequest;
 import com.schemafy.api.erd.controller.dto.request.ChangeTableNameRequest;
@@ -28,6 +27,7 @@ import com.schemafy.api.erd.controller.dto.response.TableResponse;
 import com.schemafy.api.erd.controller.dto.response.TableSnapshotResponse;
 import com.schemafy.api.erd.service.TableSnapshotOrchestrator;
 import com.schemafy.api.erd.service.table.TableApiResponseMapper;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraCommand;
 import com.schemafy.core.erd.table.application.port.in.ChangeTableExtraUseCase;

--- a/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationCache.java
+++ b/apps/backend/api/src/main/java/com/schemafy/api/mcp/service/RedisMcpTokenRevocationCache.java
@@ -5,7 +5,7 @@ import java.time.Duration;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSenderTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationDirectMessageSenderTest.java
@@ -10,8 +10,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.core.common.json.JsonCodec;
 
 import reactor.core.publisher.Sinks;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationPayloadSerializerTest.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.schemafy.api.collaboration.dto.CursorPosition;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.CursorEvent;
-import com.schemafy.api.collaboration.dto.event.ErdMutatedEvent;
+import com.schemafy.core.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.CursorEvent;
+import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
@@ -27,6 +27,7 @@ import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.dto.event.CursorEvent;
 import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.core.collaboration.dto.event.LeaveEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.common.json.JsonCodec;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/CollaborationServiceTest.java
@@ -2,6 +2,7 @@ package com.schemafy.api.collaboration.service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,17 +16,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.schemafy.api.collaboration.dto.BroadcastMessage;
-import com.schemafy.api.collaboration.dto.CursorPosition;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutboundFactory;
-import com.schemafy.api.collaboration.dto.event.CursorEvent;
-import com.schemafy.api.collaboration.dto.event.LeaveEvent;
 import com.schemafy.api.collaboration.security.WebSocketAuthInfo;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceSession;
 import com.schemafy.api.collaboration.service.presence.ProjectPresenceStore;
+import com.schemafy.core.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
+import com.schemafy.core.collaboration.dto.event.CursorEvent;
+import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
+import com.schemafy.core.collaboration.dto.event.LeaveEvent;
 import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -46,6 +50,12 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CollaborationService 단위 테스트")
 class CollaborationServiceTest {
+
+  private static final CommittedErdOperation OPERATION = new CommittedErdOperation(
+      "op-1",
+      "client-op-1",
+      42L,
+      ErdOperationDerivationKind.ORIGINAL);
 
   @Mock
   private SessionRegistry sessionRegistry;
@@ -166,6 +176,49 @@ class CollaborationServiceTest {
     assertThat(captor.getValue().message()).contains("\"type\":\"CHAT\"");
     assertThat(captor.getValue().message())
         .contains("\"sessionId\":\"session-1\"");
+  }
+
+  @Test
+  @DisplayName("ERD_MUTATED 이벤트에 sessionId가 있으면 sender를 제외하고 브로드캐스트한다")
+  void handleRedisMessage_excludes_sender_for_erd_mutated_event()
+      throws Exception {
+    ErdMutatedEvent.Outbound event = CollaborationOutboundFactory.erdMutated(
+        "session-1", "schema-1", Set.of("table-1"), OPERATION);
+    String message = objectMapper.writeValueAsString(event);
+
+    StepVerifier.create(
+        collaborationService.handleRedisMessage("project-1", message))
+        .verifyComplete();
+
+    ArgumentCaptor<BroadcastMessage> captor = ArgumentCaptor.forClass(
+        BroadcastMessage.class);
+    verify(sessionRegistry).broadcast(captor.capture());
+    assertThat(captor.getValue().projectId()).isEqualTo("project-1");
+    assertThat(captor.getValue().excludeSessionId())
+        .isEqualTo("session-1");
+    assertThat(captor.getValue().message())
+        .contains("\"type\":\"ERD_MUTATED\"");
+  }
+
+  @Test
+  @DisplayName("ERD_MUTATED 이벤트에 sessionId가 없으면 모든 세션에 브로드캐스트한다")
+  void handleRedisMessage_includes_all_sessions_for_sessionless_erd_mutated_event()
+      throws Exception {
+    ErdMutatedEvent.Outbound event = CollaborationOutboundFactory.erdMutated(
+        null, "schema-1", Set.of("table-1"), OPERATION);
+    String message = objectMapper.writeValueAsString(event);
+
+    StepVerifier.create(
+        collaborationService.handleRedisMessage("project-1", message))
+        .verifyComplete();
+
+    ArgumentCaptor<BroadcastMessage> captor = ArgumentCaptor.forClass(
+        BroadcastMessage.class);
+    verify(sessionRegistry).broadcast(captor.capture());
+    assertThat(captor.getValue().projectId()).isEqualTo("project-1");
+    assertThat(captor.getValue().excludeSessionId()).isNull();
+    assertThat(captor.getValue().message())
+        .contains("\"type\":\"ERD_MUTATED\"");
   }
 
   @Test

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandlerTest.java
@@ -11,11 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.RelationshipExtraPreviewEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/RelationshipExtraPreviewMessageHandlerTest.java
@@ -11,11 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.event.RelationshipExtraPreviewEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.event.RelationshipExtraPreviewEvent;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java
@@ -11,11 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.event.TablePositionPreviewEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.event.TablePositionPreviewEvent;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;

--- a/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/collaboration/service/handler/TablePositionPreviewMessageHandlerTest.java
@@ -11,11 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.api.collaboration.service.SessionRegistry;
 import com.schemafy.api.collaboration.service.model.SessionEntry;
 import com.schemafy.core.collaboration.dto.PreviewAction;
 import com.schemafy.core.collaboration.dto.event.TablePositionPreviewEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
@@ -12,9 +12,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.collaboration.dto.event.CollaborationOutbound;
-import com.schemafy.api.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
+import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/broadcast/ErdMutationBroadcasterTest.java
@@ -12,9 +12,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;

--- a/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/OperationControllerBroadcastTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/erd/controller/OperationControllerBroadcastTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.schemafy.api.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.common.MutationResult;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
 import com.schemafy.core.erd.operation.application.inverse.CreateTableInverse;
 import com.schemafy.core.erd.operation.application.inverse.StructuralSnapshot;
 import com.schemafy.core.erd.operation.application.port.in.RedoErdOperationUseCase;

--- a/apps/backend/core/build.gradle
+++ b/apps/backend/core/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'org.springframework:spring-web'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/CollaborationChannel.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/CollaborationChannel.java
@@ -1,0 +1,22 @@
+package com.schemafy.core.collaboration;
+
+public final class CollaborationChannel {
+
+  public static final String PATTERN = "collaboration:*";
+
+  private static final String PREFIX = "collaboration:";
+
+  private CollaborationChannel() {}
+
+  public static String forProject(String projectId) {
+    return PREFIX + projectId;
+  }
+
+  public static String extractProjectId(String channel) {
+    if (channel != null && channel.startsWith(PREFIX)) {
+      return channel.substring(PREFIX.length());
+    }
+    return channel;
+  }
+
+}

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/CollaborationEventType.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/CollaborationEventType.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto;
+package com.schemafy.core.collaboration.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/CursorPosition.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/CursorPosition.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto;
+package com.schemafy.core.collaboration.dto;
 
 public record CursorPosition(
     double x,

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/PreviewAction.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/PreviewAction.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto;
+package com.schemafy.core.collaboration.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/ProjectPresenceParticipant.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/ProjectPresenceParticipant.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto;
+package com.schemafy.core.collaboration.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/ChatEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/ChatEvent.java
@@ -1,7 +1,7 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 public final class ChatEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationInbound.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationInbound.java
@@ -1,8 +1,8 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
 @JsonSubTypes({

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationOutbound.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationOutbound.java
@@ -1,9 +1,9 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationOutboundFactory.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CollaborationOutboundFactory.java
@@ -1,12 +1,12 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import java.util.List;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.dto.CursorPosition;
-import com.schemafy.api.collaboration.dto.PreviewAction;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public final class CollaborationOutboundFactory {

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CursorEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/CursorEvent.java
@@ -1,8 +1,8 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.CursorPosition;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CursorPosition;
 
 public final class CursorEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/ErdMutatedEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/ErdMutatedEvent.java
@@ -1,9 +1,9 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 
 public final class ErdMutatedEvent {

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/JoinEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/JoinEvent.java
@@ -1,7 +1,7 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 public final class JoinEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/LeaveEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/LeaveEvent.java
@@ -1,7 +1,7 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 public final class LeaveEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/RelationshipExtraPreviewEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/RelationshipExtraPreviewEvent.java
@@ -1,24 +1,24 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
 
-public final class TablePositionPreviewEvent {
+public final class RelationshipExtraPreviewEvent {
 
-  private TablePositionPreviewEvent() {}
+  private RelationshipExtraPreviewEvent() {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record Inbound(
       PreviewAction action,
       String schemaId,
-      String tableId,
-      JsonNode position) implements CollaborationInbound {
+      String relationshipId,
+      JsonNode extra) implements CollaborationInbound {
 
     @Override
     public CollaborationEventType type() {
-      return CollaborationEventType.TABLE_POSITION_PREVIEW;
+      return CollaborationEventType.RELATIONSHIP_EXTRA_PREVIEW;
     }
 
   }
@@ -28,19 +28,19 @@ public final class TablePositionPreviewEvent {
       String sessionId,
       PreviewAction action,
       String schemaId,
-      String tableId,
-      JsonNode position,
+      String relationshipId,
+      JsonNode extra,
       long timestamp) implements CollaborationOutbound {
 
     public static Outbound of(String sessionId, PreviewAction action,
-        String schemaId, String tableId, JsonNode position) {
-      return new Outbound(sessionId, action, schemaId, tableId, position,
+        String schemaId, String relationshipId, JsonNode extra) {
+      return new Outbound(sessionId, action, schemaId, relationshipId, extra,
           System.currentTimeMillis());
     }
 
     @Override
     public CollaborationEventType type() {
-      return CollaborationEventType.TABLE_POSITION_PREVIEW;
+      return CollaborationEventType.RELATIONSHIP_EXTRA_PREVIEW;
     }
 
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/SchemaFocusEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/SchemaFocusEvent.java
@@ -1,7 +1,7 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 
 public final class SchemaFocusEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/SessionReadyEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/SessionReadyEvent.java
@@ -1,10 +1,10 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
 
 public final class SessionReadyEvent {
 

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/TablePositionPreviewEvent.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/dto/event/TablePositionPreviewEvent.java
@@ -1,24 +1,24 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
 
-public final class RelationshipExtraPreviewEvent {
+public final class TablePositionPreviewEvent {
 
-  private RelationshipExtraPreviewEvent() {}
+  private TablePositionPreviewEvent() {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record Inbound(
       PreviewAction action,
       String schemaId,
-      String relationshipId,
-      JsonNode extra) implements CollaborationInbound {
+      String tableId,
+      JsonNode position) implements CollaborationInbound {
 
     @Override
     public CollaborationEventType type() {
-      return CollaborationEventType.RELATIONSHIP_EXTRA_PREVIEW;
+      return CollaborationEventType.TABLE_POSITION_PREVIEW;
     }
 
   }
@@ -28,19 +28,19 @@ public final class RelationshipExtraPreviewEvent {
       String sessionId,
       PreviewAction action,
       String schemaId,
-      String relationshipId,
-      JsonNode extra,
+      String tableId,
+      JsonNode position,
       long timestamp) implements CollaborationOutbound {
 
     public static Outbound of(String sessionId, PreviewAction action,
-        String schemaId, String relationshipId, JsonNode extra) {
-      return new Outbound(sessionId, action, schemaId, relationshipId, extra,
+        String schemaId, String tableId, JsonNode position) {
+      return new Outbound(sessionId, action, schemaId, tableId, position,
           System.currentTimeMillis());
     }
 
     @Override
     public CollaborationEventType type() {
-      return CollaborationEventType.RELATIONSHIP_EXTRA_PREVIEW;
+      return CollaborationEventType.TABLE_POSITION_PREVIEW;
     }
 
   }

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/service/CollaborationEventPublisher.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/service/CollaborationEventPublisher.java
@@ -1,10 +1,10 @@
-package com.schemafy.api.collaboration.service;
+package com.schemafy.core.collaboration.service;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
+import com.schemafy.core.collaboration.CollaborationChannel;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.common.json.JsonCodec;
 
@@ -15,14 +15,14 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@ConditionalOnRedisEnabled
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = false)
 public class CollaborationEventPublisher {
 
   private final ReactiveStringRedisTemplate redisTemplate;
   private final JsonCodec jsonCodec;
 
   public Mono<Void> publish(String projectId, CollaborationOutbound event) {
-    String channelName = CollaborationConstants.CHANNEL_PREFIX + projectId;
+    String channelName = CollaborationChannel.forProject(projectId);
 
     return serializeToJson(event)
         .flatMap(eventJson -> redisTemplate.convertAndSend(channelName,

--- a/apps/backend/core/src/main/java/com/schemafy/core/collaboration/service/CollaborationEventPublisher.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/collaboration/service/CollaborationEventPublisher.java
@@ -1,11 +1,11 @@
 package com.schemafy.core.collaboration.service;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.core.collaboration.CollaborationChannel;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.common.json.JsonCodec;
 
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnRedisEnabled
 public class CollaborationEventPublisher {
 
   private final ReactiveStringRedisTemplate redisTemplate;

--- a/apps/backend/core/src/main/java/com/schemafy/core/common/config/ConditionalOnRedisEnabled.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/common/config/ConditionalOnRedisEnabled.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.common.config;
+package com.schemafy.core.common.config;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcaster.java
@@ -2,11 +2,11 @@ package com.schemafy.core.erd.broadcast;
 
 import java.util.Set;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
@@ -19,7 +19,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnRedisEnabled
 public class ErdMutationBroadcaster {
 
   private final GetTableByIdPort getTableByIdPort;

--- a/apps/backend/core/src/main/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcaster.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcaster.java
@@ -1,13 +1,13 @@
-package com.schemafy.api.erd.broadcast;
+package com.schemafy.core.erd.broadcast;
 
 import java.util.Set;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
-import com.schemafy.api.collaboration.constant.CollaborationConstants;
-import com.schemafy.api.common.config.ConditionalOnRedisEnabled;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutboundFactory;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
 import com.schemafy.core.erd.table.application.port.out.GetTableByIdPort;
@@ -19,7 +19,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@ConditionalOnRedisEnabled
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = false)
 public class ErdMutationBroadcaster {
 
   private final GetTableByIdPort getTableByIdPort;
@@ -101,8 +101,8 @@ public class ErdMutationBroadcaster {
       Set<String> affectedTableIds,
       CommittedErdOperation operation) {
     return Mono.deferContextual(reactorCtx -> {
-      String sessionId = reactorCtx.getOrDefault(
-          CollaborationConstants.SESSION_ID_CONTEXT_KEY, null);
+      String sessionId = ErdOperationContexts.metadata(reactorCtx)
+          .sessionId();
       return eventPublisher.publish(ctx.projectId(),
           CollaborationOutboundFactory.erdMutated(sessionId,
               ctx.schemaId(), affectedTableIds, operation));

--- a/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/ErdMutatedEventTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/ErdMutatedEventTest.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import java.util.Set;
 
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/RelationshipExtraPreviewEventTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/RelationshipExtraPreviewEventTest.java
@@ -1,12 +1,12 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/SessionReadyEventTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/SessionReadyEventTest.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import java.util.List;
 
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.ProjectPresenceParticipant;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.ProjectPresenceParticipant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/TablePositionPreviewEventTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/collaboration/dto/event/TablePositionPreviewEventTest.java
@@ -1,12 +1,12 @@
-package com.schemafy.api.collaboration.dto.event;
+package com.schemafy.core.collaboration.dto.event;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.schemafy.api.collaboration.dto.CollaborationEventType;
-import com.schemafy.api.collaboration.dto.PreviewAction;
+import com.schemafy.core.collaboration.dto.CollaborationEventType;
+import com.schemafy.core.collaboration.dto.PreviewAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/apps/backend/core/src/test/java/com/schemafy/core/collaboration/service/CollaborationEventPublisherTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/collaboration/service/CollaborationEventPublisherTest.java
@@ -1,0 +1,110 @@
+package com.schemafy.core.collaboration.service;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
+import com.schemafy.core.common.json.JsonCodec;
+import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
+import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CollaborationEventPublisher 단위 테스트")
+class CollaborationEventPublisherTest {
+
+  private static final String CHANNEL = "collaboration:project-1";
+
+  @Mock
+  private ReactiveStringRedisTemplate redisTemplate;
+
+  private ObjectMapper objectMapper;
+  private CollaborationEventPublisher publisher;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper().findAndRegisterModules();
+    publisher = new CollaborationEventPublisher(redisTemplate,
+        new JsonCodec(objectMapper));
+  }
+
+  @Test
+  @DisplayName("프로젝트 채널에 ERD_MUTATED JSON payload를 발행한다")
+  void publishes_erd_mutated_payload_to_project_channel() throws Exception {
+    ErdMutatedEvent.Outbound event = new ErdMutatedEvent.Outbound(
+        null,
+        "schema-1",
+        Set.of("table-1"),
+        new CommittedErdOperation(
+            "op-1",
+            "client-op-1",
+            42L,
+            ErdOperationDerivationKind.ORIGINAL),
+        123L);
+    given(redisTemplate.convertAndSend(eq(CHANNEL), anyString()))
+        .willReturn(Mono.just(1L));
+
+    StepVerifier.create(publisher.publish("project-1", event))
+        .verifyComplete();
+
+    ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(
+        String.class);
+    verify(redisTemplate).convertAndSend(eq(CHANNEL),
+        payloadCaptor.capture());
+
+    JsonNode payload = objectMapper.readTree(payloadCaptor.getValue());
+    assertThat(payload.path("type").asText()).isEqualTo("ERD_MUTATED");
+    assertThat(payload.has("sessionId")).isFalse();
+    assertThat(payload.path("schemaId").asText()).isEqualTo("schema-1");
+    assertThat(payload.path("affectedTableIds").get(0).asText())
+        .isEqualTo("table-1");
+    assertThat(payload.path("operation").path("opId").asText())
+        .isEqualTo("op-1");
+    assertThat(payload.path("operation").path("clientOperationId").asText())
+        .isEqualTo("client-op-1");
+    assertThat(payload.path("operation").path("committedRevision").asLong())
+        .isEqualTo(42L);
+    assertThat(payload.path("operation").path("derivationKind").asText())
+        .isEqualTo("ORIGINAL");
+    assertThat(payload.path("timestamp").asLong()).isEqualTo(123L);
+  }
+
+  @Test
+  @DisplayName("Redis 발행 오류는 호출자에게 전파하지 않는다")
+  void swallows_redis_publish_error() {
+    ErdMutatedEvent.Outbound event = ErdMutatedEvent.Outbound.of(
+        null,
+        "schema-1",
+        Set.of("table-1"),
+        new CommittedErdOperation(
+            "op-1",
+            "client-op-1",
+            42L,
+            ErdOperationDerivationKind.ORIGINAL));
+    given(redisTemplate.convertAndSend(eq(CHANNEL), anyString()))
+        .willReturn(Mono.error(new RuntimeException("Redis down")));
+
+    StepVerifier.create(publisher.publish("project-1", event))
+        .verifyComplete();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcasterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/erd/broadcast/ErdMutationBroadcasterTest.java
@@ -1,4 +1,4 @@
-package com.schemafy.api.erd.broadcast;
+package com.schemafy.core.erd.broadcast;
 
 import java.util.Set;
 
@@ -11,10 +11,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.schemafy.api.collaboration.constant.CollaborationConstants;
 import com.schemafy.core.collaboration.dto.event.CollaborationOutbound;
 import com.schemafy.core.collaboration.dto.event.ErdMutatedEvent;
 import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.erd.operation.ErdOperationContexts;
 import com.schemafy.core.erd.operation.domain.CommittedErdOperation;
 import com.schemafy.core.erd.operation.domain.ErdOperationDerivationKind;
 import com.schemafy.core.erd.schema.application.port.out.GetSchemaByIdPort;
@@ -111,9 +111,7 @@ class ErdMutationBroadcasterTest {
           .willReturn(Mono.empty());
 
       StepVerifier.create(broadcaster.broadcast(tableIds, OPERATION)
-          .contextWrite(ctx -> ctx.put(
-              CollaborationConstants.SESSION_ID_CONTEXT_KEY,
-              "session-1")))
+          .contextWrite(ErdOperationContexts.withSessionId("session-1")))
           .verifyComplete();
 
       ArgumentCaptor<CollaborationOutbound> captor = ArgumentCaptor

--- a/apps/backend/mcp/src/test/java/com/schemafy/mcp/collaboration/McpCollaborationPublishingIntegrationTest.java
+++ b/apps/backend/mcp/src/test/java/com/schemafy/mcp/collaboration/McpCollaborationPublishingIntegrationTest.java
@@ -1,0 +1,38 @@
+package com.schemafy.mcp.collaboration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.collaboration.service.CollaborationEventPublisher;
+import com.schemafy.core.erd.broadcast.ErdMutationBroadcaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "spring.data.redis.enabled=true")
+@ActiveProfiles("test")
+@DisplayName("MCP collaboration publishing wiring")
+class McpCollaborationPublishingIntegrationTest {
+
+  @MockitoBean
+  ReactiveStringRedisTemplate redisTemplate;
+
+  @Autowired
+  CollaborationEventPublisher eventPublisher;
+
+  @Autowired
+  ErdMutationBroadcaster mutationBroadcaster;
+
+  @Test
+  @DisplayName("Redis가 활성화되면 core 협업 발행 계층을 구성한다")
+  void configuresCoreCollaborationPublishingWhenRedisIsEnabled() {
+    assertThat(eventPublisher).isNotNull();
+    assertThat(mutationBroadcaster).isNotNull();
+  }
+
+}


### PR DESCRIPTION
## 개요

- 협업 이벤트 계약과 Redis channel/publisher를 core 공용 계층으로 이동
- ERD mutation broadcaster를 core로 이동하고 session ID 조회를 typed operation context로 통일
- `:mcp`가 `:api` 의존 없이 공용 publisher와 broadcaster를 구성할 수 있도록 정리
- Redis 활성화 조건을 core 공용 annotation으로 일원화

## 참고

- 기존 event payload, Redis channel 및 API sender session 제외 동작 변경 없음
- Redis subscription, WebSocket session/presence 및 실제 전송 책임은 API에 유지
- MCP mutation tool 추가와 broadcaster 호출 연결은 #428 범위

## 이슈

- close #482
