### PR TITLE
fix(#486): resolve frontend lint errors

### DIFF
--- a/apps/frontend/tests/perf-audit-canvas-ops.spec.ts
+++ b/apps/frontend/tests/perf-audit-canvas-ops.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from '@playwright/test';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import type {
+  PerformanceAuditLongTask,
+  PerformanceAuditRender,
+  PerformanceAuditWindow,
+  ReactDevToolsGlobalHook,
+} from './perf-audit-types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -14,19 +20,19 @@ async function measureOp(
   action: () => Promise<void>,
 ): Promise<{ renderCount: number; longTaskCount: number; durationMs: number }> {
   const rendersBefore = await page.evaluate(
-    () => ((window as any).__PERF_RENDERS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
   );
   const longTasksBefore = await page.evaluate(
-    () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
   );
   const start = Date.now();
   await action();
   const durationMs = Date.now() - start;
   const rendersAfter = await page.evaluate(
-    () => ((window as any).__PERF_RENDERS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
   );
   const longTasksAfter = await page.evaluate(
-    () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
   );
   return {
     renderCount: rendersAfter - rendersBefore,
@@ -47,13 +53,16 @@ test('perf-canvas-ops: 캔버스 조작 성능 진단', async ({
   await cdp.send('Runtime.enable');
 
   await page.addInitScript(() => {
-    (window as any).__PERF_RENDERS__ = [];
-    (window as any).__PERF_LONG_TASKS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    const renders: PerformanceAuditRender[] = [];
+    const longTasks: PerformanceAuditLongTask[] = [];
+    perfWindow.__PERF_RENDERS__ = renders;
+    perfWindow.__PERF_LONG_TASKS__ = longTasks;
 
     try {
       const ltObserver = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          (window as any).__PERF_LONG_TASKS__.push({
+          longTasks.push({
             startTime: Math.round(entry.startTime),
             duration: Math.round(entry.duration),
           });
@@ -70,10 +79,10 @@ test('perf-canvas-ops: 캔버스 조작 성능 진단', async ({
       get: function () {
         return undefined;
       },
-      set: function (hook) {
+      set: function (hook: ReactDevToolsGlobalHook) {
         const origCommit = hook.onCommitFiberRoot;
-        hook.onCommitFiberRoot = function (...args: any[]) {
-          (window as any).__PERF_RENDERS__.push({
+        hook.onCommitFiberRoot = function (this: unknown, ...args: unknown[]) {
+          renders.push({
             timestamp: performance.now(),
           });
           if (origCommit) origCommit.apply(this, args);
@@ -100,8 +109,9 @@ test('perf-canvas-ops: 캔버스 조작 성능 진단', async ({
   await expect(page.locator('.react-flow')).toBeVisible({ timeout: 15000 });
 
   await page.evaluate(() => {
-    (window as any).__PERF_RENDERS__ = [];
-    (window as any).__PERF_LONG_TASKS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    perfWindow.__PERF_RENDERS__ = [];
+    perfWindow.__PERF_LONG_TASKS__ = [];
   });
 
   const reactFlowBox = await page.locator('.react-flow').boundingBox();

--- a/apps/frontend/tests/perf-audit-canvas-scale.spec.ts
+++ b/apps/frontend/tests/perf-audit-canvas-scale.spec.ts
@@ -2,6 +2,14 @@ import { test } from '@playwright/test';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import type {
+  PerformanceAuditCdpMetrics,
+  PerformanceAuditLongTask,
+  PerformanceAuditOperation,
+  PerformanceAuditRender,
+  PerformanceAuditWindow,
+  ReactDevToolsGlobalHook,
+} from './perf-audit-types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -24,19 +32,19 @@ async function measureOp(
   action: () => Promise<void>,
 ): Promise<{ renderCount: number; longTaskCount: number; durationMs: number }> {
   const rendersBefore = await page.evaluate(
-    () => ((window as any).__PERF_RENDERS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
   );
   const longTasksBefore = await page.evaluate(
-    () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
   );
   const start = Date.now();
   await action();
   const durationMs = Date.now() - start;
   const rendersAfter = await page.evaluate(
-    () => ((window as any).__PERF_RENDERS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
   );
   const longTasksAfter = await page.evaluate(
-    () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
   );
   return {
     renderCount: rendersAfter - rendersBefore,
@@ -89,8 +97,9 @@ async function resetCounters(
   page: import('@playwright/test').Page,
 ): Promise<void> {
   await page.evaluate(() => {
-    (window as any).__PERF_RENDERS__ = [];
-    (window as any).__PERF_LONG_TASKS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    perfWindow.__PERF_RENDERS__ = [];
+    perfWindow.__PERF_LONG_TASKS__ = [];
   });
 }
 
@@ -107,13 +116,16 @@ test('perf-canvas-scale: 규모별 캔버스 조작 성능 진단', async ({
   await cdp.send('Runtime.enable');
 
   await page.addInitScript(() => {
-    (window as any).__PERF_RENDERS__ = [];
-    (window as any).__PERF_LONG_TASKS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    const renders: PerformanceAuditRender[] = [];
+    const longTasks: PerformanceAuditLongTask[] = [];
+    perfWindow.__PERF_RENDERS__ = renders;
+    perfWindow.__PERF_LONG_TASKS__ = longTasks;
 
     try {
       const ltObserver = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          (window as any).__PERF_LONG_TASKS__.push({
+          longTasks.push({
             startTime: Math.round(entry.startTime),
             duration: Math.round(entry.duration),
           });
@@ -130,10 +142,10 @@ test('perf-canvas-scale: 규모별 캔버스 조작 성능 진단', async ({
       get: function () {
         return undefined;
       },
-      set: function (hook) {
+      set: function (hook: ReactDevToolsGlobalHook) {
         const origCommit = hook.onCommitFiberRoot;
-        hook.onCommitFiberRoot = function (...args: any[]) {
-          (window as any).__PERF_RENDERS__.push({
+        hook.onCommitFiberRoot = function (this: unknown, ...args: unknown[]) {
+          renders.push({
             timestamp: performance.now(),
           });
           if (origCommit) origCommit.apply(this, args);
@@ -173,9 +185,13 @@ test('perf-canvas-scale: 규모별 캔버스 조작 성능 진단', async ({
   let currentTableCount = 0;
   const scaleResults: Array<{
     tableCount: number;
-    ops: { addTable: object; addColumn: object; connectEdge: object };
+    ops: {
+      addTable: PerformanceAuditOperation;
+      addColumn: PerformanceAuditOperation;
+      connectEdge: PerformanceAuditOperation;
+    };
     heap: { usedMB: number; totalMB: number };
-    cdpMetrics: object;
+    cdpMetrics: PerformanceAuditCdpMetrics;
   }> = [];
 
   for (const targetCount of SCALE_LEVELS) {

--- a/apps/frontend/tests/perf-audit-types.d.ts
+++ b/apps/frontend/tests/perf-audit-types.d.ts
@@ -1,0 +1,41 @@
+export interface PerformanceAuditWindow extends Window {
+  __PERF_VITALS__?: PerformanceAuditVitals
+  __PERF_RENDERS__?: PerformanceAuditRender[]
+  __PERF_LONG_TASKS__?: PerformanceAuditLongTask[]
+  __REACT_DEVTOOLS_GLOBAL_HOOK__?: ReactDevToolsGlobalHook
+}
+
+export interface PerformanceAuditVitals {
+  cls: number
+  fcp?: number
+  lcp?: number
+}
+
+export interface PerformanceAuditRender {
+  timestamp: number
+}
+
+export interface PerformanceAuditLongTask {
+  startTime: number
+  duration: number
+}
+
+export interface PerformanceAuditOperation {
+  renderCount: number
+  longTaskCount: number
+  durationMs: number
+  skipped?: boolean
+}
+
+export interface PerformanceAuditCdpMetrics {
+  [metricName: string]: number | undefined
+}
+
+export interface ReactDevToolsGlobalHook {
+  onCommitFiberRoot?: (this: unknown, ...args: unknown[]) => void
+}
+
+export interface LayoutShiftPerformanceEntry extends PerformanceEntry {
+  hadRecentInput: boolean
+  value: number
+}

--- a/apps/frontend/tests/perf-audit.spec.ts
+++ b/apps/frontend/tests/perf-audit.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '@playwright/test';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import type {
+  LayoutShiftPerformanceEntry,
+  PerformanceAuditLongTask,
+  PerformanceAuditRender,
+  PerformanceAuditVitals,
+  PerformanceAuditWindow,
+  ReactDevToolsGlobalHook,
+} from './perf-audit-types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -25,14 +33,18 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
   await cdp.send('Runtime.enable');
 
   await page.addInitScript(() => {
-    (window as any).__PERF_VITALS__ = { cls: 0 };
-    (window as any).__PERF_RENDERS__ = [];
-    (window as any).__PERF_LONG_TASKS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    const vitals: PerformanceAuditVitals = { cls: 0 };
+    const renders: PerformanceAuditRender[] = [];
+    const longTasks: PerformanceAuditLongTask[] = [];
+    perfWindow.__PERF_VITALS__ = vitals;
+    perfWindow.__PERF_RENDERS__ = renders;
+    perfWindow.__PERF_LONG_TASKS__ = longTasks;
 
     try {
       const ltObserver = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          (window as any).__PERF_LONG_TASKS__.push({
+          longTasks.push({
             startTime: Math.round(entry.startTime),
             duration: Math.round(entry.duration),
           });
@@ -46,16 +58,18 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
     const observer = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
         if (entry.entryType === 'largest-contentful-paint') {
-          (window as any).__PERF_VITALS__.lcp = entry.startTime;
+          vitals.lcp = entry.startTime;
         }
         if (entry.name === 'first-contentful-paint') {
-          (window as any).__PERF_VITALS__.fcp = entry.startTime;
+          vitals.fcp = entry.startTime;
         }
         if (
           entry.entryType === 'layout-shift' &&
-          !(entry as any).hadRecentInput
+          !(entry as LayoutShiftPerformanceEntry).hadRecentInput
         ) {
-          (window as any).__PERF_VITALS__.cls += (entry as any).value;
+          vitals.cls += (
+            entry as LayoutShiftPerformanceEntry
+          ).value;
         }
       }
     });
@@ -73,10 +87,10 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
       get: function () {
         return undefined;
       },
-      set: function (hook) {
+      set: function (hook: ReactDevToolsGlobalHook) {
         const origCommit = hook.onCommitFiberRoot;
-        hook.onCommitFiberRoot = function (...args: any[]) {
-          (window as any).__PERF_RENDERS__.push({
+        hook.onCommitFiberRoot = function (this: unknown, ...args: unknown[]) {
+          renders.push({
             timestamp: performance.now(),
           });
           if (origCommit) origCommit.apply(this, args);
@@ -104,8 +118,9 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
   }
 
   await page.evaluate(() => {
-    (window as any).__PERF_VITALS__ = { cls: 0 };
-    (window as any).__PERF_RENDERS__ = [];
+    const perfWindow = window as PerformanceAuditWindow;
+    perfWindow.__PERF_VITALS__ = { cls: 0 };
+    perfWindow.__PERF_RENDERS__ = [];
   });
 
   const navStart = Date.now();
@@ -122,7 +137,9 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
 
   await Promise.race([
     page
-      .waitForFunction(() => (window as any).__PERF_VITALS__?.lcp != null)
+      .waitForFunction(
+        () => (window as PerformanceAuditWindow).__PERF_VITALS__?.lcp != null,
+      )
       .catch(() => {}),
     page.waitForTimeout(3000),
   ]);
@@ -150,17 +167,21 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
 
       const measurePhase = async (action: () => Promise<void>) => {
         const rendersBefore = await page.evaluate(
-          () => ((window as any).__PERF_RENDERS__ || []).length,
+          () =>
+            ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
         );
         const longTasksBefore = await page.evaluate(
-          () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+          () =>
+            ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
         );
         await action();
         const rendersAfter = await page.evaluate(
-          () => ((window as any).__PERF_RENDERS__ || []).length,
+          () =>
+            ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
         );
         const longTasksAfter = await page.evaluate(
-          () => ((window as any).__PERF_LONG_TASKS__ || []).length,
+          () =>
+            ((window as PerformanceAuditWindow).__PERF_LONG_TASKS__ || []).length,
         );
         return {
           renderCount: rendersAfter - rendersBefore,
@@ -236,16 +257,16 @@ test('perf-audit: 로컬 성능 진단 (회귀 차단 아님)', async ({
   });
 
   const vitals = await page.evaluate(() => {
-    const v = (window as any).__PERF_VITALS__ || {};
+    const v = (window as PerformanceAuditWindow).__PERF_VITALS__;
     return {
-      lcp: v.lcp ? Math.round(v.lcp) : null,
-      fcp: v.fcp ? Math.round(v.fcp) : null,
-      cls: v.cls != null ? Math.round(v.cls * 1000) / 1000 : null,
+      lcp: v?.lcp ? Math.round(v.lcp) : null,
+      fcp: v?.fcp ? Math.round(v.fcp) : null,
+      cls: v?.cls != null ? Math.round(v.cls * 1000) / 1000 : null,
     };
   });
 
   const renderCount = await page.evaluate(
-    () => ((window as any).__PERF_RENDERS__ || []).length,
+    () => ((window as PerformanceAuditWindow).__PERF_RENDERS__ || []).length,
   );
 
   const cdpMetrics = Object.fromEntries(

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -2,7 +2,8 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "paths": {

--- a/apps/frontend/tsconfig.node.json
+++ b/apps/frontend/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["tests"]
+}


### PR DESCRIPTION
## 개요
- Playwright 테스트와 설정 파일을 TypeScript project-service에 포함했습니다.
- 성능 감사 스펙의 명시적 `any`를 테스트 전용 타입으로 교체했습니다.
- 타입을 모듈 로컬로 유지해 전역 `Window` 확장을 추가하지 않았습니다.

## 이슈


- close #486