### PR TITLE
refactor(#271): serialize workspace and project topology mutations

### DIFF
--- a/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java
+++ b/apps/backend/api/src/test/java/com/schemafy/api/project/controller/WorkspaceControllerTest.java
@@ -469,7 +469,7 @@ class WorkspaceControllerTest extends ProjectHttpTestSupport {
         .expectStatus().isNoContent();
 
     Workspace deletedWorkspace = workspaceRepository
-        .findByIdAndNotDeleted(workspace.getId()).block();
+        .findByIdAndDeletedAtIsNull(workspace.getId()).block();
     assertThat(deletedWorkspace).isNull();
 
     Project deletedProject = projectRepository

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapter.java
@@ -25,7 +25,7 @@ public class WorkspacePersistenceAdapter
 
   @Override
   public Mono<Workspace> findByIdAndNotDeleted(String workspaceId) {
-    return workspaceRepository.findByIdAndNotDeleted(workspaceId);
+    return workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId);
   }
 
   @Override
@@ -38,6 +38,12 @@ public class WorkspacePersistenceAdapter
   public Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId) {
     return workspaceRepository
         .findWithExclusiveLockByIdAndDeletedAtIsNull(workspaceId);
+  }
+
+  @Override
+  public Mono<Long> updateIfActive(String workspaceId, String name,
+      String description) {
+    return workspaceRepository.updateIfActive(workspaceId, name, description);
   }
 
   @Override

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/adapter/out/persistence/WorkspaceRepository.java
@@ -1,5 +1,6 @@
 package com.schemafy.core.project.adapter.out.persistence;
 
+import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.relational.core.sql.LockMode;
 import org.springframework.data.relational.repository.Lock;
@@ -13,17 +14,24 @@ import reactor.core.publisher.Mono;
 public interface WorkspaceRepository
     extends ReactiveCrudRepository<Workspace, String> {
 
-  @Query("""
-      SELECT * FROM workspaces
-      WHERE id = :id AND deleted_at IS NULL
-      """)
-  Mono<Workspace> findByIdAndNotDeleted(String id);
+  Mono<Workspace> findByIdAndDeletedAtIsNull(String id);
 
   @Lock(LockMode.PESSIMISTIC_READ)
   Mono<Workspace> findWithSharedLockByIdAndDeletedAtIsNull(String id);
 
   @Lock(LockMode.PESSIMISTIC_WRITE)
   Mono<Workspace> findWithExclusiveLockByIdAndDeletedAtIsNull(String id);
+
+  @Modifying
+  @Query("""
+      UPDATE workspaces
+      SET name = :name,
+          description = :description,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = :id
+        AND deleted_at IS NULL
+      """)
+  Mono<Long> updateIfActive(String id, String name, String description);
 
   @Query("""
       SELECT w.* FROM workspaces w

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/port/out/WorkspacePort.java
@@ -15,6 +15,8 @@ public interface WorkspacePort {
 
   Mono<Workspace> findByIdAndNotDeletedForUpdate(String workspaceId);
 
+  Mono<Long> updateIfActive(String workspaceId, String name, String description);
+
   Flux<Workspace> findByUserIdWithPaging(String userId, int limit, int offset);
 
   Mono<Long> countByUserId(String userId);

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptProjectInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptProjectInvitationService.java
@@ -3,7 +3,6 @@ package com.schemafy.core.project.application.service;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +15,7 @@ import com.schemafy.core.project.domain.InvitationStatus;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
+import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ class AcceptProjectInvitationService implements AcceptProjectInvitationUseCase {
   private static final Logger log = LoggerFactory.getLogger(
       AcceptProjectInvitationService.class);
 
-  private final TransactionalOperator transactionalOperator;
+  private final ProjectMutationGuard projectMutationGuard;
   private final InvitationPort invitationPort;
   private final ProjectInvitationHelper projectInvitationHelper;
   private final FindUserByIdPort findUserByIdPort;
@@ -47,47 +47,57 @@ class AcceptProjectInvitationService implements AcceptProjectInvitationUseCase {
                 return Mono.error(new DomainException(
                     ProjectErrorCode.INVITATION_TYPE_MISMATCH));
               }
-
-              invitation.validateInvitedEmailMatches(user.email());
-              return projectInvitationHelper.findProjectOrThrow(
-                  invitation.getProjectId())
-                  .then(projectInvitationHelper.checkNotAlreadyProjectMember(
-                      invitation.getProjectId(),
-                      command.requesterId()))
-                  .then(Mono.defer(() -> {
-                    invitation.accept();
-
-                    return invitationPort.save(invitation)
-                        .then(invitationPort.updateStatusByTargetAndEmail(
-                            invitation.getTargetType(),
-                            invitation.getTargetId(),
-                            invitation.getInvitedEmail(),
-                            InvitationStatus.CANCELLED.name(),
-                            InvitationStatus.PENDING.name(),
-                            invitation.getId()))
-                        .then(projectInvitationHelper.saveOrRestoreProjectMember(
-                            invitation.getProjectId(),
-                            command.requesterId(),
-                            invitation.getProjectRole()))
-                        .onErrorResume(DataIntegrityViolationException.class,
-                            error -> {
-                              log.warn(
-                                  "Concurrent member creation on invitation accept: invitationId={}",
-                                  command.invitationId());
-                              return Mono.error(new DomainException(
-                                  ProjectErrorCode.INVITATION_DUPLICATE_MEMBERSHIP_PROJECT));
-                            });
-                  }));
+              return projectMutationGuard.protectChildCreation(
+                  invitation.getProjectId(), () -> acceptLockedInvitation(command, user));
             }))
-        .as(transactionalOperator::transactional)
         .retryWhen(Retry.max(3)
             .filter(OptimisticLockingFailureException.class::isInstance)
             .doBeforeRetry(signal -> log.warn(
                 "Retrying due to concurrent modification: invitationId={}",
-                command.invitationId())))
+                command.invitationId()))
+            .onRetryExhaustedThrow((spec, signal) -> signal.failure()))
         .onErrorMap(OptimisticLockingFailureException.class,
             error -> new DomainException(
                 ProjectErrorCode.INVITATION_CONCURRENT_PROCESSED));
+  }
+
+  private Mono<ProjectMember> acceptLockedInvitation(
+      AcceptProjectInvitationCommand command,
+      User user) {
+    return projectInvitationHelper.findInvitationOrThrow(command.invitationId())
+        .flatMap(invitation -> {
+          if (!invitation.getTargetTypeAsEnum().isProject()) {
+            return Mono.error(new DomainException(
+                ProjectErrorCode.INVITATION_TYPE_MISMATCH));
+          }
+
+          invitation.validateInvitedEmailMatches(user.email());
+          return projectInvitationHelper.findProjectOrThrow(invitation.getProjectId())
+              .then(projectInvitationHelper.checkNotAlreadyProjectMember(
+                  invitation.getProjectId(), command.requesterId()))
+              .then(Mono.defer(() -> {
+                invitation.accept();
+                return invitationPort.save(invitation)
+                    .then(invitationPort.updateStatusByTargetAndEmail(
+                        invitation.getTargetType(),
+                        invitation.getTargetId(),
+                        invitation.getInvitedEmail(),
+                        InvitationStatus.CANCELLED.name(),
+                        InvitationStatus.PENDING.name(),
+                        invitation.getId()))
+                    .then(projectInvitationHelper.saveOrRestoreProjectMember(
+                        invitation.getProjectId(),
+                        command.requesterId(),
+                        invitation.getProjectRole()))
+                    .onErrorResume(DataIntegrityViolationException.class, error -> {
+                      log.warn(
+                          "Concurrent member creation on invitation accept: invitationId={}",
+                          command.invitationId());
+                      return Mono.error(new DomainException(
+                          ProjectErrorCode.INVITATION_DUPLICATE_MEMBERSHIP_PROJECT));
+                    });
+              }));
+        });
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationService.java
@@ -3,7 +3,6 @@ package com.schemafy.core.project.application.service;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +15,7 @@ import com.schemafy.core.project.domain.InvitationStatus;
 import com.schemafy.core.project.domain.WorkspaceMember;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import com.schemafy.core.user.application.port.out.FindUserByIdPort;
+import com.schemafy.core.user.domain.User;
 import com.schemafy.core.user.domain.exception.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ class AcceptWorkspaceInvitationService
   private static final Logger log = LoggerFactory.getLogger(
       AcceptWorkspaceInvitationService.class);
 
-  private final TransactionalOperator transactionalOperator;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
   private final InvitationPort invitationPort;
   private final WorkspaceInvitationHelper workspaceInvitationHelper;
   private final ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
@@ -44,58 +44,70 @@ class AcceptWorkspaceInvitationService
             new DomainException(UserErrorCode.NOT_FOUND)))
         .flatMap(user -> workspaceInvitationHelper.findInvitationOrThrow(
             command.invitationId())
-            .flatMap(invitation -> {
-              if (!invitation.getTargetTypeAsEnum().isWorkspace()) {
+            .flatMap(preLockInvitation -> {
+              if (!preLockInvitation.getTargetTypeAsEnum().isWorkspace()) {
                 return Mono.error(new DomainException(
                     ProjectErrorCode.INVITATION_TYPE_MISMATCH));
               }
-
-              invitation.validateInvitedEmailMatches(user.email());
-              return workspaceInvitationHelper.findWorkspaceOrThrow(
-                  invitation.getWorkspaceId())
-                  .then(workspaceInvitationHelper.checkNotAlreadyMember(
-                      invitation.getWorkspaceId(), command.requesterId()))
-                  .then(Mono.defer(() -> {
-                    invitation.accept();
-
-                    return invitationPort.save(invitation)
-                        .then(invitationPort.updateStatusByTargetAndEmail(
-                            invitation.getTargetType(),
-                            invitation.getTargetId(),
-                            invitation.getInvitedEmail(),
-                            InvitationStatus.CANCELLED.name(),
-                            InvitationStatus.PENDING.name(),
-                            invitation.getId()))
-                        .then(workspaceInvitationHelper
-                            .saveOrRestoreWorkspaceMember(
-                                invitation.getWorkspaceId(),
-                                command.requesterId(),
-                                invitation.getWorkspaceRole()))
-                        .onErrorResume(DataIntegrityViolationException.class,
-                            error -> {
-                              log.warn(
-                                  "Concurrent member creation on invitation accept: invitationId={}",
-                                  command.invitationId());
-                              return Mono.error(new DomainException(
-                                  ProjectErrorCode.INVITATION_DUPLICATE_WORKSPACE_MEMBER));
-                            })
-                        .flatMap(savedMember -> projectMembershipPropagationHelper
-                            .syncProjectMembershipsForWorkspaceRole(
-                                invitation.getWorkspaceId(),
-                                command.requesterId(),
-                                invitation.getWorkspaceRole())
-                            .thenReturn(savedMember));
-                  }));
+              return workspaceMutationGuard.protectExclusive(
+                  preLockInvitation.getWorkspaceId(),
+                  () -> acceptLockedInvitation(command, user));
             }))
-        .as(transactionalOperator::transactional)
         .retryWhen(Retry.max(3)
             .filter(OptimisticLockingFailureException.class::isInstance)
             .doBeforeRetry(signal -> log.warn(
                 "Retrying due to concurrent modification: invitationId={}",
-                command.invitationId())))
+                command.invitationId()))
+            .onRetryExhaustedThrow((spec, signal) -> signal.failure()))
         .onErrorMap(OptimisticLockingFailureException.class,
             error -> new DomainException(
                 ProjectErrorCode.INVITATION_CONCURRENT_PROCESSED));
+  }
+
+  private Mono<WorkspaceMember> acceptLockedInvitation(
+      AcceptWorkspaceInvitationCommand command,
+      User user) {
+    return workspaceInvitationHelper.findInvitationOrThrow(command.invitationId())
+        .flatMap(invitation -> {
+          if (!invitation.getTargetTypeAsEnum().isWorkspace()) {
+            return Mono.error(new DomainException(
+                ProjectErrorCode.INVITATION_TYPE_MISMATCH));
+          }
+
+          invitation.validateInvitedEmailMatches(user.email());
+          return workspaceInvitationHelper.findWorkspaceOrThrow(
+              invitation.getWorkspaceId())
+              .then(workspaceInvitationHelper.checkNotAlreadyMember(
+                  invitation.getWorkspaceId(), command.requesterId()))
+              .then(Mono.defer(() -> {
+                invitation.accept();
+                return invitationPort.save(invitation)
+                    .then(invitationPort.updateStatusByTargetAndEmail(
+                        invitation.getTargetType(),
+                        invitation.getTargetId(),
+                        invitation.getInvitedEmail(),
+                        InvitationStatus.CANCELLED.name(),
+                        InvitationStatus.PENDING.name(),
+                        invitation.getId()))
+                    .then(workspaceInvitationHelper.saveOrRestoreWorkspaceMember(
+                        invitation.getWorkspaceId(),
+                        command.requesterId(),
+                        invitation.getWorkspaceRole()))
+                    .onErrorResume(DataIntegrityViolationException.class, error -> {
+                      log.warn(
+                          "Concurrent member creation on invitation accept: invitationId={}",
+                          command.invitationId());
+                      return Mono.error(new DomainException(
+                          ProjectErrorCode.INVITATION_DUPLICATE_WORKSPACE_MEMBER));
+                    })
+                    .flatMap(savedMember -> projectMembershipPropagationHelper
+                        .syncProjectMembershipsForWorkspaceRole(
+                            invitation.getWorkspaceId(),
+                            command.requesterId(),
+                            invitation.getWorkspaceRole())
+                        .thenReturn(savedMember));
+              }));
+        });
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/AddWorkspaceMemberService.java
@@ -2,7 +2,6 @@ package com.schemafy.core.project.application.service;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,53 +27,55 @@ class AddWorkspaceMemberService implements AddWorkspaceMemberUseCase {
   private static final Logger log = LoggerFactory.getLogger(
       AddWorkspaceMemberService.class);
 
-  private final TransactionalOperator transactionalOperator;
   private final UlidGeneratorPort ulidGeneratorPort;
   private final WorkspaceMemberPort workspaceMemberPort;
   private final WorkspaceAccessHelper workspaceAccessHelper;
   private final ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<WorkspaceMember> addWorkspaceMember(AddWorkspaceMemberCommand command) {
     return Mono.fromSupplier(() -> Email.from(command.email()))
-        .flatMap(email -> workspaceAccessHelper.findUserByEmailOrThrow(email)
-            .flatMap(targetUser -> workspaceMemberPort
-                .findLatestByWorkspaceIdAndUserId(command.workspaceId(),
-                    targetUser.id())
-                .flatMap(existing -> {
-                  if (!existing.isDeleted()) {
-                    log.warn("Member already exists and is active: memberId={}",
-                        existing.getId());
-                    return Mono.error(new DomainException(
-                        WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
-                  }
+        .flatMap(email -> workspaceMutationGuard.protectExclusive(
+            command.workspaceId(), () -> workspaceAccessHelper
+                .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+                .then(Mono.defer(() -> workspaceAccessHelper.findUserByEmailOrThrow(email)
+                    .flatMap(targetUser -> workspaceMemberPort
+                        .findLatestByWorkspaceIdAndUserId(command.workspaceId(),
+                            targetUser.id())
+                        .flatMap(existing -> {
+                          if (!existing.isDeleted()) {
+                            log.warn("Member already exists and is active: memberId={}",
+                                existing.getId());
+                            return Mono.error(new DomainException(
+                                WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
+                          }
 
-                  existing.restore();
-                  existing.updateRole(command.role());
-                  return workspaceMemberPort.save(existing);
-                })
-                .switchIfEmpty(Mono.defer(() -> Mono
-                    .fromCallable(ulidGeneratorPort::generate)
-                    .flatMap(id -> workspaceMemberPort
-                        .save(WorkspaceMember.create(id, command.workspaceId(),
-                            targetUser.id(), command.role()))))))
-            .flatMap(savedMember -> projectMembershipPropagationHelper
-                .syncProjectMembershipsForWorkspaceRole(
-                    command.workspaceId(),
-                    savedMember.getUserId(),
-                    savedMember.getRoleAsEnum())
-                .thenReturn(savedMember))
-            .onErrorResume(error -> {
-              if (error instanceof DataIntegrityViolationException) {
-                log.warn("Duplicate key constraint: workspaceId={}, email={}",
-                    command.workspaceId(), email.address());
-                return Mono.error(new DomainException(
-                    WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
-              }
-              return Mono.error(error);
-            }))
-        .as(transactionalOperator::transactional);
+                          existing.restore();
+                          existing.updateRole(command.role());
+                          return workspaceMemberPort.save(existing);
+                        })
+                        .switchIfEmpty(Mono.defer(() -> Mono
+                            .fromCallable(ulidGeneratorPort::generate)
+                            .flatMap(id -> workspaceMemberPort
+                                .save(WorkspaceMember.create(id, command.workspaceId(),
+                                    targetUser.id(), command.role())))))
+                        .flatMap(savedMember -> projectMembershipPropagationHelper
+                            .syncProjectMembershipsForWorkspaceRole(
+                                command.workspaceId(),
+                                savedMember.getUserId(),
+                                savedMember.getRoleAsEnum())
+                            .thenReturn(savedMember))
+                        .onErrorResume(error -> {
+                          if (error instanceof DataIntegrityViolationException) {
+                            log.warn("Duplicate key constraint: workspaceId={}, email={}",
+                                command.workspaceId(), email.address());
+                            return Mono.error(new DomainException(
+                                WorkspaceErrorCode.MEMBER_ALREADY_EXISTS));
+                          }
+                          return Mono.error(error);
+                        }))))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectInvitationService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.CreateProjectInvitationCommand;
@@ -19,7 +18,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class CreateProjectInvitationService implements CreateProjectInvitationUseCase {
 
-  private final TransactionalOperator transactionalOperator;
+  private final ProjectMutationGuard projectMutationGuard;
   private final UlidGeneratorPort ulidGeneratorPort;
   private final InvitationPort invitationPort;
   private final ProjectInvitationHelper projectInvitationHelper;
@@ -29,23 +28,23 @@ class CreateProjectInvitationService implements CreateProjectInvitationUseCase {
   public Mono<Invitation> createProjectInvitation(
       CreateProjectInvitationCommand command) {
     return Mono.fromSupplier(() -> Email.from(command.email()))
-        .flatMap(email -> projectInvitationHelper
-            .findProjectOrThrow(command.projectId())
-            .flatMap(project -> projectInvitationHelper
-                .checkNotAlreadyProjectMemberByEmail(command.projectId(), email)
-                .then(projectInvitationHelper.checkDuplicatePendingInvitation(
-                    command.projectId(), email))
-                .thenReturn(project))
-            .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
-                .flatMap(id -> invitationPort.save(
-                    Invitation.createProjectInvitation(
-                        id,
-                        command.projectId(),
-                        project.getWorkspaceId(),
-                        email.address(),
-                        command.role(),
-                        command.requesterId())))))
-        .as(transactionalOperator::transactional);
+        .flatMap(email -> projectMutationGuard.protectChildCreation(
+            command.projectId(), () -> projectInvitationHelper
+                .findProjectOrThrow(command.projectId())
+                .flatMap(project -> projectInvitationHelper
+                    .checkNotAlreadyProjectMemberByEmail(command.projectId(), email)
+                    .then(projectInvitationHelper.checkDuplicatePendingInvitation(
+                        command.projectId(), email))
+                    .thenReturn(project))
+                .flatMap(project -> Mono.fromCallable(ulidGeneratorPort::generate)
+                    .flatMap(id -> invitationPort.save(
+                        Invitation.createProjectInvitation(
+                            id,
+                            command.projectId(),
+                            project.getWorkspaceId(),
+                            email.address(),
+                            command.role(),
+                            command.requesterId()))))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateProjectService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.CreateProjectCommand;
@@ -22,42 +21,44 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class CreateProjectService implements CreateProjectUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final UlidGeneratorPort ulidGeneratorPort;
   private final ProjectPort projectPort;
   private final ProjectMemberPort projectMemberPort;
   private final ProjectAccessHelper projectAccessHelper;
   private final ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+  private final WorkspaceAccessHelper workspaceAccessHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<ProjectDetail> createProject(CreateProjectCommand command) {
-    return Mono.defer(() -> Mono
-        .zip(
-            Mono.fromCallable(ulidGeneratorPort::generate),
-            Mono.fromCallable(ulidGeneratorPort::generate))
-        .flatMap(tuple -> {
-          Project project = Project.create(tuple.getT1(),
-              command.workspaceId(), command.name(), command.description());
-          ProjectMember adminMember = ProjectMember.create(
-              tuple.getT2(),
-              project.getId(),
-              command.requesterId(),
-              ProjectRole.ADMIN);
+    return workspaceMutationGuard.protectShared(
+        command.workspaceId(), () -> workspaceAccessHelper
+            .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+            .then(Mono.defer(() -> Mono.zip(
+                Mono.fromCallable(ulidGeneratorPort::generate),
+                Mono.fromCallable(ulidGeneratorPort::generate))
+                .flatMap(tuple -> {
+                  Project project = Project.create(tuple.getT1(),
+                      command.workspaceId(), command.name(), command.description());
+                  ProjectMember adminMember = ProjectMember.create(
+                      tuple.getT2(),
+                      project.getId(),
+                      command.requesterId(),
+                      ProjectRole.ADMIN);
 
-          return projectPort.save(project)
-              .flatMap(savedProject -> projectMemberPort.save(adminMember)
-                  .thenReturn(savedProject))
-              .flatMap(savedProject -> projectMembershipPropagationHelper
-                  .propagateWorkspaceMembersToProject(
-                      savedProject.getId(),
-                      command.workspaceId(),
-                      command.requesterId())
-                  .thenReturn(savedProject))
-              .flatMap(savedProject -> projectAccessHelper
-                  .buildProjectDetail(savedProject, command.requesterId()));
-        }))
-        .as(transactionalOperator::transactional);
+                  return projectPort.save(project)
+                      .flatMap(savedProject -> projectMemberPort.save(adminMember)
+                          .thenReturn(savedProject))
+                      .flatMap(savedProject -> projectMembershipPropagationHelper
+                          .propagateWorkspaceMembersToProject(
+                              savedProject.getId(),
+                              command.workspaceId(),
+                              command.requesterId())
+                          .thenReturn(savedProject))
+                      .flatMap(savedProject -> projectAccessHelper
+                          .buildProjectDetail(savedProject, command.requesterId()));
+                }))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.CreateWorkspaceInvitationCommand;
@@ -20,32 +19,34 @@ import reactor.core.publisher.Mono;
 class CreateWorkspaceInvitationService
     implements CreateWorkspaceInvitationUseCase {
 
-  private final TransactionalOperator transactionalOperator;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
   private final UlidGeneratorPort ulidGeneratorPort;
   private final InvitationPort invitationPort;
   private final WorkspaceInvitationHelper workspaceInvitationHelper;
+  private final WorkspaceAccessHelper workspaceAccessHelper;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<Invitation> createWorkspaceInvitation(
       CreateWorkspaceInvitationCommand command) {
     return Mono.fromSupplier(() -> Email.from(command.email()))
-        .flatMap(email -> workspaceInvitationHelper
-            .findWorkspaceOrThrow(command.workspaceId())
-            .flatMap(workspace -> workspaceInvitationHelper
-                .checkNotAlreadyMemberByEmail(command.workspaceId(), email)
-                .then(workspaceInvitationHelper.checkDuplicatePendingInvitation(
-                    command.workspaceId(), email))
-                .thenReturn(workspace))
-            .flatMap(workspace -> Mono.fromCallable(ulidGeneratorPort::generate)
-                .flatMap(id -> invitationPort.save(
-                    Invitation.createWorkspaceInvitation(
-                        id,
-                        command.workspaceId(),
-                        email.address(),
-                        command.role(),
-                        command.requesterId())))))
-        .as(transactionalOperator::transactional);
+        .flatMap(email -> workspaceMutationGuard.protectShared(
+            command.workspaceId(), () -> workspaceAccessHelper
+                .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+                .then(Mono.defer(() -> workspaceInvitationHelper
+                    .findWorkspaceOrThrow(command.workspaceId())
+                    .then(workspaceInvitationHelper
+                        .checkNotAlreadyMemberByEmail(command.workspaceId(), email)
+                        .then(workspaceInvitationHelper.checkDuplicatePendingInvitation(
+                            command.workspaceId(), email)))
+                    .then(Mono.fromCallable(ulidGeneratorPort::generate)
+                        .flatMap(id -> invitationPort.save(
+                            Invitation.createWorkspaceInvitation(
+                                id,
+                                command.workspaceId(),
+                                email.address(),
+                                command.role(),
+                                command.requesterId()))))))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteWorkspaceService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/DeleteWorkspaceService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.DeleteWorkspaceCommand;
@@ -20,7 +19,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class DeleteWorkspaceService implements DeleteWorkspaceUseCase {
 
-  private final TransactionalOperator transactionalOperator;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
   private final WorkspacePort workspacePort;
   private final ProjectPort projectPort;
   private final WorkspaceMemberPort workspaceMemberPort;
@@ -31,8 +30,10 @@ class DeleteWorkspaceService implements DeleteWorkspaceUseCase {
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<Void> deleteWorkspace(DeleteWorkspaceCommand command) {
-    return doDeleteWorkspace(command.workspaceId())
-        .as(transactionalOperator::transactional);
+    return workspaceMutationGuard.protectExclusive(command.workspaceId(),
+        () -> workspaceAccessHelper
+            .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+            .then(Mono.defer(() -> doDeleteWorkspace(command.workspaceId()))));
   }
 
   private Mono<Void> doDeleteWorkspace(String workspaceId) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveWorkspaceService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/LeaveWorkspaceService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.BaseEntity;
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
@@ -21,7 +20,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class LeaveWorkspaceService implements LeaveWorkspaceUseCase {
 
-  private final TransactionalOperator transactionalOperator;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
   private final WorkspacePort workspacePort;
   private final ProjectPort projectPort;
   private final WorkspaceMemberPort workspaceMemberPort;
@@ -33,22 +32,22 @@ class LeaveWorkspaceService implements LeaveWorkspaceUseCase {
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.MEMBER)
   public Mono<Void> leaveWorkspace(LeaveWorkspaceCommand command) {
-    return workspaceAccessHelper.findWorkspaceMember(command.requesterId(),
-        command.workspaceId())
-        .flatMap(member -> workspaceMemberPort
-            .countByWorkspaceIdAndNotDeleted(command.workspaceId())
-            .flatMap(totalMembers -> {
-              if (totalMembers == 1) {
-                return doDeleteWorkspace(command.workspaceId());
-              }
+    return workspaceMutationGuard.protectExclusive(command.workspaceId(),
+        () -> workspaceAccessHelper.findWorkspaceMember(command.requesterId(),
+            command.workspaceId())
+            .flatMap(member -> workspaceMemberPort
+                .countByWorkspaceIdAndNotDeleted(command.workspaceId())
+                .flatMap(totalMembers -> {
+                  if (totalMembers == 1) {
+                    return doDeleteWorkspace(command.workspaceId());
+                  }
 
-              return workspaceAccessHelper.modifyMemberWithAdminGuard(
-                  command.workspaceId(), member, BaseEntity::delete)
-                  .then(projectMembershipPropagationHelper.removeFromAllProjects(
-                      command.workspaceId(),
-                      command.requesterId()));
-            }))
-        .as(transactionalOperator::transactional);
+                  return workspaceAccessHelper.modifyMemberWithAdminGuard(
+                      command.workspaceId(), member, BaseEntity::delete)
+                      .then(projectMembershipPropagationHelper.removeFromAllProjects(
+                          command.workspaceId(),
+                          command.requesterId()));
+                })));
   }
 
   private Mono<Void> doDeleteWorkspace(String workspaceId) {

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/ProjectAccessHelper.java
@@ -45,6 +45,16 @@ class ProjectAccessHelper {
             ProjectErrorCode.MEMBER_NOT_FOUND)));
   }
 
+  Mono<ProjectMember> findProjectAdminMember(String userId, String projectId) {
+    return projectMemberPort
+        .findByProjectIdAndUserIdAndNotDeleted(projectId, userId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ProjectErrorCode.ACCESS_DENIED)))
+        .flatMap(member -> member.isAdmin()
+            ? Mono.just(member)
+            : Mono.error(new DomainException(ProjectErrorCode.ADMIN_REQUIRED)));
+  }
+
   Mono<Void> softDeleteMember(ProjectMember member) {
     return projectMemberPort.softDeleteByProjectIdAndUserId(member.getProjectId(),
         member.getUserId()).then();

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RemoveProjectMemberService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RemoveProjectMemberService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireProjectAccess;
 import com.schemafy.core.project.application.port.in.RemoveProjectMemberCommand;
@@ -15,16 +14,21 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class RemoveProjectMemberService implements RemoveProjectMemberUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final ProjectAccessHelper projectAccessHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<Void> removeProjectMember(RemoveProjectMemberCommand command) {
-    return projectAccessHelper.findProjectMember(command.targetUserId(), command.projectId())
-        .flatMap(target -> projectAccessHelper.validateWorkspaceAdminGuard(command.projectId(), target)
-            .then(projectAccessHelper.softDeleteMember(target)))
-        .as(transactionalOperator::transactional);
+    return projectAccessHelper.findProjectById(command.projectId())
+        .flatMap(project -> workspaceMutationGuard.protectShared(project.getWorkspaceId(),
+            () -> projectAccessHelper.findProjectAdminMember(
+                command.requesterId(), command.projectId())
+                .then(Mono.defer(() -> projectAccessHelper.findProjectMember(
+                    command.targetUserId(), command.projectId())))
+                .flatMap(target -> projectAccessHelper
+                    .validateWorkspaceAdminGuard(command.projectId(), target)
+                    .then(projectAccessHelper.softDeleteMember(target)))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RemoveWorkspaceMemberService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/RemoveWorkspaceMemberService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.BaseEntity;
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
@@ -16,20 +15,22 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class RemoveWorkspaceMemberService implements RemoveWorkspaceMemberUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final WorkspaceAccessHelper workspaceAccessHelper;
   private final ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<Void> removeWorkspaceMember(RemoveWorkspaceMemberCommand command) {
-    return workspaceAccessHelper.findWorkspaceMember(command.targetUserId(),
-        command.workspaceId())
-        .flatMap(targetMember -> workspaceAccessHelper.modifyMemberWithAdminGuard(
-            command.workspaceId(), targetMember, BaseEntity::delete))
-        .then(projectMembershipPropagationHelper.removeFromAllProjects(
-            command.workspaceId(), command.targetUserId()))
-        .as(transactionalOperator::transactional);
+    return workspaceMutationGuard.protectExclusive(command.workspaceId(),
+        () -> workspaceAccessHelper
+            .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+            .then(Mono.defer(() -> workspaceAccessHelper.findWorkspaceMember(command.targetUserId(),
+                command.workspaceId())
+                .flatMap(targetMember -> workspaceAccessHelper.modifyMemberWithAdminGuard(
+                    command.workspaceId(), targetMember, BaseEntity::delete))
+                .then(projectMembershipPropagationHelper.removeFromAllProjects(
+                    command.workspaceId(), command.targetUserId())))));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.RequireProjectAccess;
@@ -19,40 +18,43 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class UpdateProjectMemberRoleService implements UpdateProjectMemberRoleUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final ProjectMemberPort projectMemberPort;
   private final ProjectAccessHelper projectAccessHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireProjectAccess(role = ProjectRole.ADMIN)
   public Mono<ProjectMember> updateProjectMemberRole(
       UpdateProjectMemberRoleCommand command) {
-    return Mono.zip(
-        projectAccessHelper.findProjectMember(command.requesterId(),
-            command.projectId()),
-        projectAccessHelper.findProjectMember(command.targetUserId(),
-            command.projectId()))
-        .flatMap(tuple -> {
-          ProjectMember requester = tuple.getT1();
-          ProjectMember target = tuple.getT2();
+    return projectAccessHelper.findProjectById(command.projectId())
+        .flatMap(project -> workspaceMutationGuard.protectShared(project.getWorkspaceId(),
+            () -> Mono.zip(
+                projectAccessHelper.findProjectAdminMember(
+                    command.requesterId(), command.projectId()),
+                projectAccessHelper.findProjectMember(command.targetUserId(), command.projectId()))
+                .flatMap(tuple -> validateAndUpdateMemberRole(
+                    command, tuple.getT1(), tuple.getT2()))));
+  }
 
-          projectAccessHelper.validateRoleChangePermission(requester, target, command.role());
-          Mono<Void> workspaceAdminGuard = target.isAdmin() && !command.role().isAdmin()
-              ? projectAccessHelper.validateWorkspaceAdminGuard(command.projectId(), target)
-              : Mono.empty();
+  private Mono<ProjectMember> validateAndUpdateMemberRole(
+      UpdateProjectMemberRoleCommand command,
+      ProjectMember requester,
+      ProjectMember target) {
+    projectAccessHelper.validateRoleChangePermission(requester, target, command.role());
+    Mono<Void> workspaceAdminGuard = target.isAdmin() && !command.role().isAdmin()
+        ? projectAccessHelper.validateWorkspaceAdminGuard(command.projectId(), target)
+        : Mono.empty();
 
-          return workspaceAdminGuard
-              .then(projectMemberPort.updateRoleIfActive(target.getProjectId(),
-                  target.getUserId(), command.role().name()))
-              .filter(updatedRows -> updatedRows > 0)
-              .switchIfEmpty(Mono.error(new DomainException(
-                  ProjectErrorCode.MEMBER_NOT_FOUND)))
-              .then(Mono.fromSupplier(() -> {
-                target.updateRole(command.role());
-                return target;
-              }));
-        })
-        .as(transactionalOperator::transactional);
+    return workspaceAdminGuard
+        .then(projectMemberPort.updateRoleIfActive(target.getProjectId(),
+            target.getUserId(), command.role().name()))
+        .filter(updatedRows -> updatedRows > 0)
+        .switchIfEmpty(Mono.error(new DomainException(
+            ProjectErrorCode.MEMBER_NOT_FOUND)))
+        .then(Mono.fromSupplier(() -> {
+          target.updateRole(command.role());
+          return target;
+        }));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleService.java
@@ -1,7 +1,6 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleCommand;
@@ -17,26 +16,28 @@ import reactor.core.publisher.Mono;
 class UpdateWorkspaceMemberRoleService
     implements UpdateWorkspaceMemberRoleUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final WorkspaceAccessHelper workspaceAccessHelper;
   private final ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+  private final WorkspaceMutationGuard workspaceMutationGuard;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<WorkspaceMember> updateWorkspaceMemberRole(
       UpdateWorkspaceMemberRoleCommand command) {
-    return workspaceAccessHelper.findWorkspaceMember(command.targetUserId(),
-        command.workspaceId())
-        .flatMap(targetMember -> workspaceAccessHelper.modifyMemberWithAdminGuard(
-            command.workspaceId(),
-            targetMember,
-            member -> member.updateRole(command.role())))
-        .flatMap(savedMember -> applyWorkspaceRoleToProjectMemberships(
-            command.workspaceId(),
-            command.targetUserId(),
-            command.role())
-            .thenReturn(savedMember))
-        .as(transactionalOperator::transactional);
+    return workspaceMutationGuard.protectExclusive(command.workspaceId(),
+        () -> workspaceAccessHelper
+            .findWorkspaceAdminMember(command.requesterId(), command.workspaceId())
+            .then(Mono.defer(() -> workspaceAccessHelper.findWorkspaceMember(command.targetUserId(),
+                command.workspaceId()))
+                .flatMap(targetMember -> workspaceAccessHelper.modifyMemberWithAdminGuard(
+                    command.workspaceId(),
+                    targetMember,
+                    member -> member.updateRole(command.role())))
+                .flatMap(savedMember -> applyWorkspaceRoleToProjectMemberships(
+                    command.workspaceId(),
+                    command.targetUserId(),
+                    command.role())
+                    .thenReturn(savedMember))));
   }
 
   private Mono<Void> applyWorkspaceRoleToProjectMemberships(

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceService.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/UpdateWorkspaceService.java
@@ -1,14 +1,15 @@
 package com.schemafy.core.project.application.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.reactive.TransactionalOperator;
 
+import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.access.RequireWorkspaceAccess;
 import com.schemafy.core.project.application.port.in.UpdateWorkspaceCommand;
 import com.schemafy.core.project.application.port.in.UpdateWorkspaceUseCase;
 import com.schemafy.core.project.application.port.in.WorkspaceDetail;
 import com.schemafy.core.project.application.port.out.WorkspacePort;
 import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -17,21 +18,19 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 class UpdateWorkspaceService implements UpdateWorkspaceUseCase {
 
-  private final TransactionalOperator transactionalOperator;
   private final WorkspacePort workspacePort;
   private final WorkspaceAccessHelper workspaceAccessHelper;
 
   @Override
   @RequireWorkspaceAccess(role = WorkspaceRole.ADMIN)
   public Mono<WorkspaceDetail> updateWorkspace(UpdateWorkspaceCommand command) {
-    return workspaceAccessHelper.findWorkspaceOrThrow(command.workspaceId())
-        .flatMap(workspace -> {
-          workspace.update(command.name(), command.description());
-          return workspacePort.save(workspace);
-        })
-        .flatMap(savedWorkspace -> workspaceAccessHelper.buildWorkspaceDetail(
-            savedWorkspace, command.requesterId()))
-        .as(transactionalOperator::transactional);
+    return workspacePort.updateIfActive(command.workspaceId(), command.name(),
+        command.description())
+        .flatMap(updatedRows -> updatedRows > 0
+            ? workspaceAccessHelper.findWorkspaceOrThrow(command.workspaceId())
+            : Mono.error(new DomainException(WorkspaceErrorCode.NOT_FOUND)))
+        .flatMap(updatedWorkspace -> workspaceAccessHelper.buildWorkspaceDetail(
+            updatedWorkspace, command.requesterId()));
   }
 
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceAccessHelper.java
@@ -84,4 +84,14 @@ class WorkspaceAccessHelper {
             new DomainException(WorkspaceErrorCode.MEMBER_NOT_FOUND)));
   }
 
+  Mono<WorkspaceMember> findWorkspaceAdminMember(String userId, String workspaceId) {
+    return workspaceMemberPort
+        .findByWorkspaceIdAndUserIdAndNotDeleted(workspaceId, userId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            WorkspaceErrorCode.ACCESS_DENIED)))
+        .flatMap(member -> member.isAdmin()
+            ? Mono.just(member)
+            : Mono.error(new DomainException(WorkspaceErrorCode.ADMIN_REQUIRED)));
+  }
+
 }

--- a/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceMutationGuard.java
+++ b/apps/backend/core/src/main/java/com/schemafy/core/project/application/service/WorkspaceMutationGuard.java
@@ -1,0 +1,71 @@
+package com.schemafy.core.project.application.service;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+/** 주의: 재시도 시 {@code action}이 다시 실행될 수 있으므로 외부 부수효과를 포함하지 않는다. */
+@Component
+@RequiredArgsConstructor
+public class WorkspaceMutationGuard {
+
+  private static final Logger log = LoggerFactory.getLogger(
+      WorkspaceMutationGuard.class);
+
+  private final WorkspacePort workspacePort;
+  private final TransactionalOperator transactionalOperator;
+
+  public <T> Mono<T> protectShared(String workspaceId, Supplier<Mono<T>> action) {
+    return Mono.defer(() -> lockInShareMode(workspaceId)
+        .then(Mono.defer(action)))
+        .as(transactionalOperator::transactional)
+        .retryWhen(lockRetry(workspaceId));
+  }
+
+  public <T> Mono<T> protectExclusive(String workspaceId, Supplier<Mono<T>> action) {
+    return Mono.defer(() -> lockForUpdate(workspaceId)
+        .then(Mono.defer(action)))
+        .as(transactionalOperator::transactional)
+        .retryWhen(lockRetry(workspaceId));
+  }
+
+  private Mono<Void> lockInShareMode(String workspaceId) {
+    return workspacePort.findByIdAndNotDeletedInShareMode(workspaceId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            WorkspaceErrorCode.NOT_FOUND)))
+        .then();
+  }
+
+  private Mono<Void> lockForUpdate(String workspaceId) {
+    return workspacePort.findByIdAndNotDeletedForUpdate(workspaceId)
+        .switchIfEmpty(Mono.error(new DomainException(
+            WorkspaceErrorCode.NOT_FOUND)))
+        .then();
+  }
+
+  private Retry lockRetry(String workspaceId) {
+    return Retry.backoff(3, Duration.ofMillis(25))
+        .maxBackoff(Duration.ofMillis(250))
+        .jitter(0.5)
+        .filter(PessimisticLockingFailureException.class::isInstance)
+        .onRetryExhaustedThrow((spec, signal) -> signal.failure())
+        .doBeforeRetry(signal -> log.warn(
+            "Retrying workspace mutation transaction: workspaceId={}, retry={}",
+            workspaceId, signal.totalRetries() + 1));
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapterTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/adapter/out/persistence/WorkspacePersistenceAdapterTest.java
@@ -77,4 +77,49 @@ class WorkspacePersistenceAdapterTest {
         .verifyComplete();
   }
 
+  @Test
+  @DisplayName("updateIfActive: 활성 워크스페이스의 이름과 설명만 수정한다")
+  void updateIfActive_updatesActiveWorkspace() {
+    Workspace workspace = sut.save(Workspace.create(UlidGenerator.generate(),
+        "Before", "Description")).block();
+
+    StepVerifier.create(sut.updateIfActive(workspace.getId(), "After", "Updated"))
+        .expectNext(1L)
+        .verifyComplete();
+
+    StepVerifier.create(sut.findByIdAndNotDeleted(workspace.getId()))
+        .assertNext(updated -> {
+          assertThat(updated.getName()).isEqualTo("After");
+          assertThat(updated.getDescription()).isEqualTo("Updated");
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("updateIfActive: 삭제된 워크스페이스는 수정하지 않는다")
+  void updateIfActive_doesNotUpdateDeletedWorkspace() {
+    Workspace workspace = sut.save(Workspace.create(UlidGenerator.generate(),
+        "Before", "Description")).block();
+    workspace.delete();
+
+    StepVerifier.create(sut.save(workspace))
+        .expectNextCount(1)
+        .verifyComplete();
+
+    StepVerifier.create(sut.updateIfActive(workspace.getId(), "After", "Updated"))
+        .expectNext(0L)
+        .verifyComplete();
+
+    StepVerifier.create(sut.findByIdAndNotDeleted(workspace.getId()))
+        .verifyComplete();
+
+    StepVerifier.create(workspaceRepository.findById(workspace.getId()))
+        .assertNext(stored -> {
+          assertThat(stored.getName()).isEqualTo("Before");
+          assertThat(stored.getDescription()).isEqualTo("Description");
+          assertThat(stored.getDeletedAt()).isNotNull();
+        })
+        .verifyComplete();
+  }
+
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AcceptProjectInvitationServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AcceptProjectInvitationServiceTest.java
@@ -1,0 +1,213 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.AcceptProjectInvitationCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.user.application.port.out.FindUserByIdPort;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static com.schemafy.core.project.application.service.MutationGuardTestSupport.invokeGuardAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 초대 수락 서비스 테스트")
+class AcceptProjectInvitationServiceTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String INVITATION_ID = "invitation-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  ProjectMutationGuard projectMutationGuard;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  ProjectInvitationHelper projectInvitationHelper;
+
+  @Mock
+  FindUserByIdPort findUserByIdPort;
+
+  @InjectMocks
+  AcceptProjectInvitationService sut;
+
+  @Test
+  @DisplayName("프로젝트 공유 락을 획득한 트랜잭션에서 초대를 다시 읽고 최신 상태로 멤버십을 만든다")
+  void rereadsInvitationAfterAcquiringSharedProjectLock() {
+    var command = command();
+    var user = user();
+    var lockKeyInvitation = invitation();
+    var freshInvitation = invitation();
+    var savedMember = ProjectMember.create("member-id", PROJECT_ID, USER_ID,
+        ProjectRole.EDITOR);
+    var enteredGuard = new AtomicBoolean();
+
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user));
+    given(projectInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willReturn(Mono.just(lockKeyInvitation), Mono.just(freshInvitation));
+    given(projectMutationGuard.protectChildCreation(eq(PROJECT_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<ProjectMember>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(projectInvitationHelper.findProjectOrThrow(PROJECT_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description"));
+        });
+    given(projectInvitationHelper.checkNotAlreadyProjectMember(PROJECT_ID, USER_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          assertThat((Invitation) invocation.getArgument(0)).isSameAs(freshInvitation);
+          return Mono.just(invocation.getArgument(0));
+        });
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(projectInvitationHelper.saveOrRestoreProjectMember(
+        PROJECT_ID, USER_ID, ProjectRole.EDITOR)).willReturn(Mono.just(savedMember));
+
+    StepVerifier.create(sut.acceptProjectInvitation(command))
+        .expectNext(savedMember)
+        .verifyComplete();
+
+    then(projectMutationGuard).should().protectChildCreation(eq(PROJECT_ID), any());
+    then(projectInvitationHelper).should(org.mockito.Mockito.times(2))
+        .findInvitationOrThrow(INVITATION_ID);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 초대를 프로젝트 수락으로 처리하면 프로젝트 공유 락을 요청하지 않고 타입 불일치 오류를 반환한다")
+  void rejectsWorkspaceInvitationBeforeAcquiringProjectLock() {
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user()));
+    given(projectInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willReturn(Mono.just(Invitation.createWorkspaceInvitation(
+            INVITATION_ID, WORKSPACE_ID, "invitee@test.com", WorkspaceRole.MEMBER,
+            "admin-id")));
+
+    StepVerifier.create(sut.acceptProjectInvitation(command()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_TYPE_MISMATCH);
+        })
+        .verify();
+
+    then(projectMutationGuard).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("프로젝트 멤버 저장의 무결성 위반을 중복 멤버 오류로 변환한다")
+  void mapsDuplicateProjectMemberIntegrityViolation() {
+    prepareAcceptanceWithinProjectLock(new DataIntegrityViolationException("duplicate"));
+
+    StepVerifier.create(sut.acceptProjectInvitation(command()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_DUPLICATE_MEMBERSHIP_PROJECT);
+        })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("프로젝트 초대 저장이 계속 충돌하면 3회 재시도 후 INVITATION_CONCURRENT_PROCESSED로 변환한다")
+  void mapsOptimisticLockFailureAfterRetries() {
+    var attempts = new AtomicInteger();
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user()));
+    given(projectInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willAnswer(invocation -> Mono.just(invitation()));
+    given(projectMutationGuard.protectChildCreation(eq(PROJECT_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(projectInvitationHelper.findProjectOrThrow(PROJECT_ID))
+        .willReturn(Mono.just(Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description")));
+    given(projectInvitationHelper.checkNotAlreadyProjectMember(PROJECT_ID, USER_ID))
+        .willReturn(Mono.empty());
+    given(invitationPort.save(any(Invitation.class))).willAnswer(invocation -> {
+      attempts.incrementAndGet();
+      return Mono.error(new OptimisticLockingFailureException("conflict"));
+    });
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(projectInvitationHelper.saveOrRestoreProjectMember(
+        PROJECT_ID, USER_ID, ProjectRole.EDITOR)).willReturn(Mono.just(
+            ProjectMember.create("member-id", PROJECT_ID, USER_ID, ProjectRole.EDITOR)));
+
+    StepVerifier.create(sut.acceptProjectInvitation(command()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_CONCURRENT_PROCESSED);
+        })
+        .verify();
+
+    assertThat(attempts).hasValue(4);
+  }
+
+  private void prepareAcceptanceWithinProjectLock(Throwable memberSaveError) {
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user()));
+    given(projectInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willAnswer(invocation -> Mono.just(invitation()));
+    given(projectMutationGuard.protectChildCreation(eq(PROJECT_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(projectInvitationHelper.findProjectOrThrow(PROJECT_ID))
+        .willReturn(Mono.just(Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description")));
+    given(projectInvitationHelper.checkNotAlreadyProjectMember(PROJECT_ID, USER_ID))
+        .willReturn(Mono.empty());
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(projectInvitationHelper.saveOrRestoreProjectMember(
+        PROJECT_ID, USER_ID, ProjectRole.EDITOR))
+        .willReturn(Mono.error(memberSaveError));
+  }
+
+  private AcceptProjectInvitationCommand command() {
+    return new AcceptProjectInvitationCommand(INVITATION_ID, USER_ID);
+  }
+
+  private User user() {
+    return User.signUp(USER_ID, "invitee@test.com", "Invitee", "password");
+  }
+
+  private Invitation invitation() {
+    return Invitation.createProjectInvitation(INVITATION_ID, PROJECT_ID, WORKSPACE_ID,
+        "invitee@test.com", ProjectRole.EDITOR, "admin-id");
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AcceptWorkspaceInvitationServiceTest.java
@@ -1,0 +1,219 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.AcceptWorkspaceInvitationCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+import com.schemafy.core.user.application.port.out.FindUserByIdPort;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static com.schemafy.core.project.application.service.MutationGuardTestSupport.invokeGuardAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 초대 수락 서비스")
+class AcceptWorkspaceInvitationServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String INVITATION_ID = "invitation-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  WorkspaceInvitationHelper workspaceInvitationHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @Mock
+  FindUserByIdPort findUserByIdPort;
+
+  @InjectMocks
+  AcceptWorkspaceInvitationService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 초대를 다시 읽고 최신 상태로 멤버십을 만든다")
+  void rereadsInvitationAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new AcceptWorkspaceInvitationCommand(INVITATION_ID, USER_ID);
+    var user = User.signUp(USER_ID, "invitee@test.com", "Invitee", "password");
+    var preLockInvitation = invitation();
+    var freshInvitation = invitation();
+    var savedMember = WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER);
+    var enteredGuard = new AtomicBoolean();
+
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user));
+    given(workspaceInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willReturn(Mono.just(preLockInvitation), Mono.just(freshInvitation));
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<WorkspaceMember>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceInvitationHelper.findWorkspaceOrThrow(WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(Workspace.create(WORKSPACE_ID, "Workspace", "Description"));
+        });
+    given(workspaceInvitationHelper.checkNotAlreadyMember(WORKSPACE_ID, USER_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          assertThat((Invitation) invocation.getArgument(0)).isSameAs(freshInvitation);
+          return Mono.just(invocation.getArgument(0));
+        });
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(workspaceInvitationHelper.saveOrRestoreWorkspaceMember(
+        WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER)).willReturn(Mono.just(savedMember));
+    given(projectMembershipPropagationHelper.syncProjectMembershipsForWorkspaceRole(
+        WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER)).willReturn(Mono.empty());
+
+    StepVerifier.create(sut.acceptWorkspaceInvitation(command))
+        .expectNext(savedMember)
+        .verifyComplete();
+
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+    then(workspaceInvitationHelper).should(org.mockito.Mockito.times(2))
+        .findInvitationOrThrow(INVITATION_ID);
+  }
+
+  @Test
+  @DisplayName("프로젝트 초대를 워크스페이스 수락으로 처리하면 워크스페이스 배타 락을 요청하지 않고 타입 불일치 오류를 반환한다")
+  void rejectsProjectInvitationBeforeAcquiringWorkspaceLock() {
+    var command = new AcceptWorkspaceInvitationCommand(INVITATION_ID, USER_ID);
+    var user = User.signUp(USER_ID, "invitee@test.com", "Invitee", "password");
+    var projectInvitation = Invitation.createProjectInvitation(
+        INVITATION_ID, "project-id", WORKSPACE_ID, "invitee@test.com",
+        com.schemafy.core.project.domain.ProjectRole.EDITOR, "admin-id");
+
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user));
+    given(workspaceInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willReturn(Mono.just(projectInvitation));
+
+    StepVerifier.create(sut.acceptWorkspaceInvitation(command))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_TYPE_MISMATCH);
+        })
+        .verify();
+
+    then(workspaceMutationGuard).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버 저장의 무결성 위반을 중복 멤버 오류로 변환한다")
+  void mapsDuplicateWorkspaceMemberIntegrityViolation() {
+    prepareAcceptanceWithinWorkspaceLock(new DataIntegrityViolationException("duplicate"));
+
+    StepVerifier.create(sut.acceptWorkspaceInvitation(command()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_DUPLICATE_WORKSPACE_MEMBER);
+        })
+        .verify();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 초대 저장이 계속 충돌하면 3회 재시도 후 INVITATION_CONCURRENT_PROCESSED로 변환한다")
+  void mapsOptimisticLockFailureAfterRetries() {
+    var attempts = new AtomicInteger();
+    var user = User.signUp(USER_ID, "invitee@test.com", "Invitee", "password");
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user));
+    given(workspaceInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willAnswer(invocation -> Mono.just(invitation()));
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(workspaceInvitationHelper.findWorkspaceOrThrow(WORKSPACE_ID))
+        .willReturn(Mono.just(Workspace.create(WORKSPACE_ID, "Workspace", "Description")));
+    given(workspaceInvitationHelper.checkNotAlreadyMember(WORKSPACE_ID, USER_ID))
+        .willReturn(Mono.empty());
+    given(invitationPort.save(any(Invitation.class))).willAnswer(invocation -> {
+      attempts.incrementAndGet();
+      return Mono.error(new OptimisticLockingFailureException("conflict"));
+    });
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(workspaceInvitationHelper.saveOrRestoreWorkspaceMember(
+        WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER))
+        .willReturn(Mono.just(WorkspaceMember.create(
+            "member-id", WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER)));
+
+    StepVerifier.create(sut.acceptWorkspaceInvitation(command()))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(ProjectErrorCode.INVITATION_CONCURRENT_PROCESSED);
+        })
+        .verify();
+
+    assertThat(attempts).hasValue(4);
+  }
+
+  private void prepareAcceptanceWithinWorkspaceLock(Throwable memberSaveError) {
+    var user = User.signUp(USER_ID, "invitee@test.com", "Invitee", "password");
+    given(findUserByIdPort.findUserById(USER_ID)).willReturn(Mono.just(user));
+    given(workspaceInvitationHelper.findInvitationOrThrow(INVITATION_ID))
+        .willAnswer(invocation -> Mono.just(invitation()));
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(workspaceInvitationHelper.findWorkspaceOrThrow(WORKSPACE_ID))
+        .willReturn(Mono.just(Workspace.create(WORKSPACE_ID, "Workspace", "Description")));
+    given(workspaceInvitationHelper.checkNotAlreadyMember(WORKSPACE_ID, USER_ID))
+        .willReturn(Mono.empty());
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    given(invitationPort.updateStatusByTargetAndEmail(any(), any(), any(), any(), any(), any()))
+        .willReturn(Mono.just(0L));
+    given(workspaceInvitationHelper.saveOrRestoreWorkspaceMember(
+        WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER))
+        .willReturn(Mono.error(memberSaveError));
+  }
+
+  private AcceptWorkspaceInvitationCommand command() {
+    return new AcceptWorkspaceInvitationCommand(INVITATION_ID, USER_ID);
+  }
+
+  private Invitation invitation() {
+    return Invitation.createWorkspaceInvitation(INVITATION_ID, WORKSPACE_ID,
+        "invitee@test.com", WorkspaceRole.MEMBER, "admin-id");
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AddWorkspaceMemberServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/AddWorkspaceMemberServiceTest.java
@@ -1,0 +1,130 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.AddWorkspaceMemberCommand;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 멤버 추가 서비스")
+class AddWorkspaceMemberServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  UlidGeneratorPort ulidGeneratorPort;
+
+  @Mock
+  WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @InjectMocks
+  AddWorkspaceMemberService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 대상 멤버의 최신 상태를 조회하고 프로젝트 멤버십을 동기화한다")
+  void readsLatestMemberAndSynchronizesProjectsAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new AddWorkspaceMemberCommand(
+        WORKSPACE_ID, "target@test.com", WorkspaceRole.MEMBER, "requester-id");
+    var targetUser = User.signUp(USER_ID, command.email(), "Target", "password");
+    var enteredGuard = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceAccessHelper.findUserByEmailOrThrow(any()))
+        .willReturn(Mono.just(targetUser));
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+            "requester-id", WorkspaceRole.ADMIN)));
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<WorkspaceMember>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceMemberPort.findLatestByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(ulidGeneratorPort.generate()).willReturn("workspace-member-id");
+    given(workspaceMemberPort.save(any(WorkspaceMember.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    given(projectMembershipPropagationHelper.syncProjectMembershipsForWorkspaceRole(
+        WORKSPACE_ID, USER_ID, WorkspaceRole.MEMBER)).willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    StepVerifier.create(sut.addWorkspaceMember(command))
+        .assertNext(member -> {
+          assertThat(member.getUserId()).isEqualTo(USER_ID);
+          assertThat(member.getRoleAsEnum()).isEqualTo(WorkspaceRole.MEMBER);
+        })
+        .verifyComplete();
+
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("잠금 획득 뒤 요청자가 워크스페이스에서 제거되면 대상 사용자를 조회하거나 멤버를 추가하지 않는다")
+  void rejectsRemovedRequesterAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new AddWorkspaceMemberCommand(
+        WORKSPACE_ID, "target@test.com", WorkspaceRole.MEMBER, "requester-id");
+    var requesterWasRemoved = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<WorkspaceMember>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasRemoved.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasRemoved.get()
+            ? Mono.error(new com.schemafy.core.common.exception.DomainException(
+                WorkspaceErrorCode.ACCESS_DENIED))
+            : Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+                "requester-id", WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.addWorkspaceMember(command))
+        .expectErrorMatches(com.schemafy.core.common.exception.DomainException
+            .hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+
+    then(workspaceAccessHelper).should(org.mockito.Mockito.never())
+        .findUserByEmailOrThrow(any());
+    then(workspaceMemberPort).shouldHaveNoInteractions();
+    then(ulidGeneratorPort).shouldHaveNoInteractions();
+    then(projectMembershipPropagationHelper).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateProjectInvitationServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateProjectInvitationServiceTest.java
@@ -1,0 +1,93 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.CreateProjectInvitationCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 초대 생성 서비스 테스트")
+class CreateProjectInvitationServiceTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String WORKSPACE_ID = "workspace-id";
+
+  @Mock
+  ProjectMutationGuard projectMutationGuard;
+
+  @Mock
+  UlidGeneratorPort ulidGeneratorPort;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  ProjectInvitationHelper projectInvitationHelper;
+
+  @InjectMocks
+  CreateProjectInvitationService sut;
+
+  @Test
+  @DisplayName("프로젝트 공유 락을 획득한 트랜잭션에서 최신 프로젝트와 중복 상태를 확인한 뒤 초대를 저장한다")
+  void createsInvitationAfterAcquiringSharedProjectLock() {
+    var command = new CreateProjectInvitationCommand(
+        PROJECT_ID, "invitee@test.com", ProjectRole.EDITOR, "requester-id");
+    var enteredGuard = new AtomicBoolean();
+
+    given(projectMutationGuard.protectChildCreation(eq(PROJECT_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Invitation>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(projectInvitationHelper.findProjectOrThrow(PROJECT_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description"));
+        });
+    given(projectInvitationHelper.checkNotAlreadyProjectMemberByEmail(eq(PROJECT_ID), any()))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(projectInvitationHelper.checkDuplicatePendingInvitation(eq(PROJECT_ID), any()))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(ulidGeneratorPort.generate()).willReturn("invitation-id");
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+    StepVerifier.create(sut.createProjectInvitation(command))
+        .assertNext(invitation -> {
+          assertThat(invitation.getId()).isEqualTo("invitation-id");
+          assertThat(invitation.getProjectId()).isEqualTo(PROJECT_ID);
+        })
+        .verifyComplete();
+
+    then(projectMutationGuard).should().protectChildCreation(eq(PROJECT_ID), any());
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateProjectServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateProjectServiceTest.java
@@ -1,0 +1,137 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.CreateProjectCommand;
+import com.schemafy.core.project.application.port.in.ProjectDetail;
+import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 생성 서비스")
+class CreateProjectServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String REQUESTER_ID = "requester-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  UlidGeneratorPort ulidGeneratorPort;
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  ProjectMemberPort projectMemberPort;
+
+  @Mock
+  ProjectAccessHelper projectAccessHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @InjectMocks
+  CreateProjectService sut;
+
+  @Test
+  @DisplayName("워크스페이스 공유 락을 획득한 트랜잭션에서 프로젝트 생성과 멤버 전파를 수행한다")
+  void createsProjectAndPropagatesMembersAfterAcquiringSharedWorkspaceLock() {
+    var command = new CreateProjectCommand(
+        WORKSPACE_ID, "Project", "Description", REQUESTER_ID);
+    var enteredGuard = new AtomicBoolean();
+
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<ProjectDetail>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember(REQUESTER_ID, WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create(
+            "requester-member-id", WORKSPACE_ID, REQUESTER_ID, WorkspaceRole.ADMIN)));
+    given(ulidGeneratorPort.generate()).willReturn("project-id", "member-id");
+    given(projectPort.save(any(Project.class))).willAnswer(invocation -> {
+      assertThat(enteredGuard).isTrue();
+      return Mono.just(invocation.getArgument(0));
+    });
+    given(projectMemberPort.save(any(ProjectMember.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    given(projectMembershipPropagationHelper.propagateWorkspaceMembersToProject(
+        "project-id", WORKSPACE_ID, REQUESTER_ID)).willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(projectAccessHelper.buildProjectDetail(any(Project.class), eq(REQUESTER_ID)))
+        .willAnswer(invocation -> Mono.just(new ProjectDetail(
+            invocation.getArgument(0), ProjectRole.ADMIN.name())));
+
+    StepVerifier.create(sut.createProject(command))
+        .expectNextCount(1)
+        .verifyComplete();
+
+    then(workspaceMutationGuard).should().protectShared(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("락 획득 뒤 요청자가 워크스페이스에서 제거되면 프로젝트를 생성하지 않는다")
+  void rejectsRemovedRequesterAfterAcquiringSharedWorkspaceLock() {
+    var command = new CreateProjectCommand(
+        WORKSPACE_ID, "Project", "Description", REQUESTER_ID);
+    var requesterWasRemoved = new AtomicBoolean();
+
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<ProjectDetail>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasRemoved.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember(REQUESTER_ID, WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasRemoved.get()
+            ? Mono.error(new DomainException(WorkspaceErrorCode.ACCESS_DENIED))
+            : Mono.just(WorkspaceMember.create(
+                "requester-member-id", WORKSPACE_ID, REQUESTER_ID, WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.createProject(command))
+        .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+
+    then(ulidGeneratorPort).shouldHaveNoInteractions();
+    then(projectPort).shouldHaveNoInteractions();
+    then(projectMemberPort).shouldHaveNoInteractions();
+    then(projectMembershipPropagationHelper).shouldHaveNoInteractions();
+    then(projectAccessHelper).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/CreateWorkspaceInvitationServiceTest.java
@@ -1,0 +1,132 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.CreateWorkspaceInvitationCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.domain.Invitation;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.ulid.application.port.out.UlidGeneratorPort;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 초대 생성 서비스")
+class CreateWorkspaceInvitationServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  UlidGeneratorPort ulidGeneratorPort;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  WorkspaceInvitationHelper workspaceInvitationHelper;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @InjectMocks
+  CreateWorkspaceInvitationService sut;
+
+  @Test
+  @DisplayName("워크스페이스 공유 락을 획득한 트랜잭션에서 최신 워크스페이스와 중복 상태를 확인한 뒤 초대를 저장한다")
+  void createsInvitationAfterAcquiringSharedWorkspaceLock() {
+    var command = new CreateWorkspaceInvitationCommand(
+        WORKSPACE_ID, "invitee@test.com", WorkspaceRole.MEMBER, "requester-id");
+    var enteredGuard = new AtomicBoolean();
+
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Invitation>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+            "requester-id", WorkspaceRole.ADMIN)));
+    given(workspaceInvitationHelper.findWorkspaceOrThrow(WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(Workspace.create(WORKSPACE_ID, "Workspace", "Description"));
+        });
+    given(workspaceInvitationHelper.checkNotAlreadyMemberByEmail(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(workspaceInvitationHelper.checkDuplicatePendingInvitation(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(ulidGeneratorPort.generate()).willReturn("invitation-id");
+    given(invitationPort.save(any(Invitation.class)))
+        .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+    StepVerifier.create(sut.createWorkspaceInvitation(command))
+        .assertNext(invitation -> {
+          assertThat(invitation.getId()).isEqualTo("invitation-id");
+          assertThat(invitation.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
+        })
+        .verifyComplete();
+
+    then(workspaceMutationGuard).should().protectShared(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("잠금 획득 뒤 요청자가 관리자가 아니면 초대 중복을 확인하거나 저장하지 않는다")
+  void rejectsNonAdminRequesterAfterAcquiringSharedWorkspaceLock() {
+    var command = new CreateWorkspaceInvitationCommand(
+        WORKSPACE_ID, "invitee@test.com", WorkspaceRole.MEMBER, "requester-id");
+    var requesterWasDemoted = new AtomicBoolean();
+
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<Invitation>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasDemoted.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasDemoted.get()
+            ? Mono.error(new com.schemafy.core.common.exception.DomainException(
+                WorkspaceErrorCode.ADMIN_REQUIRED))
+            : Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+                "requester-id", WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.createWorkspaceInvitation(command))
+        .expectErrorMatches(com.schemafy.core.common.exception.DomainException
+            .hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
+        .verify();
+
+    then(workspaceInvitationHelper).shouldHaveNoInteractions();
+    then(ulidGeneratorPort).shouldHaveNoInteractions();
+    then(invitationPort).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/DeleteWorkspaceServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/DeleteWorkspaceServiceTest.java
@@ -1,0 +1,134 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.DeleteWorkspaceCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.InvitationType;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 삭제 서비스")
+class DeleteWorkspaceServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  WorkspacePort workspacePort;
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @Mock
+  ProjectCascadeHelper projectCascadeHelper;
+
+  @InjectMocks
+  DeleteWorkspaceService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 워크스페이스와 각 프로젝트를 삭제한다")
+  void deletesWorkspaceAndProjectsAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new DeleteWorkspaceCommand(WORKSPACE_ID, "requester-id");
+    var workspace = Workspace.create(WORKSPACE_ID, "Workspace", "Description");
+    var project = Project.create("project-id", WORKSPACE_ID, "Project", "Description");
+    var enteredGuard = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+            "requester-id", WorkspaceRole.ADMIN)));
+    given(workspaceAccessHelper.findWorkspaceOrThrow(WORKSPACE_ID)).willAnswer(invocation -> {
+      assertThat(enteredGuard).isTrue();
+      return Mono.just(workspace);
+    });
+    given(workspacePort.save(workspace)).willReturn(Mono.just(workspace));
+    given(projectPort.findByWorkspaceId(WORKSPACE_ID)).willReturn(Flux.just(project));
+    given(projectCascadeHelper.softDeleteProjectCascade(project)).willReturn(Mono.empty());
+    given(workspaceMemberPort.softDeleteByWorkspaceId(WORKSPACE_ID)).willReturn(Mono.empty());
+    given(invitationPort.softDeleteByTarget(InvitationType.WORKSPACE.name(), WORKSPACE_ID))
+        .willReturn(Mono.just(0L));
+
+    StepVerifier.create(sut.deleteWorkspace(command)).verifyComplete();
+
+    assertThat(workspace.isDeleted()).isTrue();
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+    then(projectCascadeHelper).should().softDeleteProjectCascade(project);
+  }
+
+  @Test
+  @DisplayName("잠금 획득 뒤 요청자가 관리자가 아니면 워크스페이스를 삭제하지 않는다")
+  void rejectsNonAdminRequesterAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new DeleteWorkspaceCommand(WORKSPACE_ID, "requester-id");
+    var requesterWasDemoted = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasDemoted.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasDemoted.get()
+            ? Mono.error(new com.schemafy.core.common.exception.DomainException(
+                WorkspaceErrorCode.ADMIN_REQUIRED))
+            : Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+                "requester-id", WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.deleteWorkspace(command))
+        .expectErrorMatches(com.schemafy.core.common.exception.DomainException
+            .hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
+        .verify();
+
+    then(workspaceAccessHelper).should(org.mockito.Mockito.never())
+        .findWorkspaceOrThrow(any());
+    then(workspacePort).shouldHaveNoInteractions();
+    then(projectPort).shouldHaveNoInteractions();
+    then(workspaceMemberPort).shouldHaveNoInteractions();
+    then(invitationPort).shouldHaveNoInteractions();
+    then(projectCascadeHelper).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveWorkspaceServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/LeaveWorkspaceServiceTest.java
@@ -1,0 +1,138 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.LeaveWorkspaceCommand;
+import com.schemafy.core.project.application.port.out.InvitationPort;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.InvitationType;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static com.schemafy.core.project.application.service.MutationGuardTestSupport.invokeGuardAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 탈퇴 서비스")
+class LeaveWorkspaceServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  WorkspacePort workspacePort;
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  InvitationPort invitationPort;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @Mock
+  ProjectCascadeHelper projectCascadeHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @InjectMocks
+  LeaveWorkspaceService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 최신 멤버 수를 확인하고 일반 멤버를 제거한다")
+  void removesMemberAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new LeaveWorkspaceCommand(WORKSPACE_ID, USER_ID);
+    var member = WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER);
+    var enteredGuard = new AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceMember(USER_ID, WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(member);
+        });
+    given(workspaceMemberPort.countByWorkspaceIdAndNotDeleted(WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(2L);
+        });
+    given(workspaceAccessHelper.modifyMemberWithAdminGuard(eq(WORKSPACE_ID), eq(member), any()))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(member);
+        });
+    given(projectMembershipPropagationHelper.removeFromAllProjects(WORKSPACE_ID, USER_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+
+    StepVerifier.create(sut.leaveWorkspace(command)).verifyComplete();
+
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("마지막 활성 멤버가 탈퇴하면 워크스페이스 배타 락을 획득한 트랜잭션에서 워크스페이스와 하위 항목을 삭제한다")
+  void deletesWorkspaceWhenLastActiveMemberLeaves() {
+    var command = new LeaveWorkspaceCommand(WORKSPACE_ID, USER_ID);
+    var member = WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER);
+    var workspace = Workspace.create(WORKSPACE_ID, "Workspace", "Description");
+    var project = Project.create("project-id", WORKSPACE_ID, "Project", "Description");
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(workspaceAccessHelper.findWorkspaceMember(USER_ID, WORKSPACE_ID))
+        .willReturn(Mono.just(member));
+    given(workspaceMemberPort.countByWorkspaceIdAndNotDeleted(WORKSPACE_ID))
+        .willReturn(Mono.just(1L));
+    given(workspaceAccessHelper.findWorkspaceOrThrow(WORKSPACE_ID)).willReturn(Mono.just(workspace));
+    given(workspacePort.save(workspace)).willReturn(Mono.just(workspace));
+    given(projectPort.findByWorkspaceId(WORKSPACE_ID)).willReturn(Flux.just(project));
+    given(projectCascadeHelper.softDeleteProjectCascade(project)).willReturn(Mono.empty());
+    given(workspaceMemberPort.softDeleteByWorkspaceId(WORKSPACE_ID)).willReturn(Mono.empty());
+    given(invitationPort.softDeleteByTarget(InvitationType.WORKSPACE.name(), WORKSPACE_ID))
+        .willReturn(Mono.just(0L));
+
+    StepVerifier.create(sut.leaveWorkspace(command)).verifyComplete();
+
+    assertThat(workspace.isDeleted()).isTrue();
+    then(projectCascadeHelper).should().softDeleteProjectCascade(project);
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/MutationGuardTestSupport.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/MutationGuardTestSupport.java
@@ -1,0 +1,20 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Supplier;
+
+import org.mockito.stubbing.Answer;
+
+import reactor.core.publisher.Mono;
+
+final class MutationGuardTestSupport {
+
+  private MutationGuardTestSupport() {}
+
+  static <T> Answer<Mono<T>> invokeGuardAction() {
+    return invocation -> {
+      Supplier<Mono<T>> action = invocation.getArgument(1);
+      return action.get();
+    };
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectMutationGuardTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("프로젝트 변경 보호 테스트")
+@DisplayName("프로젝트 변경 잠금과 재시도")
 class ProjectMutationGuardTest {
 
   @Mock

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectServiceTransactionBoundaryTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/ProjectServiceTransactionBoundaryTest.java
@@ -1,0 +1,36 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.stream.Stream;
+
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("프로젝트 서비스 트랜잭션 경계")
+class ProjectServiceTransactionBoundaryTest {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("servicesUsingLockTransaction")
+  @DisplayName("잠금 트랜잭션과 별도의 트랜잭션 경계를 만들지 않는다")
+  void doesNotCreateSeparateTransactionBoundary(Class<?> serviceType) {
+    assertThat(serviceType.getDeclaredConstructors())
+        .allSatisfy(constructor -> assertThat(constructor.getParameterTypes())
+            .doesNotContain(TransactionalOperator.class));
+  }
+
+  private static Stream<Class<?>> servicesUsingLockTransaction() {
+    return Stream.of(
+        AcceptProjectInvitationService.class,
+        AcceptWorkspaceInvitationService.class,
+        CreateProjectInvitationService.class,
+        CreateWorkspaceInvitationService.class,
+        DeleteWorkspaceService.class,
+        LeaveWorkspaceService.class,
+        RemoveProjectMemberService.class);
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/RemoveProjectMemberServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/RemoveProjectMemberServiceTest.java
@@ -1,0 +1,150 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.RemoveProjectMemberCommand;
+import com.schemafy.core.project.domain.Project;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.exception.ProjectErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static com.schemafy.core.project.application.service.MutationGuardTestSupport.invokeGuardAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("프로젝트 멤버 제거 서비스 테스트")
+class RemoveProjectMemberServiceTest {
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String TARGET_ID = "target-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  ProjectAccessHelper projectAccessHelper;
+
+  @InjectMocks
+  RemoveProjectMemberService sut;
+
+  @Test
+  @DisplayName("워크스페이스 공유 락을 획득한 트랜잭션에서 최신 대상 멤버를 읽고 제거한다")
+  void removesCurrentMemberAfterAcquiringSharedWorkspaceLock() {
+    var command = new RemoveProjectMemberCommand(PROJECT_ID, TARGET_ID, "requester-id");
+    var project = Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description");
+    var target = ProjectMember.create("member-id", PROJECT_ID, TARGET_ID, ProjectRole.EDITOR);
+    var enteredGuard = new AtomicBoolean();
+
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(target);
+        });
+    given(projectAccessHelper.findProjectAdminMember("requester-id", PROJECT_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(ProjectMember.create("requester-member", PROJECT_ID, "requester-id",
+              ProjectRole.ADMIN));
+        });
+    given(projectAccessHelper.validateWorkspaceAdminGuard(PROJECT_ID, target))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    given(projectAccessHelper.softDeleteMember(target))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+
+    StepVerifier.create(sut.removeProjectMember(command)).verifyComplete();
+
+    then(workspaceMutationGuard).should().protectShared(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("조건부 삭제 결과가 0건이어도 멱등적으로 완료한다")
+  void completesWhenConditionalDeleteAffectsNoRows() {
+    var command = new RemoveProjectMemberCommand(PROJECT_ID, TARGET_ID, "requester-id");
+    var project = Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description");
+    var target = ProjectMember.create("member-id", PROJECT_ID, TARGET_ID, ProjectRole.EDITOR);
+
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID)).willReturn(Mono.just(target));
+    given(projectAccessHelper.findProjectAdminMember("requester-id", PROJECT_ID))
+        .willReturn(Mono.just(ProjectMember.create("requester-member", PROJECT_ID, "requester-id",
+            ProjectRole.ADMIN)));
+    given(projectAccessHelper.validateWorkspaceAdminGuard(PROJECT_ID, target)).willReturn(Mono.empty());
+    given(projectAccessHelper.softDeleteMember(target)).willReturn(Mono.empty());
+
+    StepVerifier.create(sut.removeProjectMember(command)).verifyComplete();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 공유 락 대기 중 요청자가 비관리자로 변경되면 대상 멤버를 제거하지 않는다")
+  void rejectsDemotedRequesterAfterAcquiringSharedWorkspaceLock() {
+    var command = new RemoveProjectMemberCommand(PROJECT_ID, TARGET_ID, "requester-id");
+    var project = Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description");
+
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectAdminMember("requester-id", PROJECT_ID))
+        .willReturn(Mono.error(new DomainException(ProjectErrorCode.ADMIN_REQUIRED)));
+
+    StepVerifier.create(sut.removeProjectMember(command))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
+        .verify();
+
+    then(projectAccessHelper).should(never()).validateWorkspaceAdminGuard(eq(PROJECT_ID), any());
+    then(projectAccessHelper).should(never()).softDeleteMember(any());
+  }
+
+  @Test
+  @DisplayName("워크스페이스 공유 락 대기 중 요청자 멤버십이 삭제되면 대상 멤버를 제거하지 않는다")
+  void rejectsRemovedRequesterAfterAcquiringSharedWorkspaceLock() {
+    var command = new RemoveProjectMemberCommand(PROJECT_ID, TARGET_ID, "requester-id");
+    var project = Project.create(PROJECT_ID, WORKSPACE_ID, "Project", "Description");
+
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(eq(WORKSPACE_ID), any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectAdminMember("requester-id", PROJECT_ID))
+        .willReturn(Mono.error(new DomainException(ProjectErrorCode.ACCESS_DENIED)));
+
+    StepVerifier.create(sut.removeProjectMember(command))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+        .verify();
+
+    then(projectAccessHelper).should(never()).validateWorkspaceAdminGuard(eq(PROJECT_ID), any());
+    then(projectAccessHelper).should(never()).softDeleteMember(any());
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/RemoveWorkspaceMemberServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/RemoveWorkspaceMemberServiceTest.java
@@ -1,0 +1,114 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.RemoveWorkspaceMemberCommand;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 멤버 제거 서비스")
+class RemoveWorkspaceMemberServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String TARGET_USER_ID = "target-user-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @InjectMocks
+  RemoveWorkspaceMemberService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 대상과 마지막 관리자 조건을 확인하고 프로젝트 멤버십을 제거한다")
+  void removesMemberAndProjectMembershipsAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new RemoveWorkspaceMemberCommand(
+        WORKSPACE_ID, TARGET_USER_ID, "requester-id");
+    var targetMember = WorkspaceMember.create(
+        "member-id", WORKSPACE_ID, TARGET_USER_ID, WorkspaceRole.MEMBER);
+    var enteredGuard = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+            "requester-id", WorkspaceRole.ADMIN)));
+    given(workspaceAccessHelper.findWorkspaceMember(TARGET_USER_ID, WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(targetMember);
+        });
+    given(workspaceAccessHelper.modifyMemberWithAdminGuard(eq(WORKSPACE_ID),
+        eq(targetMember), any())).willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(targetMember);
+        });
+    given(projectMembershipPropagationHelper.removeFromAllProjects(WORKSPACE_ID, TARGET_USER_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    StepVerifier.create(sut.removeWorkspaceMember(command)).verifyComplete();
+
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("잠금 획득 뒤 요청자가 관리자가 아니면 대상 멤버를 조회하거나 제거하지 않는다")
+  void rejectsNonAdminRequesterAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new RemoveWorkspaceMemberCommand(WORKSPACE_ID, TARGET_USER_ID, "requester-id");
+    var requesterWasDemoted = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<Void>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasDemoted.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasDemoted.get()
+            ? Mono.error(new com.schemafy.core.common.exception.DomainException(
+                WorkspaceErrorCode.ADMIN_REQUIRED))
+            : Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+                "requester-id", WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.removeWorkspaceMember(command))
+        .expectErrorMatches(com.schemafy.core.common.exception.DomainException
+            .hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
+        .verify();
+
+    then(workspaceAccessHelper).should(org.mockito.Mockito.never())
+        .findWorkspaceMember(any(), any());
+    then(projectMembershipPropagationHelper).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateProjectMemberRoleServiceTest.java
@@ -1,6 +1,6 @@
 package com.schemafy.core.project.application.service;
 
-import org.springframework.transaction.reactive.TransactionalOperator;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.port.in.UpdateProjectMemberRoleCommand;
 import com.schemafy.core.project.application.port.out.ProjectMemberPort;
+import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectMember;
 import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.exception.ProjectErrorCode;
@@ -19,10 +20,10 @@ import com.schemafy.core.project.domain.exception.ProjectErrorCode;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static com.schemafy.core.project.application.service.MutationGuardTestSupport.invokeGuardAction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +35,7 @@ class UpdateProjectMemberRoleServiceTest {
   private static final String TARGET_ID = "target-id";
 
   @Mock
-  TransactionalOperator transactionalOperator;
+  WorkspaceMutationGuard workspaceMutationGuard;
 
   @Mock
   ProjectMemberPort projectMemberPort;
@@ -54,11 +55,26 @@ class UpdateProjectMemberRoleServiceTest {
         TARGET_ID, ProjectRole.VIEWER);
     UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
         PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
-    stubTransactionPassThrough();
-    given(projectAccessHelper.findProjectMember(REQUESTER_ID, PROJECT_ID))
-        .willReturn(Mono.just(requester));
+    var project = Project.create(PROJECT_ID, "workspace-id", "Project", "Description");
+    var enteredGuard = new java.util.concurrent.atomic.AtomicBoolean();
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(org.mockito.ArgumentMatchers.eq("workspace-id"),
+        org.mockito.ArgumentMatchers.any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<ProjectMember>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(projectAccessHelper.findProjectAdminMember(REQUESTER_ID, PROJECT_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(requester);
+        });
     given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
-        .willReturn(Mono.just(target));
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(target);
+        });
     given(projectMemberPort.updateRoleIfActive(PROJECT_ID, TARGET_ID,
         ProjectRole.EDITOR.name())).willReturn(Mono.just(1L));
 
@@ -70,6 +86,8 @@ class UpdateProjectMemberRoleServiceTest {
     then(projectMemberPort).should().updateRoleIfActive(PROJECT_ID, TARGET_ID,
         ProjectRole.EDITOR.name());
     then(projectMemberPort).should(never()).save(target);
+    then(workspaceMutationGuard).should().protectShared(
+        org.mockito.ArgumentMatchers.eq("workspace-id"), org.mockito.ArgumentMatchers.any());
   }
 
   @Test
@@ -81,8 +99,12 @@ class UpdateProjectMemberRoleServiceTest {
         TARGET_ID, ProjectRole.VIEWER);
     UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
         PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
-    stubTransactionPassThrough();
-    given(projectAccessHelper.findProjectMember(REQUESTER_ID, PROJECT_ID))
+    var project = Project.create(PROJECT_ID, "workspace-id", "Project", "Description");
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(org.mockito.ArgumentMatchers.eq("workspace-id"),
+        org.mockito.ArgumentMatchers.any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectAdminMember(REQUESTER_ID, PROJECT_ID))
         .willReturn(Mono.just(requester));
     given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
         .willReturn(Mono.just(target));
@@ -101,10 +123,54 @@ class UpdateProjectMemberRoleServiceTest {
     then(projectMemberPort).should(never()).save(target);
   }
 
-  private void stubTransactionPassThrough() {
-    lenient().when(transactionalOperator.<ProjectMember>transactional(
-        org.mockito.ArgumentMatchers.<Mono<ProjectMember>>any()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+  @Test
+  @DisplayName("워크스페이스 공유 락 대기 중 요청자가 비관리자로 변경되면 역할을 변경하지 않는다")
+  void rejectsDemotedRequesterAfterAcquiringSharedWorkspaceLock() {
+    ProjectMember target = ProjectMember.create("target-member", PROJECT_ID,
+        TARGET_ID, ProjectRole.VIEWER);
+    UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
+    var project = Project.create(PROJECT_ID, "workspace-id", "Project", "Description");
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(org.mockito.ArgumentMatchers.eq("workspace-id"),
+        org.mockito.ArgumentMatchers.any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectAdminMember(REQUESTER_ID, PROJECT_ID))
+        .willReturn(Mono.error(new DomainException(ProjectErrorCode.ADMIN_REQUIRED)));
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
+        .willReturn(Mono.just(target));
+
+    StepVerifier.create(sut.updateProjectMemberRole(command))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ADMIN_REQUIRED))
+        .verify();
+
+    then(projectMemberPort).should(never()).updateRoleIfActive(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR.name());
+  }
+
+  @Test
+  @DisplayName("워크스페이스 공유 락 대기 중 요청자 멤버십이 삭제되면 역할을 변경하지 않는다")
+  void rejectsRemovedRequesterAfterAcquiringSharedWorkspaceLock() {
+    ProjectMember target = ProjectMember.create("target-member", PROJECT_ID,
+        TARGET_ID, ProjectRole.VIEWER);
+    UpdateProjectMemberRoleCommand command = new UpdateProjectMemberRoleCommand(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR, REQUESTER_ID);
+    var project = Project.create(PROJECT_ID, "workspace-id", "Project", "Description");
+    given(projectAccessHelper.findProjectById(PROJECT_ID)).willReturn(Mono.just(project));
+    given(workspaceMutationGuard.protectShared(org.mockito.ArgumentMatchers.eq("workspace-id"),
+        org.mockito.ArgumentMatchers.any()))
+        .willAnswer(invokeGuardAction());
+    given(projectAccessHelper.findProjectAdminMember(REQUESTER_ID, PROJECT_ID))
+        .willReturn(Mono.error(new DomainException(ProjectErrorCode.ACCESS_DENIED)));
+    given(projectAccessHelper.findProjectMember(TARGET_ID, PROJECT_ID))
+        .willReturn(Mono.just(target));
+
+    StepVerifier.create(sut.updateProjectMemberRole(command))
+        .expectErrorMatches(DomainException.hasErrorCode(ProjectErrorCode.ACCESS_DENIED))
+        .verify();
+
+    then(projectMemberPort).should(never()).updateRoleIfActive(
+        PROJECT_ID, TARGET_ID, ProjectRole.EDITOR.name());
   }
 
 }

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateWorkspaceMemberRoleServiceTest.java
@@ -1,0 +1,120 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleCommand;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 멤버 역할 변경 서비스")
+class UpdateWorkspaceMemberRoleServiceTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String TARGET_USER_ID = "target-user-id";
+
+  @Mock
+  WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @Mock
+  ProjectMembershipPropagationHelper projectMembershipPropagationHelper;
+
+  @InjectMocks
+  UpdateWorkspaceMemberRoleService sut;
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 트랜잭션에서 대상과 마지막 관리자 조건을 확인하고 프로젝트 역할을 반영한다")
+  void updatesRoleAndProjectMembershipsAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new UpdateWorkspaceMemberRoleCommand(
+        WORKSPACE_ID, TARGET_USER_ID, WorkspaceRole.MEMBER, "requester-id");
+    var targetMember = WorkspaceMember.create(
+        "member-id", WORKSPACE_ID, TARGET_USER_ID, WorkspaceRole.ADMIN);
+    var enteredGuard = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          enteredGuard.set(true);
+          Supplier<Mono<WorkspaceMember>> action = invocation.getArgument(1);
+          return action.get();
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willReturn(Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+            "requester-id", WorkspaceRole.ADMIN)));
+    given(workspaceAccessHelper.findWorkspaceMember(TARGET_USER_ID, WORKSPACE_ID))
+        .willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.just(targetMember);
+        });
+    given(workspaceAccessHelper.modifyMemberWithAdminGuard(eq(WORKSPACE_ID),
+        eq(targetMember), any())).willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          Consumer<WorkspaceMember> action = invocation.getArgument(2);
+          action.accept(targetMember);
+          return Mono.just(targetMember);
+        });
+    given(projectMembershipPropagationHelper.updateActiveProjectMembershipRoles(
+        WORKSPACE_ID, TARGET_USER_ID, WorkspaceRole.MEMBER)).willAnswer(invocation -> {
+          assertThat(enteredGuard).isTrue();
+          return Mono.empty();
+        });
+    StepVerifier.create(sut.updateWorkspaceMemberRole(command))
+        .assertNext(member -> assertThat(member.getRoleAsEnum()).isEqualTo(WorkspaceRole.MEMBER))
+        .verifyComplete();
+
+    then(workspaceMutationGuard).should().protectExclusive(eq(WORKSPACE_ID), any());
+  }
+
+  @Test
+  @DisplayName("잠금 획득 뒤 요청자가 워크스페이스에서 제거되면 대상 역할을 변경하지 않는다")
+  void rejectsRemovedRequesterAfterAcquiringExclusiveWorkspaceLock() {
+    var command = new UpdateWorkspaceMemberRoleCommand(
+        WORKSPACE_ID, TARGET_USER_ID, WorkspaceRole.MEMBER, "requester-id");
+    var requesterWasRemoved = new java.util.concurrent.atomic.AtomicBoolean();
+
+    given(workspaceMutationGuard.protectExclusive(eq(WORKSPACE_ID), any()))
+        .willAnswer(invocation -> {
+          Supplier<Mono<WorkspaceMember>> action = invocation.getArgument(1);
+          return Mono.defer(() -> {
+            requesterWasRemoved.set(true);
+            return action.get();
+          });
+        });
+    given(workspaceAccessHelper.findWorkspaceAdminMember("requester-id", WORKSPACE_ID))
+        .willAnswer(invocation -> requesterWasRemoved.get()
+            ? Mono.error(new com.schemafy.core.common.exception.DomainException(
+                WorkspaceErrorCode.ACCESS_DENIED))
+            : Mono.just(WorkspaceMember.create("requester-member-id", WORKSPACE_ID,
+                "requester-id", WorkspaceRole.ADMIN)));
+
+    StepVerifier.create(sut.updateWorkspaceMemberRole(command))
+        .expectErrorMatches(com.schemafy.core.common.exception.DomainException
+            .hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+
+    then(workspaceAccessHelper).should(org.mockito.Mockito.never())
+        .findWorkspaceMember(any(), any());
+    then(projectMembershipPropagationHelper).shouldHaveNoInteractions();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateWorkspaceServiceTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/UpdateWorkspaceServiceTest.java
@@ -1,0 +1,83 @@
+package com.schemafy.core.project.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.in.UpdateWorkspaceCommand;
+import com.schemafy.core.project.application.port.in.WorkspaceDetail;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 수정 서비스 테스트")
+class UpdateWorkspaceServiceTest {
+
+  @Mock
+  WorkspacePort workspacePort;
+
+  @Mock
+  WorkspaceAccessHelper workspaceAccessHelper;
+
+  @InjectMocks
+  UpdateWorkspaceService sut;
+
+  @Test
+  @DisplayName("활성 워크스페이스 행을 수정한 뒤 최신 상세 정보를 조회한다")
+  void updateWorkspace_updatesThenLoadsDetail() {
+    Workspace workspace = Workspace.create("workspace-id", "변경 이름", "변경 설명");
+    WorkspaceDetail detail = new WorkspaceDetail(workspace, 2L, "ADMIN");
+    UpdateWorkspaceCommand command = new UpdateWorkspaceCommand(
+        workspace.getId(), "변경 이름", "변경 설명", "requester-id");
+    given(workspacePort.updateIfActive(workspace.getId(), "변경 이름", "변경 설명"))
+        .willReturn(Mono.just(1L));
+    given(workspaceAccessHelper.findWorkspaceOrThrow(workspace.getId()))
+        .willReturn(Mono.just(workspace));
+    given(workspaceAccessHelper.buildWorkspaceDetail(workspace, "requester-id"))
+        .willReturn(Mono.just(detail));
+
+    StepVerifier.create(sut.updateWorkspace(command))
+        .expectNext(detail)
+        .verifyComplete();
+
+    then(workspacePort).should()
+        .updateIfActive(workspace.getId(), "변경 이름", "변경 설명");
+    then(workspaceAccessHelper).should().findWorkspaceOrThrow(workspace.getId());
+  }
+
+  @Test
+  @DisplayName("수정된 행이 없으면 워크스페이스 없음 오류를 반환하고 상세 정보를 조회하지 않는다")
+  void updateWorkspace_rejectsMissingWorkspaceWithoutLoadingDetail() {
+    UpdateWorkspaceCommand command = new UpdateWorkspaceCommand(
+        "workspace-id", "변경 이름", "변경 설명", "requester-id");
+    given(workspacePort.updateIfActive("workspace-id", "변경 이름", "변경 설명"))
+        .willReturn(Mono.just(0L));
+
+    StepVerifier.create(sut.updateWorkspace(command))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(WorkspaceErrorCode.NOT_FOUND);
+        })
+        .verify();
+
+    then(workspaceAccessHelper).should(never()).findWorkspaceOrThrow("workspace-id");
+    then(workspaceAccessHelper).should(never())
+        .buildWorkspaceDetail(org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/WorkspaceAccessHelperTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/WorkspaceAccessHelperTest.java
@@ -1,0 +1,83 @@
+package com.schemafy.core.project.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.ProjectPort;
+import com.schemafy.core.project.application.port.out.WorkspaceMemberPort;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.WorkspaceMember;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.user.application.port.out.FindUserByEmailPort;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 관리자 접근 검증")
+class WorkspaceAccessHelperTest {
+
+  private static final String WORKSPACE_ID = "workspace-id";
+  private static final String USER_ID = "user-id";
+
+  @Mock
+  WorkspacePort workspacePort;
+
+  @Mock
+  WorkspaceMemberPort workspaceMemberPort;
+
+  @Mock
+  ProjectPort projectPort;
+
+  @Mock
+  FindUserByEmailPort findUserByEmailPort;
+
+  @InjectMocks
+  WorkspaceAccessHelper sut;
+
+  @Test
+  @DisplayName("활성 멤버십이 없으면 접근 거부를 반환한다")
+  void returnsAccessDeniedWhenActiveMembershipIsMissing() {
+    given(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+        .willReturn(Mono.empty());
+
+    StepVerifier.create(sut.findWorkspaceAdminMember(USER_ID, WORKSPACE_ID))
+        .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("활성 일반 멤버는 관리자 권한 필요 오류를 반환한다")
+  void returnsAdminRequiredWhenActiveMemberIsNotAdmin() {
+    var member = WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+        WorkspaceRole.MEMBER);
+    given(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+        .willReturn(Mono.just(member));
+
+    StepVerifier.create(sut.findWorkspaceAdminMember(USER_ID, WORKSPACE_ID))
+        .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ADMIN_REQUIRED))
+        .verify();
+  }
+
+  @Test
+  @DisplayName("활성 관리자는 최신 멤버십을 반환한다")
+  void returnsActiveAdminMembership() {
+    var member = WorkspaceMember.create("member-id", WORKSPACE_ID, USER_ID,
+        WorkspaceRole.ADMIN);
+    given(workspaceMemberPort.findByWorkspaceIdAndUserIdAndNotDeleted(WORKSPACE_ID, USER_ID))
+        .willReturn(Mono.just(member));
+
+    StepVerifier.create(sut.findWorkspaceAdminMember(USER_ID, WORKSPACE_ID))
+        .expectNext(member)
+        .verifyComplete();
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/WorkspaceMutationGuardTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/application/service/WorkspaceMutationGuardTest.java
@@ -1,0 +1,185 @@
+package com.schemafy.core.project.application.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.port.out.WorkspacePort;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("워크스페이스 변경 잠금과 재시도")
+class WorkspaceMutationGuardTest {
+
+  @Mock
+  private WorkspacePort workspacePort;
+
+  @Mock
+  private TransactionalOperator transactionalOperator;
+
+  private final AtomicInteger transactionSubscriptions = new AtomicInteger();
+
+  private WorkspaceMutationGuard sut;
+
+  @BeforeEach
+  void setUp() {
+    sut = new WorkspaceMutationGuard(workspacePort, transactionalOperator);
+    transactionSubscriptions.set(0);
+    lenient().when(transactionalOperator.<Object>transactional(
+        ArgumentMatchers.<Mono<Object>>any()))
+        .thenAnswer(invocation -> Mono.defer(() -> {
+          transactionSubscriptions.incrementAndGet();
+          return invocation.<Mono<Object>>getArgument(0);
+        }));
+  }
+
+  @Test
+  @DisplayName("워크스페이스 공유 락을 획득한 뒤 상태 변경을 실행한다")
+  void protectShared_locksInShareModeBeforeRunningAction() {
+    AtomicBoolean locked = new AtomicBoolean();
+    when(workspacePort.findByIdAndNotDeletedInShareMode("workspace-id"))
+        .thenReturn(Mono.defer(() -> {
+          locked.set(true);
+          return Mono.just(workspace());
+        }));
+
+    StepVerifier.create(sut.protectShared("workspace-id", () -> Mono.defer(() -> {
+      assertThat(locked).isTrue();
+      return Mono.just("done");
+    })))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(workspacePort).findByIdAndNotDeletedInShareMode("workspace-id");
+    verify(workspacePort, never()).findByIdAndNotDeletedForUpdate("workspace-id");
+  }
+
+  @Test
+  @DisplayName("워크스페이스 배타 락을 획득한 뒤 상태 변경을 실행한다")
+  void protectExclusive_locksForUpdate() {
+    when(workspacePort.findByIdAndNotDeletedForUpdate("workspace-id"))
+        .thenReturn(Mono.just(workspace()));
+
+    StepVerifier.create(sut.protectExclusive("workspace-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(workspacePort).findByIdAndNotDeletedForUpdate("workspace-id");
+    verify(workspacePort, never())
+        .findByIdAndNotDeletedInShareMode("workspace-id");
+  }
+
+  @Test
+  @DisplayName("잠금 대상이 없으면 작업을 실행하지 않고 워크스페이스 없음 오류를 반환한다")
+  void protectShared_rejectsMissingWorkspaceWithoutRunningAction() {
+    AtomicBoolean actionCalled = new AtomicBoolean();
+    when(workspacePort.findByIdAndNotDeletedInShareMode("workspace-id"))
+        .thenReturn(Mono.empty());
+
+    StepVerifier.create(sut.protectShared("workspace-id", () -> {
+      actionCalled.set(true);
+      return Mono.just("done");
+    }))
+        .expectErrorSatisfies(error -> {
+          assertThat(error).isInstanceOf(DomainException.class);
+          assertThat(((DomainException) error).getErrorCode())
+              .isEqualTo(WorkspaceErrorCode.NOT_FOUND);
+        })
+        .verify();
+
+    assertThat(actionCalled).isFalse();
+  }
+
+  @Test
+  @DisplayName("공유 잠금 실패 시 잠금부터 전체 작업을 재시도한다")
+  void protectShared_retriesFromLockWhenLockCannotBeAcquired() {
+    when(workspacePort.findByIdAndNotDeletedInShareMode("workspace-id"))
+        .thenReturn(Mono.error(new CannotAcquireLockException("lock timeout")))
+        .thenReturn(Mono.just(workspace()));
+
+    StepVerifier.create(sut.protectShared("workspace-id", () -> Mono.just("done")))
+        .expectNext("done")
+        .verifyComplete();
+
+    verify(workspacePort, times(2))
+        .findByIdAndNotDeletedInShareMode("workspace-id");
+    assertThat(transactionSubscriptions).hasValue(2);
+  }
+
+  @Test
+  @DisplayName("작업 중 잠금 실패 시 배타 잠금부터 전체 작업을 재시도한다")
+  void protectExclusive_retriesActionFromLock() {
+    AtomicInteger actionAttempts = new AtomicInteger();
+    when(workspacePort.findByIdAndNotDeletedForUpdate("workspace-id"))
+        .thenReturn(Mono.just(workspace()));
+
+    StepVerifier.create(sut.protectExclusive("workspace-id", () -> Mono.defer(
+        () -> actionAttempts.incrementAndGet() == 1
+            ? Mono.error(new CannotAcquireLockException("lock timeout"))
+            : Mono.just("done"))))
+        .expectNext("done")
+        .verifyComplete();
+
+    assertThat(actionAttempts).hasValue(2);
+    verify(workspacePort, times(2))
+        .findByIdAndNotDeletedForUpdate("workspace-id");
+    assertThat(transactionSubscriptions).hasValue(2);
+  }
+
+  @Test
+  @DisplayName("도메인 오류는 재시도하지 않고 그대로 전달한다")
+  void protectExclusive_doesNotRetryDomainException() {
+    DomainException failure = new DomainException(WorkspaceErrorCode.NOT_FOUND);
+    when(workspacePort.findByIdAndNotDeletedForUpdate("workspace-id"))
+        .thenReturn(Mono.error(failure));
+
+    StepVerifier.create(sut.protectExclusive("workspace-id", () -> Mono.just("done")))
+        .expectErrorSatisfies(error -> assertThat(error).isSameAs(failure))
+        .verify();
+
+    verify(workspacePort).findByIdAndNotDeletedForUpdate("workspace-id");
+  }
+
+  @Test
+  @DisplayName("잠금 재시도 소진 시 마지막 잠금 예외를 그대로 전달한다")
+  void protectShared_propagatesLastLockFailureWhenRetriesExhausted() {
+    CannotAcquireLockException failure = new CannotAcquireLockException("lock timeout");
+    when(workspacePort.findByIdAndNotDeletedInShareMode("workspace-id"))
+        .thenReturn(Mono.error(failure));
+
+    StepVerifier.create(sut.protectShared("workspace-id", () -> Mono.just("done")))
+        .expectErrorSatisfies(error -> assertThat(error).isSameAs(failure))
+        .verify();
+
+    verify(workspacePort, times(4))
+        .findByIdAndNotDeletedInShareMode("workspace-id");
+    assertThat(transactionSubscriptions).hasValue(4);
+  }
+
+  private Workspace workspace() {
+    return Workspace.create("workspace-id", "워크스페이스", "설명");
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectInvitationConcurrencyIntegrationTest.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,7 @@ import com.schemafy.core.user.domain.User;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@DisplayName("Project invitation concurrency integration")
+@DisplayName("프로젝트 초대 동시성 통합 테스트")
 class ProjectInvitationConcurrencyIntegrationTest
     extends ProjectDomainIntegrationSupport {
 
@@ -32,7 +33,7 @@ class ProjectInvitationConcurrencyIntegrationTest
   private AcceptProjectInvitationUseCase acceptProjectInvitationUseCase;
 
   @Test
-  @DisplayName("concurrent project invitation accept succeeds exactly once")
+  @DisplayName("프로젝트 초대 수락을 동시에 요청해도 정확히 한 번만 성공한다")
   void concurrentAccept_onlyOneSucceeds() throws InterruptedException {
     User admin = signUpUser("admin-pic@test.com", "Admin");
     User invitee = signUpUser("invitee-pic@test.com", "Invitee");
@@ -51,7 +52,8 @@ class ProjectInvitationConcurrencyIntegrationTest
     CountDownLatch doneLatch = new CountDownLatch(5);
     ConcurrentLinkedQueue<Throwable> unexpectedErrors = new ConcurrentLinkedQueue<>();
 
-    try (ExecutorService executor = Executors.newFixedThreadPool(5)) {
+    ExecutorService executor = Executors.newFixedThreadPool(5);
+    try {
       for (int i = 0; i < 5; i++) {
         executor.submit(() -> {
           readyLatch.countDown();
@@ -78,9 +80,13 @@ class ProjectInvitationConcurrencyIntegrationTest
         });
       }
 
-      readyLatch.await();
+      assertThat(readyLatch.await(3, TimeUnit.SECONDS)).isTrue();
       startLatch.countDown();
-      doneLatch.await();
+      assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      startLatch.countDown();
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
     }
 
     Invitation updatedInvitation = invitationRepository.findById(invitation.getId()).block();

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/ProjectMutationConcurrencyIntegrationTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import com.schemafy.core.common.exception.DomainException;
 import com.schemafy.core.project.application.port.in.AccessShareLinkQuery;
 import com.schemafy.core.project.application.port.in.AccessShareLinkUseCase;
+import com.schemafy.core.project.application.port.in.CreateProjectInvitationCommand;
+import com.schemafy.core.project.application.port.in.CreateProjectInvitationUseCase;
 import com.schemafy.core.project.application.port.in.DeleteProjectCommand;
 import com.schemafy.core.project.application.port.in.DeleteProjectUseCase;
 import com.schemafy.core.project.application.port.in.DeleteShareLinkCommand;
@@ -24,6 +26,7 @@ import com.schemafy.core.project.application.port.in.DeleteShareLinkUseCase;
 import com.schemafy.core.project.application.port.in.UpdateProjectCommand;
 import com.schemafy.core.project.application.port.in.UpdateProjectUseCase;
 import com.schemafy.core.project.application.service.ProjectMutationGuard;
+import com.schemafy.core.project.domain.InvitationType;
 import com.schemafy.core.project.domain.Project;
 import com.schemafy.core.project.domain.ProjectRole;
 import com.schemafy.core.project.domain.ShareLink;
@@ -48,6 +51,9 @@ class ProjectMutationConcurrencyIntegrationTest
 
   @Autowired
   private DeleteProjectUseCase deleteProjectUseCase;
+
+  @Autowired
+  private CreateProjectInvitationUseCase createProjectInvitationUseCase;
 
   @Autowired
   private AccessShareLinkUseCase accessShareLinkUseCase;
@@ -153,6 +159,29 @@ class ProjectMutationConcurrencyIntegrationTest
     }
   }
 
+  @Test
+  @DisplayName("프로젝트 삭제와 초대 생성이 동시에 실행되어도 삭제된 프로젝트에 활성 대기 초대가 남지 않는다")
+  void concurrentProjectDeletionAndInvitationCreationLeavesNoActiveInvitation()
+      throws InterruptedException {
+    User admin = signUpUser("admin-project-invitation-delete@test.com", "Admin");
+    User invitee = signUpUser("invitee-project-invitation-delete@test.com", "Invitee");
+    Workspace workspace = saveWorkspace("Project Invitation Delete", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, invitee, WorkspaceRole.MEMBER);
+    Project project = saveProject(workspace, "Project Invitation Delete");
+    saveProjectMember(project, admin, ProjectRole.ADMIN);
+    List<CheckedTask> tasks = List.of(
+        () -> createProjectInvitationIgnoringDeletion(project, invitee, admin),
+        () -> deleteProjectIgnoringInvitationCreation(project, admin));
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(tasks);
+
+    assertThat(errors).isEmpty();
+    assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
+    assertThat(invitationRepository.countByTarget(InvitationType.PROJECT.name(), project.getId())
+        .block()).isZero();
+  }
+
   private void accessShareLinkIgnoringDeletion(ShareLink link) {
     try {
       accessShareLinkUseCase.accessShareLink(new AccessShareLinkQuery(
@@ -169,6 +198,36 @@ class ProjectMutationConcurrencyIntegrationTest
     try {
       updateProjectUseCase.updateProject(new UpdateProjectCommand(
           project.getId(), "Updated", "Updated", admin.id())).block();
+    } catch (DomainException error) {
+      if (error.getErrorCode() != ProjectErrorCode.NOT_FOUND
+          && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED
+          && error.getErrorCode() != ProjectErrorCode.MEMBER_NOT_FOUND) {
+        throw error;
+      }
+    }
+  }
+
+  private void createProjectInvitationIgnoringDeletion(
+      Project project,
+      User invitee,
+      User admin) {
+    try {
+      createProjectInvitationUseCase.createProjectInvitation(
+          new CreateProjectInvitationCommand(project.getId(), invitee.email(),
+              ProjectRole.EDITOR, admin.id())).block();
+    } catch (DomainException error) {
+      if (error.getErrorCode() != ProjectErrorCode.NOT_FOUND
+          && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED
+          && error.getErrorCode() != ProjectErrorCode.MEMBER_NOT_FOUND) {
+        throw error;
+      }
+    }
+  }
+
+  private void deleteProjectIgnoringInvitationCreation(Project project, User admin) {
+    try {
+      deleteProjectUseCase.deleteProject(
+          new DeleteProjectCommand(project.getId(), admin.id())).block();
     } catch (DomainException error) {
       if (error.getErrorCode() != ProjectErrorCode.NOT_FOUND
           && error.getErrorCode() != ProjectErrorCode.ACCESS_DENIED

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceInvitationConcurrencyIntegrationTest.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ import com.schemafy.core.user.domain.User;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@DisplayName("Workspace invitation concurrency integration")
+@DisplayName("워크스페이스 초대 동시성 통합 테스트")
 class WorkspaceInvitationConcurrencyIntegrationTest
     extends ProjectDomainIntegrationSupport {
 
@@ -31,8 +32,8 @@ class WorkspaceInvitationConcurrencyIntegrationTest
   private AcceptWorkspaceInvitationUseCase acceptWorkspaceInvitationUseCase;
 
   @Test
-  @DisplayName("concurrent workspace invitation accept succeeds exactly once")
-  void concurrentAccept_onlyOneSucceeds() throws InterruptedException {
+  @DisplayName("동시에 워크스페이스 초대를 수락해도 정확히 한 번만 성공한다")
+  void concurrentAcceptSucceedsExactlyOnce() throws InterruptedException {
     User admin = signUpUser("admin-wic@test.com", "Admin");
     User invitee = signUpUser("invitee-wic@test.com", "Invitee");
     var workspace = saveWorkspace("Concurrency WS", "Description");
@@ -47,7 +48,8 @@ class WorkspaceInvitationConcurrencyIntegrationTest
     CountDownLatch doneLatch = new CountDownLatch(5);
     ConcurrentLinkedQueue<Throwable> unexpectedErrors = new ConcurrentLinkedQueue<>();
 
-    try (ExecutorService executor = Executors.newFixedThreadPool(5)) {
+    ExecutorService executor = Executors.newFixedThreadPool(5);
+    try {
       for (int i = 0; i < 5; i++) {
         executor.submit(() -> {
           readyLatch.countDown();
@@ -74,9 +76,13 @@ class WorkspaceInvitationConcurrencyIntegrationTest
         });
       }
 
-      readyLatch.await();
+      assertThat(readyLatch.await(3, TimeUnit.SECONDS)).isTrue();
       startLatch.countDown();
-      doneLatch.await();
+      assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      startLatch.countDown();
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
     }
 
     Invitation updatedInvitation = invitationRepository.findById(invitation.getId()).block();

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceTopologyConcurrencyIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceTopologyConcurrencyIntegrationTest.java
@@ -1,0 +1,269 @@
+package com.schemafy.core.project.integration;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.schemafy.core.common.exception.DomainException;
+import com.schemafy.core.project.application.access.ProjectAccessRequesterContext;
+import com.schemafy.core.project.application.port.in.AddWorkspaceMemberCommand;
+import com.schemafy.core.project.application.port.in.AddWorkspaceMemberUseCase;
+import com.schemafy.core.project.application.port.in.CreateProjectCommand;
+import com.schemafy.core.project.application.port.in.CreateProjectUseCase;
+import com.schemafy.core.project.application.port.in.DeleteWorkspaceCommand;
+import com.schemafy.core.project.application.port.in.DeleteWorkspaceUseCase;
+import com.schemafy.core.project.application.port.in.ProjectDetail;
+import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleCommand;
+import com.schemafy.core.project.application.port.in.UpdateWorkspaceMemberRoleUseCase;
+import com.schemafy.core.project.application.service.WorkspaceMutationGuard;
+import com.schemafy.core.project.domain.ProjectMember;
+import com.schemafy.core.project.domain.ProjectRole;
+import com.schemafy.core.project.domain.Workspace;
+import com.schemafy.core.project.domain.WorkspaceRole;
+import com.schemafy.core.project.domain.exception.WorkspaceErrorCode;
+import com.schemafy.core.user.domain.User;
+
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("워크스페이스 토폴로지 동시성 통합 테스트")
+class WorkspaceTopologyConcurrencyIntegrationTest
+    extends ProjectDomainIntegrationSupport {
+
+  @Autowired
+  private CreateProjectUseCase createProjectUseCase;
+
+  @Autowired
+  private DeleteWorkspaceUseCase deleteWorkspaceUseCase;
+
+  @Autowired
+  private AddWorkspaceMemberUseCase addWorkspaceMemberUseCase;
+
+  @Autowired
+  private UpdateWorkspaceMemberRoleUseCase updateWorkspaceMemberRoleUseCase;
+
+  @Autowired
+  private WorkspaceMutationGuard workspaceMutationGuard;
+
+  @Test
+  @DisplayName("동시에 상호 강등해도 활성 워크스페이스 관리자는 한 명 유지된다")
+  void concurrentMutualAdminDemotionsLeaveExactlyOneActiveAdmin()
+      throws InterruptedException {
+    User firstAdmin = signUpUser("topology-first-admin@test.com", "First Admin");
+    User secondAdmin = signUpUser("topology-second-admin@test.com", "Second Admin");
+    Workspace workspace = saveWorkspace("Topology Demotion", "Description");
+    saveWorkspaceMember(workspace, firstAdmin, WorkspaceRole.ADMIN);
+    saveWorkspaceMember(workspace, secondAdmin, WorkspaceRole.ADMIN);
+    AtomicInteger successes = new AtomicInteger();
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(List.of(
+        () -> {
+          updateWorkspaceMemberRoleUseCase.updateWorkspaceMemberRole(
+              new UpdateWorkspaceMemberRoleCommand(
+                  workspace.getId(), secondAdmin.id(), WorkspaceRole.MEMBER, firstAdmin.id()))
+              .contextWrite(ProjectAccessRequesterContext.withRequesterId(firstAdmin.id()))
+              .block();
+          successes.incrementAndGet();
+        },
+        () -> {
+          updateWorkspaceMemberRoleUseCase.updateWorkspaceMemberRole(
+              new UpdateWorkspaceMemberRoleCommand(
+                  workspace.getId(), firstAdmin.id(), WorkspaceRole.MEMBER, secondAdmin.id()))
+              .contextWrite(ProjectAccessRequesterContext.withRequesterId(secondAdmin.id()))
+              .block();
+          successes.incrementAndGet();
+        }));
+
+    assertThat(successes).hasValue(1);
+    assertThat(errors).hasSize(1);
+    assertThat(errors.peek()).isInstanceOf(DomainException.class);
+    assertThat((DomainException) errors.peek())
+        .extracting(DomainException::getErrorCode)
+        .isIn(WorkspaceErrorCode.LAST_ADMIN_CANNOT_LEAVE,
+            WorkspaceErrorCode.ADMIN_REQUIRED);
+    assertThat(workspaceMemberRepository.countByWorkspaceIdAndRoleAndNotDeleted(
+        workspace.getId(), WorkspaceRole.ADMIN.name()).block()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("프로젝트 생성과 워크스페이스 멤버 추가를 동시에 요청해도 새 멤버가 새 프로젝트에 활성 상태로 존재한다")
+  void concurrentProjectCreationAndMemberAdditionPropagatesNewMemberToNewProject()
+      throws InterruptedException {
+    User admin = signUpUser("topology-project-admin@test.com", "Admin");
+    User newMember = signUpUser("topology-new-member@test.com", "New Member");
+    Workspace workspace = saveWorkspace("Topology Project", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+    AtomicReference<ProjectDetail> createdProject = new AtomicReference<>();
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(List.of(
+        () -> createdProject.set(createProjectUseCase.createProject(
+            new CreateProjectCommand(
+                workspace.getId(), "Concurrent Project", "Description", admin.id()))
+            .contextWrite(ProjectAccessRequesterContext.withRequesterId(admin.id()))
+            .block()),
+        () -> addWorkspaceMemberUseCase.addWorkspaceMember(
+            new AddWorkspaceMemberCommand(
+                workspace.getId(), newMember.email(), WorkspaceRole.MEMBER, admin.id()))
+            .contextWrite(ProjectAccessRequesterContext.withRequesterId(admin.id()))
+            .block()));
+
+    assertThat(errors).isEmpty();
+    assertThat(createdProject).hasValueSatisfying(project -> {
+      ProjectMember membership = projectMemberRepository
+          .findByProjectIdAndUserIdAndNotDeleted(project.project().getId(), newMember.id())
+          .block();
+      assertThat(membership).isNotNull();
+      assertThat(membership.getRoleAsEnum()).isEqualTo(ProjectRole.VIEWER);
+    });
+  }
+
+  @Test
+  @DisplayName("워크스페이스 삭제와 프로젝트 생성을 동시에 요청해도 삭제된 워크스페이스 아래 활성 프로젝트가 남지 않는다")
+  void concurrentWorkspaceDeletionAndProjectCreationLeavesNoActiveProjectBelowDeletedWorkspace()
+      throws InterruptedException {
+    User admin = signUpUser("topology-delete-create-admin@test.com", "Admin");
+    Workspace workspace = saveWorkspace("Topology Delete Create", "Description");
+    saveWorkspaceMember(workspace, admin, WorkspaceRole.ADMIN);
+
+    ConcurrentLinkedQueue<Throwable> errors = runConcurrently(List.of(
+        () -> deleteWorkspaceUseCase.deleteWorkspace(new DeleteWorkspaceCommand(
+            workspace.getId(), admin.id()))
+            .contextWrite(ProjectAccessRequesterContext.withRequesterId(admin.id()))
+            .block(),
+        () -> createProjectUseCase.createProject(new CreateProjectCommand(
+            workspace.getId(), "Concurrent Project", "Description", admin.id()))
+            .contextWrite(ProjectAccessRequesterContext.withRequesterId(admin.id()))
+            .block()));
+
+    assertThat(errors).allMatch(DomainException.class::isInstance);
+    assertThat(workspaceRepository.findByIdAndDeletedAtIsNull(workspace.getId()).block())
+        .isNull();
+    assertThat(projectRepository.countByWorkspaceIdAndNotDeleted(workspace.getId()).block())
+        .isZero();
+  }
+
+  @Test
+  @DisplayName("공유 토폴로지 작업이 끝난 뒤 배타 토폴로지 변경이 진행된다")
+  void sharedTopologyWorkCompletesBeforeExclusiveTopologyChangeProceeds()
+      throws Exception {
+    Workspace workspace = saveWorkspace("Topology Guard", "Description");
+    CountDownLatch sharedReady = new CountDownLatch(1);
+    CountDownLatch sharedStart = new CountDownLatch(1);
+    CountDownLatch sharedActionStarted = new CountDownLatch(1);
+    CountDownLatch releaseShared = new CountDownLatch(1);
+    CountDownLatch exclusiveReady = new CountDownLatch(1);
+    CountDownLatch exclusiveStart = new CountDownLatch(1);
+    CountDownLatch exclusiveActionStarted = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<?> shared = executor.submit(() -> {
+        sharedReady.countDown();
+        await(sharedStart);
+        try {
+          workspaceMutationGuard.protectShared(workspace.getId(),
+              () -> Mono.fromRunnable(() -> {
+                sharedActionStarted.countDown();
+                await(releaseShared);
+              }))
+              .block();
+        } finally {
+          done.countDown();
+        }
+      });
+      assertThat(sharedReady.await(3, TimeUnit.SECONDS)).isTrue();
+      sharedStart.countDown();
+      assertThat(sharedActionStarted.await(3, TimeUnit.SECONDS)).isTrue();
+
+      Future<?> exclusive = executor.submit(() -> {
+        exclusiveReady.countDown();
+        await(exclusiveStart);
+        try {
+          workspaceMutationGuard.protectExclusive(workspace.getId(),
+              () -> Mono.fromRunnable(exclusiveActionStarted::countDown))
+              .block();
+        } finally {
+          done.countDown();
+        }
+      });
+      assertThat(exclusiveReady.await(3, TimeUnit.SECONDS)).isTrue();
+      exclusiveStart.countDown();
+      assertThat(exclusiveActionStarted.await(200, TimeUnit.MILLISECONDS)).isFalse();
+
+      releaseShared.countDown();
+      assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+      shared.get(3, TimeUnit.SECONDS);
+      exclusive.get(3, TimeUnit.SECONDS);
+      assertThat(exclusiveActionStarted.getCount()).isZero();
+    } finally {
+      sharedStart.countDown();
+      exclusiveStart.countDown();
+      releaseShared.countDown();
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  private ConcurrentLinkedQueue<Throwable> runConcurrently(List<CheckedTask> tasks)
+      throws InterruptedException {
+    CountDownLatch ready = new CountDownLatch(tasks.size());
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(tasks.size());
+    ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+    ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+
+    try {
+      for (CheckedTask task : tasks) {
+        executor.submit(() -> {
+          ready.countDown();
+          await(start);
+          try {
+            task.run();
+          } catch (Throwable error) {
+            errors.add(error);
+          } finally {
+            done.countDown();
+          }
+        });
+      }
+      assertThat(ready.await(3, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
+    }
+    return errors;
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException error) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(error);
+    }
+  }
+
+  @FunctionalInterface
+  private interface CheckedTask {
+
+    void run();
+
+  }
+
+}

--- a/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
+++ b/apps/backend/core/src/test/java/com/schemafy/core/project/integration/WorkspaceUseCaseIntegrationTest.java
@@ -120,7 +120,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         workspace.getId(),
         admin.id())).block();
 
-    assertThat(workspaceRepository.findByIdAndNotDeleted(workspace.getId()).block()).isNull();
+    assertThat(workspaceRepository.findByIdAndDeletedAtIsNull(workspace.getId()).block()).isNull();
     assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
     assertThat(projectRepository.findByIdAndNotDeleted(secondProject.getId()).block()).isNull();
     assertThat(findSchemasByProjectId(project.getId())).isEmpty();
@@ -562,7 +562,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         workspace.getId(),
         admin.id())).block();
 
-    assertThat(workspaceRepository.findByIdAndNotDeleted(workspace.getId()).block()).isNull();
+    assertThat(workspaceRepository.findByIdAndDeletedAtIsNull(workspace.getId()).block()).isNull();
     assertThat(projectRepository.findByIdAndNotDeleted(project.getId()).block()).isNull();
     assertThat(projectMemberRepository
         .findByProjectIdAndUserIdAndNotDeleted(project.getId(), outsider.id())
@@ -634,7 +634,7 @@ class WorkspaceUseCaseIntegrationTest extends ProjectDomainIntegrationSupport {
         .expectErrorMatches(DomainException.hasErrorCode(WorkspaceErrorCode.ACCESS_DENIED))
         .verify();
 
-    assertThat(workspaceRepository.findByIdAndNotDeleted(workspace.getId()).block()).isNotNull();
+    assertThat(workspaceRepository.findByIdAndDeletedAtIsNull(workspace.getId()).block()).isNotNull();
   }
 
 }


### PR DESCRIPTION
## 개요
서로 다른 서비스가 같은 워크스페이스·프로젝트 구조를 동시에 변경할 때 실행 순서를 보장하지 못해 다음 경쟁 상태가 발생할 수 있었습니다.

- 프로젝트 생성과 워크스페이스 멤버 추가가 동시에 실행되어 새 프로젝트에 멤버가 전파되지 않음
- 워크스페이스 삭제 중 프로젝트가 생성되어 삭제된 워크스페이스 아래 활성 프로젝트가 남음
- 워크스페이스 관리자들이 동시에 서로를 강등하여 활성 관리자가 사라짐
- 프로젝트 삭제 중 초대가 생성되어 삭제된 프로젝트에 대기 중인 초대가 남음
- 락 대기 중 권한이 변경됐지만 이전 권한 검사 결과로 변경이 계속 진행됨

워크스페이스를 프로젝트와 멤버십 토폴로지의 상위 경계로 보고 다음 락 정책을 적용했습니다.

| 변경 유형 | 락 | 목적 |
| --- | --- | --- |
| 프로젝트 생성 및 프로젝트 멤버 역할 변경·제거 | 워크스페이스 공유 락 | 워크스페이스 전체 변경과 충돌하지 않는 하위 변경을 병렬 허용 |
| 워크스페이스 초대 생성 | 워크스페이스 공유 락 | 워크스페이스 삭제와 초대 생성을 직렬화 |
| 워크스페이스 멤버 추가·삭제·역할 변경 | 워크스페이스 배타 락 | 멤버 전파와 관리자 수 검증을 하나의 순서로 처리 |
| 워크스페이스 초대 수락·탈퇴·삭제 | 워크스페이스 배타 락 | 워크스페이스 전체 토폴로지 변경 중 하위 변경 차단 |
| 프로젝트 초대 생성·수락 | 프로젝트 공유 락 | 프로젝트 삭제와 하위 리소스 생성을 직렬화 |
| 프로젝트 삭제 | 워크스페이스 공유 락 → 프로젝트 배타 락 | 워크스페이스 삭제 및 프로젝트 하위 변경과 충돌 방지 |

`WorkspaceMutationGuard`가 락 획득과 트랜잭션 경계를 관리하며, 잠금 실패만 최대 3회 재시도합니다.

기존 AOP 접근 제어는 빠른 요청 거부를 위해 유지하되, 락 획득 후 최신 멤버십·권한·초대 상태를 다시 검증합니다. 멤버 전파와 하위 리소스 변경도 락이 유지되는 동일 트랜잭션 안에서 처리합니다.

## 이슈
